### PR TITLE
[Backport] Adds release notes for 1.3.0.0 (#918)

### DIFF
--- a/release-notes/opensearch-security-dashboards-plugin.release-notes-1.3.0.0.md
+++ b/release-notes/opensearch-security-dashboards-plugin.release-notes-1.3.0.0.md
@@ -1,0 +1,23 @@
+## Version 1.3.0.0
+
+### Enhancements
+* Add auto backport functionality to security plugin ([#887](https://github.com/opensearch-project/security-dashboards-plugin/pull/887))
+* Adds auto delete workflow for backport branches ([#901](https://github.com/opensearch-project/security-dashboards-plugin/pull/901))
+* Configure ML plugin actions ([#912](https://github.com/opensearch-project/security-dashboards-plugin/pull/912))
+
+## Bug Fixes
+* Updates rule def for @osd/eslint/require-license-header ([#905](https://github.com/opensearch-project/security-dashboards-plugin/pull/905))
+* Updates backport workflow with custom branch and github app ([#900](https://github.com/opensearch-project/security-dashboards-plugin/pull/900))
+
+### Maintenance
+* Bumps version to 1.3.0.0 ([#884](https://github.com/opensearch-project/security-dashboards-plugin/pull/884))
+* Adds support for codeowners to repo ([#883](https://github.com/opensearch-project/security-dashboards-plugin/pull/883))
+* Adds .whitesource and configs file to activate whitesource integration ([#885](https://github.com/opensearch-project/security-dashboards-plugin/pull/885))
+* Uses 1.x branch of Dashboards for unit tests ([#890](https://github.com/opensearch-project/security-dashboards-plugin/pull/890))
+* Makes PR template easier to fill in ([#888](https://github.com/opensearch-project/security-dashboards-plugin/pull/888))
+* Adds release notes for 1.3.0.0 ([#918](https://github.com/opensearch-project/security-dashboards-plugin/pull/918))
+
+## Documentation
+* Improves developer guide ([#889](https://github.com/opensearch-project/security-dashboards-plugin/pull/889))
+* Adds back removed portion of developer guide ([#893](https://github.com/opensearch-project/security-dashboards-plugin/pull/893))
+* Updates maintainers list ([#902](https://github.com/opensearch-project/security-dashboards-plugin/pull/902))

--- a/release-notes/opensearch-security-dashboards-plugin.release-notes-1.3.0.0.md
+++ b/release-notes/opensearch-security-dashboards-plugin.release-notes-1.3.0.0.md
@@ -5,7 +5,7 @@
 * Adds auto delete workflow for backport branches ([#901](https://github.com/opensearch-project/security-dashboards-plugin/pull/901))
 * Configure ML plugin actions ([#912](https://github.com/opensearch-project/security-dashboards-plugin/pull/912))
 
-## Bug Fixes
+### Bug Fixes
 * Updates rule def for @osd/eslint/require-license-header ([#905](https://github.com/opensearch-project/security-dashboards-plugin/pull/905))
 * Updates backport workflow with custom branch and github app ([#900](https://github.com/opensearch-project/security-dashboards-plugin/pull/900))
 
@@ -16,8 +16,9 @@
 * Uses 1.x branch of Dashboards for unit tests ([#890](https://github.com/opensearch-project/security-dashboards-plugin/pull/890))
 * Makes PR template easier to fill in ([#888](https://github.com/opensearch-project/security-dashboards-plugin/pull/888))
 * Adds release notes for 1.3.0.0 ([#918](https://github.com/opensearch-project/security-dashboards-plugin/pull/918))
+* Updates release notes for 1.3.0.0 ([#920](https://github.com/opensearch-project/security-dashboards-plugin/pull/920))
 
-## Documentation
+### Documentation
 * Improves developer guide ([#889](https://github.com/opensearch-project/security-dashboards-plugin/pull/889))
 * Adds back removed portion of developer guide ([#893](https://github.com/opensearch-project/security-dashboards-plugin/pull/893))
 * Updates maintainers list ([#902](https://github.com/opensearch-project/security-dashboards-plugin/pull/902))


### PR DESCRIPTION
### Description
Backports release notes for version 1.3.0.0 to 1.3 branch
See main PR here: https://github.com/opensearch-project/security-dashboards-plugin/pull/918

### Category
Maintenance

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).