### PR TITLE
Get security_tenant search param from URL

### DIFF
--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -46,10 +46,14 @@ export function resolveTenant(
   let selectedTenant: string | undefined;
   const securityTenant_ = request?.url?.searchParams?.get('securityTenant_');
   const securitytenant = request?.url?.searchParams?.get('securitytenant');
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const security_tenant = request?.url?.searchParams?.get('security_tenant');
   if (securityTenant_) {
     selectedTenant = securityTenant_;
   } else if (securitytenant) {
     selectedTenant = securitytenant;
+  } else if (security_tenant) {
+    selectedTenant = security_tenant;
   } else if (request.headers.securitytenant || request.headers.securityTenant_) {
     selectedTenant = request.headers.securitytenant
       ? (request.headers.securitytenant as string)


### PR DESCRIPTION
Signed-off-by: cliu123 <lc12251109@gmail.com>

### Description
The root cause of [the issue](https://github.com/opensearch-project/security-dashboards-plugin/issues/1012) is that the search param(`security_tenant`) in the URL is not captured.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation] Bug fix

### Issues Resolved
https://github.com/opensearch-project/security-dashboards-plugin/issues/1012
### Testing

- The sharing saved object functionality doesn't have UTs, so there's no suitable place to add test for this fix for now. I've created [an issue](https://github.com/opensearch-project/security-dashboards-plugin/issues/1023) to track adding tests for this functionatlity.
- Manual Testing:
  * Create a visualization in global tenant.
  * Copy the link to share the visualization.
  * Visit the link in private tenant.
  * Browser successfully re-directs to the right saved object.(used to be `{"statusCode":404,"error":"Not Found","message":"Saved object [url/<saved_object_id>] not found"}`)


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).