### PR TITLE
Preserve URL Hash for SAML based login

### DIFF
--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -230,6 +230,8 @@ export class SamlAuthRoutes {
       }
     );
 
+    // captureUrlFragment is the first route that will be invoked in the SP initiated login.
+    // This route will execute the captureUrlFragment.js script.
     this.coreSetup.http.resources.register(
       {
         path: '/auth/saml/captureUrlFragment',
@@ -260,6 +262,7 @@ export class SamlAuthRoutes {
       }
     );
 
+    // This script will store the URL Hash in browser's local storage.
     this.coreSetup.http.resources.register(
       {
         path: '/auth/saml/captureUrlFragment.js',
@@ -289,6 +292,9 @@ export class SamlAuthRoutes {
       }
     );
 
+    //  Once the User is authenticated via the '_opendistro/_security/saml/acs' route,
+    //  the browser will be redirected to '/auth/saml/redirectUrlFragment' route,
+    //  which will execute the redirectUrlFragment.js.
     this.coreSetup.http.resources.register(
       {
         path: '/auth/saml/redirectUrlFragment',
@@ -314,6 +320,8 @@ export class SamlAuthRoutes {
       }
     );
 
+    // This script will pop the Hash from local storage if it exists.
+    // And forward the browser to the next url.
     this.coreSetup.http.resources.register(
       {
         path: '/auth/saml/redirectUrlFragment.js',

--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -148,7 +148,6 @@ export class SamlAuthRoutes {
           };
           this.sessionStorageFactory.asScoped(request).set(cookie);
           if (redirectHash) {
-            console.log('The server base path is : ' + this.coreSetup.http.basePath.serverBasePath);
             return response.redirected({
               headers: {
                 location: `${

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -54,18 +54,18 @@ export class SamlAuthentication extends AuthenticationType {
   private generateNextUrl(request: OpenSearchDashboardsRequest): string {
     const path =
       this.coreSetup.http.basePath.serverBasePath +
-      (request.url.path || '/app/opensearch-dashboards');
+      (request.url.pathname || '/app/opensearch-dashboards');
     return escape(path);
   }
 
-  private redirectToLoginUri(request: OpenSearchDashboardsRequest, toolkit: AuthToolkit) {
+  private redirectSAMlCapture = (request: OpenSearchDashboardsRequest, toolkit: AuthToolkit) => {
     const nextUrl = this.generateNextUrl(request);
     const clearOldVersionCookie = clearOldVersionCookieValue(this.config);
     return toolkit.redirected({
-      location: `${this.coreSetup.http.basePath.serverBasePath}/auth/saml/login?nextUrl=${nextUrl}`,
+      location: `${this.coreSetup.http.basePath.serverBasePath}/auth/saml/captureUrlFragment?nextUrl=${nextUrl}`,
       'set-cookie': clearOldVersionCookie,
     });
-  }
+  };
 
   private setupRoutes(): void {
     const samlAuthRoutes = new SamlAuthRoutes(
@@ -112,7 +112,7 @@ export class SamlAuthentication extends AuthenticationType {
     toolkit: AuthToolkit
   ): IOpenSearchDashboardsResponse | AuthResult {
     if (this.isPageRequest(request)) {
-      return this.redirectToLoginUri(request, toolkit);
+      return this.redirectSAMlCapture(request, toolkit);
     } else {
       return response.unauthorized();
     }

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -36,6 +36,7 @@ export interface SecuritySessionCookie {
   saml?: {
     requestId?: string;
     nextUrl?: string;
+    redirectHash?: boolean;
   };
 }
 


### PR DESCRIPTION
### Description
In Opensearch Dashboards URL Hash encodes the state of a visualization (state could be the filters to apply, the time range etc). Currently for SAML based authentication when User logins-for-the-first-time/re-authenticates the url hash is being dropped because of redirecting to the IDP. This PR ensures that URL Hash is preserved after authenticating with the IDP.

Old Closed PR for reference : https://github.com/opensearch-project/security-dashboards-plugin/pull/1001.

### Category
Enhancement

### Why these changes are required?
This PR ensures that state of visualization remains consistent after authenticating via IDP.

### What is the old behavior before changes and new behavior after changes?
In the old behavior when the dashboard plugin redirects browser to IDP the hash is lost and User looses their unsaved work. In the new behavior,  before redirecting to IDP the dashboard plugin will store the hash in browser's local storage, later after the User is authenticated the hash is restored from the browser's local storage.

### Issues Resolved
#543 and #831

### Testing
### Intergation Testing:

- [I have written selenium based integration test, which will simulate the Login Flow. I have not included it in this PR. Will raise a separate PR for that.](https://github.com/devardee/security-dashboards-plugin/blob/saml_integ_tests/test/jest_integration/saml_auth.tests.ts)

### Manual Testing:
To Test the flow manually we need 3 servers.

1. Opensearch Server is running with the following settings in the yml file.
```plugins.security.ssl.transport.pemcert_filepath: esnode.pem
plugins.security.ssl.transport.pemkey_filepath: esnode-key.pem
plugins.security.ssl.transport.pemtrustedcas_filepath: root-ca.pem
plugins.security.ssl.transport.enforce_hostname_verification: false
plugins.security.ssl.http.enabled: true
plugins.security.ssl.http.pemcert_filepath: esnode.pem
plugins.security.ssl.http.pemkey_filepath: esnode-key.pem
plugins.security.ssl.http.pemtrustedcas_filepath: root-ca.pem
plugins.security.allow_unsafe_democertificates: true
plugins.security.allow_default_init_securityindex: true
plugins.security.authcz.admin_dn:
  - CN=kirk,OU=client,O=client,L=test, C=de

plugins.security.unsupported.restapi.allow_securityconfig_modification: true
plugins.security.audit.type: internal_opensearch
plugins.security.enable_snapshot_restore_privilege: true
plugins.security.check_snapshot_restore_write_privileges: true
plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
plugins.security.system_indices.enabled: true
plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
```

2. For SAML IDP, Clone this [repo](https://github.com/mcguinness/saml-idp) and run the following commands in a separate terminal
```
openssl req -x509 -new -newkey rsa:2048 -nodes \
>     -subj '/C=US/ST=California/L=San Francisco/O=JankyCo/CN=Test Identity Provider' \
>     -keyout idp-private-key.pem \
>     -out idp-public-cert.pem -days 7300

node app.js --acsUrl http://localhost:5601/woq --audience https://localhost:9200
```

3. Now start the opensearch dashboard server with the following settings in the dashboards.yml file:
```
server.host: "localhost"
server.basePath: "/woq"
server.xsrf.whitelist: ["/_opendistro/_security/saml/acs/idpinitiated", "/_opendistro/_security/saml/acs",
                        "/_opendistro/_security/saml/logout"]
opensearch.hosts: ["https://localhost:9200"]
opensearch.ssl.verificationMode: none
opensearch.username: "kibanaserver"
opensearch.password: "kibanaserver"
opensearch.requestHeadersWhitelist: [ authorization,securitytenant ]
opensearch_security.multitenancy.enabled: true
opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
opensearch_security.readonly_mode.roles: ["kibana_read_only"]
opensearch_security.auth.type: "saml"
opensearch_security.auth.anonymous_auth_enabled: true

# Use this setting if you are running opensearch-dashboards without https
opensearch_security.cookie.secure: false
```

4. Perform a PATCH request to Openserach Server to enable SAML
```
curl -X PATCH https://localhost:9200/_plugins/_security/api/securityconfig -H 'Content-Type: application/json' -H 'Accept: application/json' -d '[{"op": "add","path": "/config/dynamic/authc/saml_auth_domain","value": {"http_enabled": "true","transport_enabled": "false","order": 5,"http_authenticator": {"challenge": true,"type": "saml","config": {"idp": {"metadata_url": "http://localhost:7000/metadata","entity_id": "urn:example:idp"},"sp": {"entity_id": "https://localhost:9200"},"kibana_url": "http://localhost:5601/woq","exchange_key": "6aff3042-1327-4f3d-82f0-40a157ac4464"}}, "authentication_backend":{"type": "noop","config": {}}}}]' -k -u 'admin:admin'
```

5. `saml.jackson@example.com` is the default username, that can be changed in the config of the IDP. PATCH Request to map all_access role to that user for testing purpose.
```
curl -X PATCH https://localhost:9200/_plugins/_security/api/rolesmapping/all_access -H 'Content-Type: application/json' -H 'Accept: application/json' -d '[{"op":"add", "path": "/users", "value": ["saml.jackson@example.com"]}]'
```

6. Login as the user and download the sample data and verify if the hash is being preserved after re-logging/loginng-for-the-first-time.

### HAR File:
[SamlHashPreserve.har.zip](https://github.com/opensearch-project/security-dashboards-plugin/files/9155007/SamlHashPreserve.har.zip)

### Video demonstrating the flow:
![SamlHashPreserve](https://user-images.githubusercontent.com/80896069/180101499-efb7e4e6-1ab6-47ae-9f75-d0fee47b2abf.gif)


### Check List
- [x] New functionality includes testing
- [] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).