### PR TITLE
Revert "Enforce authentication on api/status route by default"

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -70,14 +70,14 @@ export const configSchema = schema.object({
     }),
     anonymous_auth_enabled: schema.boolean({ defaultValue: false }),
     unauthenticated_routes: schema.arrayOf(schema.string(), {
-      defaultValue: ['/api/reporting/stats'],
+      defaultValue: ['/api/status', '/api/reporting/stats'],
     }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     logout_url: schema.string({ defaultValue: '' }),
   }),
   basicauth: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
-    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: [] }),
+    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status'] }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     header_trumps_session: schema.boolean({ defaultValue: false }),
     alternative_login: schema.object({

--- a/test/jest_integration/basic_auth.test.ts
+++ b/test/jest_integration/basic_auth.test.ts
@@ -207,16 +207,4 @@ describe('start OpenSearch Dashboards server', () => {
 
     expect(response.status).toEqual(302);
   });
-
-  it('enforce authentication on api/status route', async () => {
-    const response = await osdTestServer.request.get(root, '/api/status');
-    expect(response.status).toEqual(401);
-  });
-
-  it('can access api/status route with admin credential', async () => {
-    const response = await osdTestServer.request
-      .get(root, '/api/status')
-      .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
-    expect(response.status).toEqual(200);
-  });
 });


### PR DESCRIPTION
Reverts https://github.com/opensearch-project/security-dashboards-plugin/pull/943. The change was planned to be merged after 2.0.0-rc1.