### PR TITLE
[Build] bump to 2.0.0.0-rc1

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "securityDashboards",
-  "version": "2.0.0.0",
+  "version": "2.0.0.0-rc1",
   "opensearchDashboardsVersion": "2.0.0",
   "configPath": ["opensearch_security"],
   "requiredPlugins": ["navigation"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-security-dashboards",
-  "version": "2.0.0.0",
+  "version": "2.0.0.0-rc1",
   "main": "target/plugins/opensearch_security_dashboards",
   "opensearchDashboards": {
     "version": "2.0.0",


### PR DESCRIPTION
### Description
To be supported within the distribution for OSD 2.0.0-rc1 from the build repo, plugins need to ensure their plugin version is the expected version until https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1398 is addressed. If OSD plugins version does not match the qualifier of the build then the build will fail. 

### Category
Maintenance

### Why these changes are required?
To build successfully within the build distribution

### What is the old behavior before changes and new behavior after changes?
n/a

### Issues Resolved
n/a

### Testing
n/a

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).