### PR TITLE
Fix 'openserach' typo in constants.tsx

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -96,7 +96,7 @@ export const CLUSTER_PERMISSIONS: string[] = [
   'cluster:admin/opensearch/ml/models/get',
   'cluster:admin/opensearch/ml/models/search',
   'cluster:admin/opensearch/ml/predict',
-  'cluster:admin/openserach/ml/stats/nodes',
+  'cluster:admin/opensearch/ml/stats/nodes',
   'cluster:admin/opensearch/ml/tasks/delete',
   'cluster:admin/opensearch/ml/tasks/get',
   'cluster:admin/opensearch/ml/tasks/search',


### PR DESCRIPTION
Signed-off-by: Cam McKenzie <camAtGitHub@users.noreply.github.com>

### Description
Fix 'openserach' typo. 
This commit has not been tested, however I scanned 'security', 'security-dashboard-plugins, and 'opensearch' repos.
security and its dashboards are the only two occurrences of the word.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).