### PR TITLE
Invalidate Session cookies when auth is affected by change in SAML ex…

### DIFF
--- a/lib/auth/types/AuthType.js
+++ b/lib/auth/types/AuthType.js
@@ -341,6 +341,22 @@ export default class AuthType {
                 }
             }
 
+            // when exchange key is changed for SAML, the authorization header becomes invalid and hence the authenticate fails for logged in user
+	    // this will check if the authorization header is valid and if not return false as the token is invalid
+	    authToken = request.headers.authorization;
+            if(authToken) {
+                if (authToken.startsWith("bearer ")){
+                    try {
+                        await request.auth.securitySessionStorage.authenticate({
+                            authHeaderValue: request.headers.authorization
+                        });
+                    } catch (error) {
+                        // Error will be an instance of AuthenticationError and all the cookies will be cleared by Authentication function called in try block.
+                        return {valid: false}
+                    }
+                }
+            }
+
             return {valid: true, credentials: session};
 
         };


### PR DESCRIPTION
Invalidate Session cookies when auth is affected by change in SAML exchange key.
This will properly logout user to desired login page, instead of alert dialog asking for username and password 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
