### PR TITLE
Enforce authentication on api/status route by default

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -70,14 +70,14 @@ export const configSchema = schema.object({
     }),
     anonymous_auth_enabled: schema.boolean({ defaultValue: false }),
     unauthenticated_routes: schema.arrayOf(schema.string(), {
-      defaultValue: ['/api/status', '/api/reporting/stats'],
+      defaultValue: ['/api/reporting/stats'],
     }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     logout_url: schema.string({ defaultValue: '' }),
   }),
   basicauth: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
-    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status'] }),
+    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: [] }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     header_trumps_session: schema.boolean({ defaultValue: false }),
     alternative_login: schema.object({

--- a/test/jest_integration/basic_auth.test.ts
+++ b/test/jest_integration/basic_auth.test.ts
@@ -207,4 +207,16 @@ describe('start OpenSearch Dashboards server', () => {
 
     expect(response.status).toEqual(302);
   });
+
+  it('enforce authentication on api/status route', async () => {
+    const response = await osdTestServer.request.get(root, '/api/status');
+    expect(response.status).toEqual(401);
+  });
+
+  it('can access api/status route with admin credential', async () => {
+    const response = await osdTestServer.request
+      .get(root, '/api/status')
+      .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
+    expect(response.status).toEqual(200);
+  });
 });


### PR DESCRIPTION
Signed-off-by: Chang Liu <cgliu@amazon.com>

### Description
Enforce authentication on `api/status` route by default.

### Category
Bug fix

### Why these changes are required?
Secure `api/status` route


### What is the old behavior before changes and new behavior after changes?
Old behavior:
`api/status` route bypasses authentication by default.
New behavior:
Enforce authentication on `api/status` route by default unless user explicitly configures `api/status` as `auth.unauthenticated_routes`.

### Issues Resolved
#945

### Testing
ITs

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).