### PR TITLE
Select tenant popup only appears when multi-tenacy is enabled

### DIFF
--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -66,7 +66,8 @@ export function AccountNavButton(props: {
     [props.config, props.coreStart]
   );
 
-  if (getShouldShowTenantPopup()) {
+  // Check if the tenant modal should be shown on load
+  if (props.config.multitenancy.enabled && getShouldShowTenantPopup()) {
     setShouldShowTenantPopup(false);
     showTenantSwitchPanel();
   }


### PR DESCRIPTION
### Description
The current behavior is that all users will see a message to switch
tenants and if multi-tenancy is disabled, that message will be prompting
the user to ask the admin to enable the feature.  This is causing users
pain that are not interested in using the tenancy features.

### Issues Resolved
* Resolves #838

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).