### PR TITLE
upgrade to node14

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,12 +15,12 @@ jobs:
     steps:
       - name: Download OpenSearch Core
         run: |
-          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.0/488/linux/x64/builds/opensearch/dist/opensearch-min-1.3.0-linux-x64.tar.gz
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.0.0/latest/linux/x64/builds/opensearch/dist/opensearch-min-2.0.0-linux-x64.tar.gz
           tar -xzf opensearch-*.tar.gz
           rm -f opensearch-*.tar.gz
 
       - name: Download OpenSearch Security Plugin
-        run: wget -O opensearch-security.zip https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/1.3.0/488/linux/x64/builds/opensearch/plugins/opensearch-security-1.3.0.0.zip
+        run: wget -O opensearch-security.zip https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.0.0/latest/linux/x64/builds/opensearch/plugins/opensearch-security-2.0.0.0.zip
 
       - name: Run OpenSearch with plugin
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
-          ref: '1.x'
+          ref: 'main'
           fetch-depth: 0
       - name: Create plugins dir
         run: |

--- a/common/index.ts
+++ b/common/index.ts
@@ -44,5 +44,6 @@ export enum AuthType {
  */
 export function isValidResourceName(resourceName: string): boolean {
   // see: https://javascript.info/regexp-unicode
-  return !/[\p{C}%]/u.test(resourceName) && resourceName.length > 0;
+  const exp = new RegExp(/[\p{C}%]/u);
+  return !exp.test(resourceName) && resourceName.length > 0;
 }

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "securityDashboards",
-  "version": "1.3.0.0",
-  "opensearchDashboardsVersion": "1.3.0",
+  "version": "2.0.0.0",
+  "opensearchDashboardsVersion": "2.0.0",
   "configPath": ["opensearch_security"],
   "requiredPlugins": ["navigation"],
   "server": true,

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "opensearch-security-dashboards",
-  "version": "1.3.0.0",
+  "version": "2.0.0.0",
   "main": "target/plugins/opensearch_security_dashboards",
   "opensearchDashboards": {
-    "version": "1.3.0",
-    "templateVersion": "1.3.0"
+    "version": "2.0.0",
+    "templateVersion": "2.0.0"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/security-dashboards-plugin",
@@ -24,11 +24,11 @@
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/osd-eslint-import-resolver-opensearch-dashboards", 
     "typescript": "4.0.2",
     "gulp-rename": "2.0.0",
-    "@testing-library/react-hooks": "^3.4.1",
+    "@testing-library/react-hooks": "^7.0.2",
     "@types/hapi__wreck": "^15.0.1"
   },
   "dependencies": {
-    "@hapi/wreck": "^15.0.2",
+    "@hapi/wreck": "^17.1.0",
     "@hapi/cryptiles": "5.0.0",
     "html-entities": "1.3.1"
   }


### PR DESCRIPTION
### Description
Makes changes to work with Node 14.18.2

### Category
Maintenance

### Why these changes are required?
OpenSearch Darshboards 2.0 is using Node@14.18.2 and thus this change is required for the plugin.



### Issues Resolved
#875 

### Testing
1. Checkout OpenSearch Dashboards `main` branch
2. Clone security plugin repo inside `plugins` folder
3. Run tests.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).