### PR TITLE
Made PR template easier to fill in

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,65 +1,25 @@
+### Description
+[Describe what this change achieves]
 
-##  opensearch-project/security-dashboards-plugin pull request intake form
-_Please provide as much details as possible to get feedback/acceptance on your PR quickly_
+### Category
+[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]
 
- 
- 1. __Category:__ (_Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation_)
- 
- 
- 
- 2. __Github Issue # or road-map entry, if available:__
+### Why these changes are required?
 
 
-
- 3. __Description of changes:__
-
+### What is the old behavior before changes and new behavior after changes?
 
 
- 4. __Why these changes are required?__ 
+### Issues Resolved
+[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]
 
+### Testing
+[Please provide details of testing done: unit testing, integration testing and manual testing]
 
-
- 5. __What is the old behavior before changes and new behavior after changes?__ (_Please add any example/logs/screen-shot if available_)
-
-
-
- 6. __Testing done:__ (_Please provide details of testing done: Unit testing, integration testing and manual testing_)
- 
- 
- 
- 7. __TO-DOs, if any:__ (_Please describe pending items and provide Github issues# for each of them_)
-
-
-
- 8. __Is it backport from main branch?__ (_If yes, please add backport PR # and commits #_)
-
-
-
-
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
+### Check List
+- [ ] New functionality includes testing
+- [ ] New functionality has been documented
+- [ ] Commits are signed per the DCO using --signoff
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


### PR DESCRIPTION
Signed-off-by: Dave Lago <davelago@amazon.com>

### Description
Updated PR template so that it is easier to fill in. Mostly just formatting changes, making it consistent with the backend security plugin repo (https://github.com/opensearch-project/security/pull/1567)

### Category
Maintenance

### Why these changes are required?
Save a few clicks/keystrokes when filling in PRs.

### What is the old behavior before changes and new behavior after changes?
No behavior changes introduced.

### Issues Resolved
N/A

### Testing
N/A

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).