### PR TITLE
Fixed the tenant switching after timeout

### DIFF
--- a/public/apps/account/test/plugin.test.tsx
+++ b/public/apps/account/test/plugin.test.tsx
@@ -1,0 +1,48 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { interceptError } from '../../../utils/logout-utils';
+import { setShouldShowTenantPopup } from '../../../utils/storage-utils';
+import { LOGIN_PAGE_URI } from '../../../../common';
+
+jest.mock('../../../utils/storage-utils', () => ({
+  setShouldShowTenantPopup: jest.fn(),
+}));
+
+describe('Intercept error handler', () => {
+  const fakeError401 = {
+    response: {
+      status: 401,
+    },
+  };
+
+  const fakeError400 = {
+    response: {
+      status: 400,
+    },
+  };
+
+  it('Intercept error handler Should call setShouldShowTenantPopup on session timeout', () => {
+    const sessionTimeoutFn = interceptError(LOGIN_PAGE_URI, window);
+    sessionTimeoutFn(fakeError401, null);
+    expect(setShouldShowTenantPopup).toBeCalledTimes(1);
+  });
+
+  it('Intercept error handler Should not call setShouldShowTenantPopup on session timeout', () => {
+    const sessionTimeoutFn = interceptError(LOGIN_PAGE_URI, window);
+    sessionTimeoutFn(fakeError400, null);
+    expect(setShouldShowTenantPopup).toBeCalledTimes(0);
+  });
+});

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -43,6 +43,7 @@ import {
   SecurityPluginStart,
 } from './types';
 import { addTenantToShareURL } from './services/shared-link';
+import { interceptError } from './utils/logout-utils';
 
 async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
   try {
@@ -149,23 +150,7 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
     if (config.ui.autologout) {
       // logout the user when getting 401 unauthorized, e.g. when session timed out.
       core.http.intercept({
-        responseError: (httpErrorResponse, controller) => {
-          if (
-            httpErrorResponse.response?.status === 401 &&
-            !(
-              window.location.pathname.toLowerCase().includes(LOGIN_PAGE_URI) ||
-              window.location.pathname.toLowerCase().includes(CUSTOM_ERROR_PAGE_URI)
-            )
-          ) {
-            if (config.auth.logout_url) {
-              window.location.href = config.auth.logout_url;
-            } else {
-              // when session timed out, user credentials in cookie are wiped out
-              // refres the page will direct the user to go through login process
-              window.location.reload();
-            }
-          }
-        },
+        responseError: interceptError(config.auth.logout_url, window),
       });
     }
 

--- a/public/utils/logout-utils.tsx
+++ b/public/utils/logout-utils.tsx
@@ -1,0 +1,43 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { setShouldShowTenantPopup } from './storage-utils';
+import {
+  HttpInterceptorResponseError,
+  IHttpInterceptController,
+} from '../../../../src/core/public';
+import { CUSTOM_ERROR_PAGE_URI, LOGIN_PAGE_URI } from '../../common';
+
+export function interceptError(logoutUrl: string, thisWindow: Window): any {
+  return (httpErrorResponse: HttpInterceptorResponseError, _: IHttpInterceptController) => {
+    if (httpErrorResponse.response?.status === 401) {
+      setShouldShowTenantPopup(null);
+      if (
+        !(
+          thisWindow.location.pathname.toLowerCase().includes(LOGIN_PAGE_URI) ||
+          thisWindow.location.pathname.toLowerCase().includes(CUSTOM_ERROR_PAGE_URI)
+        )
+      ) {
+        if (logoutUrl) {
+          thisWindow.location.href = logoutUrl;
+        } else {
+          // when session timed out, user credentials in cookie are wiped out
+          // refres the page will direct the user to go through login process
+          thisWindow.location.reload();
+        }
+      }
+    }
+  };
+}


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>

### Description
Fix the issue of user tenant automatically switch back to Private/Global by default after session timeout.

### Category
Bug fix

### Issues Resolved
* Resolved https://github.com/opensearch-project/security-dashboards-plugin/issues/1084

### Check List
- [x] New functionality includes testing
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).