### PR TITLE
Rename tenants to tenant permissions, set default tenant permission 

### DIFF
--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -16,7 +16,7 @@
 import { EuiButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiSuperSelect } from '@elastic/eui';
 import React, { Dispatch, Fragment, SetStateAction } from 'react';
 import { isEmpty } from 'lodash';
-import { RoleTenantPermission, TenantPermissionType } from '../../types';
+import { RoleTenantPermission, TenantPermissionType, ComboBoxOptions } from '../../types';
 import {
   appendElementToArray,
   removeElementFromArray,
@@ -29,7 +29,7 @@ import {
 } from '../../utils/combo-box-utils';
 import { FormRow } from '../../utils/form-row';
 import { PanelWithHeader } from '../../utils/panel-with-header';
-import { ComboBoxOptions, RoleTenantPermissionStateClass } from './types';
+import { RoleTenantPermissionStateClass } from './types';
 import { TENANT_READ_PERMISSION, TENANT_WRITE_PERMISSION } from '../../constants';
 import { getTenantPermissionType } from '../../utils/tenant-utils';
 
@@ -68,7 +68,7 @@ export function unbuildTenantPermissionState(
 function getEmptyTenantPermission(): RoleTenantPermissionStateClass {
   return {
     tenantPatterns: [],
-    permissionType: TenantPermissionType.None,
+    permissionType: TenantPermissionType.Full,
   };
 }
 
@@ -134,7 +134,7 @@ export function TenantPanel(props: {
   }
   return (
     <PanelWithHeader
-      headerText="Tenants"
+      headerText="Tenant permissions"
       headerSubText="Tenants are useful for safely sharing your work with other Kibana users. You can control which roles have access to a tenant and whether those roles have read or write access."
       helpLink="/"
     >
@@ -147,7 +147,7 @@ export function TenantPanel(props: {
           appendElementToArray(setState, [], getEmptyTenantPermission());
         }}
       >
-        Add another tenant
+        Add another tenant permission
       </EuiButton>
     </PanelWithHeader>
   );

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -14,7 +14,13 @@
  */
 
 import React, { useState, useEffect } from 'react';
-import { EuiInMemoryTable, EuiLink, EuiText, EuiGlobalToastList } from '@elastic/eui';
+import {
+  EuiInMemoryTable,
+  EuiLink,
+  EuiText,
+  EuiGlobalToastList,
+  EuiBasicTableColumn,
+} from '@elastic/eui';
 import { CoreStart } from 'kibana/public';
 import { getAuthInfo } from '../../../../utils/auth-info-utils';
 import { PanelWithHeader } from '../../utils/panel-with-header';
@@ -92,7 +98,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
     }
   };
 
-  const columns = [
+  const columns: Array<EuiBasicTableColumn<RoleTenantPermissionDetail>> = [
     {
       field: 'tenant_patterns',
       name: 'Name',
@@ -147,7 +153,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
     },
   ];
 
-  const headerText = 'Tenants (' + tenantPermissionDetail.length + ')';
+  const headerText = 'Tenant permissions (' + tenantPermissionDetail.length + ')';
   return (
     <>
       <PanelWithHeader


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Rename tenants to tenant permissions
* Default to full tenant permission 


|  Before |After   |
|---|---|
| ![image](https://user-images.githubusercontent.com/63078162/90922257-88f12900-e3a0-11ea-82be-5826b6089bb9.png)  | ![image](https://user-images.githubusercontent.com/63078162/90922080-3c0d5280-e3a0-11ea-8239-392a6126a9da.png)  |
| ![image](https://user-images.githubusercontent.com/63078162/90922191-67903d00-e3a0-11ea-8bb5-bf0cd24f6093.png)  | ![image](https://user-images.githubusercontent.com/63078162/90922133-52b3a980-e3a0-11ea-8b11-7122ce86f8c5.png)  |



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
