### PR TITLE
Fix a bug that reserved role shows as custom

### DIFF
--- a/public/apps/configuration/utils/role-list-utils.tsx
+++ b/public/apps/configuration/utils/role-list-utils.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { map, merge, chain } from 'lodash';
+import { map, chain } from 'lodash';
 import { HttpStart } from '../../../../../../src/core/public';
 import { API_ENDPOINT_ROLES } from '../constants';
 
@@ -40,6 +40,7 @@ Input[0] - Role Schema: {
 Input[1] - RoleMapping schema: {
   data: {
     [roleName]: {
+      reserved,
       backend_roles: [""],
       users: [""]
     }
@@ -57,7 +58,7 @@ Output schema: [{
 }]
 */
 export function transformRoleData(rawRoleData: any, rawRoleMappingData: any) {
-  return map(merge(rawRoleData.data, rawRoleMappingData.data), (v: any, k: string) => ({
+  return map(rawRoleData.data, (v: any, k: string) => ({
     role_name: k,
     reserved: v.reserved,
     cluster_permissions: v.cluster_permissions,
@@ -67,8 +68,8 @@ export function transformRoleData(rawRoleData: any, rawRoleMappingData: any) {
       .flatten()
       .compact()
       .value(),
-    internal_users: v.users,
-    backend_roles: v.backend_roles,
+    internal_users: rawRoleMappingData.data[k]?.users || [],
+    backend_roles: rawRoleMappingData.data[k]?.backend_roles || [],
   }));
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix a bug that reserved role shows as custom. 

Why:
Merged data of both roles and mapping, they both have a `reserved` field. On the listing page we should show based on `role.reserved`. While before fix, `lodash.merge` will overwrite the `reserved` field based on the argument order (roles mapping is second argument so if role mapping is present, its field overwrite roles')

Screenshots:
`kibana_user` role itself is reserved, while `kibana_user` role mapping is not.
Before fix:
![image](https://user-images.githubusercontent.com/63078162/84302574-5b6b4200-ab0a-11ea-9dda-e3318d77af22.png)

After fix:
![image](https://user-images.githubusercontent.com/63078162/84302804-c4eb5080-ab0a-11ea-9bb9-a0e9a331c94e.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
