### PR TITLE
Fix the UI user flow of selecting custom teanant on tenant switch panel

### DIFF
--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -232,6 +232,9 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
     }
   };
 
+  const invalidCustomTenant =
+    tenantSwitchRadioIdSelected === CUSTOM_TENANT_RADIO_ID && !selectedCustomTenantOption[0];
+
   let content;
 
   if (isMultiTenancyEnabled) {
@@ -249,6 +252,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
           In current EUI if put into the child of radio option, clicking in the combo box will not
           show the drop down list since the radio option consumes the click event. */}
         <EuiComboBox
+          placeholder="Select a custom tenant"
           options={customTenantOptions}
           singleSelection={{ asPlainText: true }}
           selectedOptions={selectedCustomTenantOption}
@@ -297,8 +301,8 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
 
           <EuiButton
             data-test-subj="confirm"
-            fill
-            disabled={!isMultiTenancyEnabled}
+            fill={isMultiTenancyEnabled && !invalidCustomTenant}
+            disabled={!isMultiTenancyEnabled || invalidCustomTenant}
             onClick={handleTenantConfirmation}
           >
             Confirm

--- a/public/apps/account/test/__snapshots__/tenant-switch-panel.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/tenant-switch-panel.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
             },
           ]
         }
+        placeholder="Select a custom tenant"
         selectedOptions={Array []}
         singleSelection={
           Object {
@@ -190,6 +191,7 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
             },
           ]
         }
+        placeholder="Select a custom tenant"
         selectedOptions={Array []}
         singleSelection={
           Object {
@@ -304,6 +306,7 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
             },
           ]
         }
+        placeholder="Select a custom tenant"
         selectedOptions={Array []}
         singleSelection={
           Object {
@@ -418,6 +421,7 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
             },
           ]
         }
+        placeholder="Select a custom tenant"
         selectedOptions={Array []}
         singleSelection={
           Object {
@@ -532,6 +536,7 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
             },
           ]
         }
+        placeholder="Select a custom tenant"
         selectedOptions={Array []}
         singleSelection={
           Object {


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>

### Description
- Add description into the custom tenant selecting dropdown list, and disable the button when there is no valid selection for custom tenant.
- Update the unit test.

### Category
Bug fix

### Issues Resolved
* Resolved https://github.com/opensearch-project/security-dashboards-plugin/issues/819

### Testing
![Sep-30-2022 12-13-31](https://user-images.githubusercontent.com/109499885/193312909-26f8df7f-f33b-4066-80dd-ad9282700806.gif)

### Check List
- [x] New functionality includes testing
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).