### PR TITLE
Backport #1024 tenant resolver to 1.2, 1.1, 1.0 and `opendistro` versions

### DIFF
--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -43,8 +43,12 @@ export function resolveTenant(
 ): string | undefined {
   let selectedTenant: string | undefined;
   const query: any = request.url.query as any;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const security_tenant = request?.url?.searchParams?.get('security_tenant');
   if (query && (query.security_tenant || query.securitytenant)) {
     selectedTenant = query.security_tenant ? query.security_tenant : query.securitytenant;
+  } else if (security_tenant) {
+    selectedTenant = security_tenant;
   } else if (request.headers.securitytenant || request.headers.security_tenant) {
     selectedTenant = request.headers.securitytenant
       ? (request.headers.securitytenant as string)


### PR DESCRIPTION
Backport https://github.com/opensearch-project/security-dashboards-plugin/pull/1024 to branches "1.3", "1.2", "1.1", 1.0"/
Follow up issue: https://github.com/opensearch-project/security-dashboards-plugin/issues/1012
### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

Please tag the PR with labels : `backport 1.1`, `backport 1.0`, `backport 1.x`, `opendistro-1.13` to enable auto-bot to generate PRs for auto-backporting to previous versions after this PR is merged into `1.2`.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).