### PR TITLE
Make Git ignore .idea/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn.lock
 yarn-error.log
 kibana-coverage/
 .DS_Store
+.idea/


### PR DESCRIPTION
Signed-off-by: Chang Liu <cgliu@amazon.com>

### Description
Make Git ignore .idea/ folder

### Category
Maintenance

### Testing
MT
### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).