### PR TITLE
Add the feature of showing useful error message during CI

### DIFF
--- a/.github/workflows/prerequisite-test.yml
+++ b/.github/workflows/prerequisite-test.yml
@@ -1,0 +1,14 @@
+name: Prerequisite Checks
+
+on: [push, pull_request]
+
+jobs:
+  tests:
+    name: Run prerequisite checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for the existence of the OpenSearch Security Plugin artifact
+        env:
+          opensearch_version: 2.3.0
+          opensearch_security_plugin_version: 2.3.0.0
+        run: wget -S --spider https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${opensearch_version}/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-${opensearch_security_plugin_version}.zip || (echo "Please make sure security plugin has been bumped to the same version and added to manifest." && exit 1)


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>

### Description
Create a separate workflow and implemented environment variable of version to check for the existence of the OpenSearch Security Plugin artifact

### Issues Resolved
* Resolved https://github.com/opensearch-project/security-dashboards-plugin/issues/1073 

### Testing
~[CI test case#1 with "403 Forbidden" response](https://github.com/opensearch-project/security-dashboards-plugin/runs/8000467600?check_suite_focus=true)~
~[CI test case#2 with "404 Not Found" response](https://github.com/opensearch-project/security-dashboards-plugin/runs/8000584940?check_suite_focus=true)~
Created a new workflow for "Verify there is matching build of security plugin" by running `prerequisites-test`

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).