### PR TITLE
[Build] restore osdVersion to 2.0.0

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "securityDashboards",
   "version": "2.0.0.0-rc1",
-  "opensearchDashboardsVersion": "2.0.0-rc1",
+  "opensearchDashboardsVersion": "2.0.0",
   "configPath": ["opensearch_security"],
   "requiredPlugins": ["navigation"],
   "server": true,


### PR DESCRIPTION
### Description

By keeping `opensearchDashboardsVersion: 2.0.0`, plugin owners can
do development using the main branch of OpenSearch Dashboards since
OpenSearch Dashboards sets this value to 2.0.0.

This key-value lets OpenSearch Dashboards can properly install the
plugin since it does a semvar + qualifier check on this value if
they match then OpenSearch Dashboards proceeds to install it.

The build repo passes the qualifier while building OpenSearch Dashboards
and plugins that automatically sets this value to build the correct
version + qualifier. This allows a distribution to be made with value
for `opensearchDashboardsVersion` be the expected value, for example
`opensearchDashboardsVersion: 2.0.0-rc1`.

Original PR:
https://github.com/opensearch-project/security-dashboards-plugin/pull/946

Signed-off-by: Kawika Avilla <kavilla414@gmail.com>

### Category
[Maintenance]

### Why these changes are required?

For local development

### What is the old behavior before changes and new behavior after changes?

If using OpenSearch Dashboards `main`, the plugin might have issues bootstrapping.

### Issues Resolved
n/a

### Testing
n/a

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).