### PR TITLE
Clear the sessionStorage when logging out

### DIFF
--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -31,6 +31,8 @@ export async function fetchAccountInfoSafe(http: HttpStart): Promise<AccountInfo
 export async function logout(http: HttpStart, logoutUrl?: string): Promise<void> {
   await httpPost(http, API_AUTH_LOGOUT);
   setShouldShowTenantPopup(null);
+  // Clear everything in the sessionStorage since they can contain sensitive information
+  sessionStorage.clear();
   // When no basepath is set, we can take '/' as the basepath.
   const basePath = http.basePath.serverBasePath ? http.basePath.serverBasePath : '/';
   const nextUrl = encodeURIComponent(basePath);


### PR DESCRIPTION
Signed-off-by: Miki <miki@amazon.com>

### Description
OSD uses the browser's `sessionStorage` to store potentially sensitive information. This change clears the `sessionStorage` during logout.

### Category
Enhancement

### Why these changes are required?
Without this, potentially sensitive information is left in the `sessionStorage`.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).