### PR TITLE
Fix OIDC looping issue - too many redriects

### DIFF
--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -178,8 +178,11 @@ export class OpenIdAuthRoutes {
           });
         } catch (error) {
           context.security_plugin.logger.error(`OpenId authentication failed: ${error}`);
-          // redirect to login
-          return this.redirectToLogin(request, response);
+          if(error.toString().toLowerCase().includes("authentication exception")){
+            return response.unauthorized();
+          }else{
+            return this.redirectToLogin(request, response);
+          }
         }
       }
     );

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -178,9 +178,9 @@ export class OpenIdAuthRoutes {
           });
         } catch (error) {
           context.security_plugin.logger.error(`OpenId authentication failed: ${error}`);
-          if(error.toString().toLowerCase().includes("authentication exception")){
+          if (error.toString().toLowerCase().includes('authentication exception')) {
             return response.unauthorized();
-          }else{
+          } else {
             return this.redirectToLogin(request, response);
           }
         }


### PR DESCRIPTION
Signed-off-by: Aozixuan Priscilla Guan <aoguan@amazon.com>

### Description
Customized error handling mechanism based on the error message for OIDC routing 

### Category
Bug fix

### Why these changes are required?
Resolve redirect login looping issues when authentication failures detected.

### What is the old behavior before changes and new behavior after changes?
Old Behavior:

Any exceptions caught during the OIDC authentication process causes redirecting login infinitely.

New Behavior:
If error message includes "authentication error": => return 401: unauthorized 
Else: redirect to login

### Issues Resolved
https://github.com/opensearch-project/security-dashboards-plugin/issues/990

### Testing
unit testing and integration testing 

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).