### PR TITLE
Adding @cwperks to Security maintainers.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,3 +7,4 @@
 | Darshit Chanpura | [DarshitChanpura](https://github.com/DarshitChanpura) | Amazon      |
 | Dave Lago        | [davidlago](https://github.com/davidlago)             | Amazon      |
 | Peter Nied       | [peternied](https://github.com/peternied)             | Amazon      |
+| Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |


### PR DESCRIPTION
### Description

Following the process in https://github.com/opensearch-project/.github/pull/59, I had nominated Craig Perkins (@cwperks) as a co-maintainer. The maintainers have voted and agreed to this nomination.

Craig has been participating in creating pull requests in both the back-end and front-end security repositories, answering questions and engaging with issue along with providing pull request feedback to keep standards high.

![image](https://user-images.githubusercontent.com/2754967/183511085-bf5dc19c-adf6-4134-a80e-61033ea65ddd.png)

![image](https://user-images.githubusercontent.com/2754967/183511035-88692bf4-9f7c-4844-b8ab-9c91e32ee759.png)

### Check List
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
