### PR TITLE
Enforce authentication on api/status route by default

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -70,14 +70,14 @@ export const configSchema = schema.object({
     }),
     anonymous_auth_enabled: schema.boolean({ defaultValue: false }),
     unauthenticated_routes: schema.arrayOf(schema.string(), {
-      defaultValue: ['/api/status', '/api/reporting/stats'],
+      defaultValue: ['/api/reporting/stats'],
     }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     logout_url: schema.string({ defaultValue: '' }),
   }),
   basicauth: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
-    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status'] }),
+    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: [] }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     header_trumps_session: schema.boolean({ defaultValue: false }),
     alternative_login: schema.object({

--- a/test/jest_integration/basic_auth.test.ts
+++ b/test/jest_integration/basic_auth.test.ts
@@ -208,6 +208,11 @@ describe('start OpenSearch Dashboards server', () => {
     expect(response.status).toEqual(302);
   });
 
+  it('enforce authentication on api/status route', async () => {
+    const response = await osdTestServer.request.get(root, '/api/status');
+    expect(response.status).toEqual(401);
+  });
+
   it('can access api/status route with admin credential', async () => {
     const response = await osdTestServer.request
       .get(root, '/api/status')


### PR DESCRIPTION
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description
Re-submit #943. It was reverted from 2.0.0-rc1.

### Category
Bug fix

### Issues Resolved
https://github.com/opensearch-project/security-dashboards-plugin/issues/945

### Testing
ITs([One of the test cases](https://github.com/opensearch-project/security-dashboards-plugin/blob/main/test/jest_integration/basic_auth.test.ts#L211-L216) for this fix has already been merged with [another PR](https://github.com/opensearch-project/security-dashboards-plugin/pull/940)) by accident.

### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).