### PR TITLE
Fixed the inconsistence of column name on the list of roles page

### DIFF
--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -71,7 +71,7 @@ const columns: Array<EuiBasicTableColumn<RoleListing>> = [
   },
   {
     field: 'indexPermissions',
-    name: 'Index permissions',
+    name: 'Index',
     render: truncatedListView(tableItemsUIProps),
     truncateText: true,
   },
@@ -202,7 +202,7 @@ export function RoleList(props: AppDependencies) {
         {
           type: 'field_value_selection',
           field: 'indexPermissions',
-          name: 'Index permissions',
+          name: 'Index',
           multiSelect: 'or',
           options: buildSearchFilterOptions(roleData, 'indexPermissions'),
         },


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>

### Description
Fixed the column name "Index permissions" on the list of roles page is inconsistent with the field name "Index" on the "Create Role" page

### Issues Resolved
* Resolves https://github.com/opensearch-project/security-dashboards-plugin/issues/922

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).