### PR TITLE
Update rule def for @osd/eslint/require-license-header

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
         '@osd/eslint/require-license-header': [
           'error',
           {
-            license: LICENSE_HEADER,
+            licenses: [ LICENSE_HEADER ],
           },
         ],
         "no-console": 0


### PR DESCRIPTION
### Description
Update rule def for @osd/eslint/require-license-header

Previously the rule was defined as:
```json
{
   "license": "license",
}
```

Now the format is
```json
{
   "licenses": ["license", "..."],
}
```

### Category
Test fix

### Issues Resolved
- Resolves #904

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).