### PR TITLE
[Backport to 2.x] Fix 'openserach' typo in constants.tsx (#953)

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -96,7 +96,7 @@ export const CLUSTER_PERMISSIONS: string[] = [
   'cluster:admin/opensearch/ml/models/get',
   'cluster:admin/opensearch/ml/models/search',
   'cluster:admin/opensearch/ml/predict',
-  'cluster:admin/openserach/ml/stats/nodes',
+  'cluster:admin/opensearch/ml/stats/nodes',
   'cluster:admin/opensearch/ml/tasks/delete',
   'cluster:admin/opensearch/ml/tasks/get',
   'cluster:admin/opensearch/ml/tasks/search',


### PR DESCRIPTION
Signed-off-by: Cam <camAtGitHub@users.noreply.github.com>

### Description
Backport PR #953 to 2.x

### Category
bug fix

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).