### PR TITLE
Backport/backport 1058 to 1.0

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -66,7 +66,7 @@ jobs:
           docker build -t opensearch-test:latest -f- . <<EOF
           FROM ubuntu:latest
           COPY --chown=1001:1001 os-ep.sh /docker-host/
-          COPY --chown=1001:1001 security/target/releases/opensearch-security-1.0.0.0.zip /docker-host/security-plugin.zip
+          COPY --chown=1001:1001 security/target/releases/opensearch-security-1.0.1.0.zip /docker-host/security-plugin.zip
           COPY --chown=1001:1001 opensearch* /opensearch/
           RUN chmod +x /docker-host/os-ep.sh
           RUN useradd -u 1001 -s /sbin/nologin opensearch

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,6 +1,6 @@
 {
   "id": "securityDashboards",
-  "version": "1.0.0.0",
+  "version": "1.0.1.0",
   "opensearchDashboardsVersion": "1.0.0",
   "configPath": ["opensearch_security"],
   "requiredPlugins": ["navigation"],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-security-dashboards",
-  "version": "1.0.0.0",
+  "version": "1.0.1.0",
   "main": "target/plugins/opensearch_security_dashboards",
   "opensearchDashboards": {
     "version": "1.0.0",

--- a/public/apps/account/account-app.tsx
+++ b/public/apps/account/account-app.tsx
@@ -64,6 +64,7 @@ export async function setupTopNavButton(coreStart: CoreStart, config: ClientConf
             });
             tenant = savedTenant;
             shouldShowTenantPopup = false;
+            window.location.reload();
           }
         }
       } catch (e) {

--- a/public/apps/account/log-out-button.tsx
+++ b/public/apps/account/log-out-button.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
 import { HttpStart } from 'opensearch-dashboards/public';
-import { logout } from './utils';
+import { logout, samlLogout } from './utils';
 
 export function LogoutButton(props: {
   authType: string;
@@ -24,7 +24,21 @@ export function LogoutButton(props: {
   divider: JSX.Element;
   logoutUrl?: string;
 }) {
-  if (props.authType === 'openid' || props.authType === 'saml') {
+  if (props.authType === 'openid') {
+    return (
+      <div>
+        {props.divider}
+        <EuiButtonEmpty
+          data-test-subj="log-out-2"
+          color="danger"
+          size="xs"
+          href={`${props.http.basePath.serverBasePath}/auth/logout`}
+        >
+          Log out
+        </EuiButtonEmpty>
+      </div>
+    );
+  } else if (props.authType === 'saml') {
     return (
       <div>
         {props.divider}
@@ -32,7 +46,7 @@ export function LogoutButton(props: {
           data-test-subj="log-out-1"
           color="danger"
           size="xs"
-          href={`${props.http.basePath.serverBasePath}/auth/logout`}
+          onClick={() => samlLogout(props.http)}
         >
           Log out
         </EuiButtonEmpty>
@@ -45,7 +59,7 @@ export function LogoutButton(props: {
       <div>
         {props.divider}
         <EuiButtonEmpty
-          data-test-subj="log-out-2"
+          data-test-subj="log-out-3"
           color="danger"
           size="xs"
           onClick={() => logout(props.http, props.logoutUrl)}

--- a/public/apps/account/test/__snapshots__/log-out-button.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/log-out-button.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Account menu - Log out button renders renders when auth type is OpenId 
 <div>
   <EuiButtonEmpty
     color="danger"
-    data-test-subj="log-out-1"
+    data-test-subj="log-out-2"
     href="/auth/logout"
     size="xs"
   >
@@ -20,7 +20,7 @@ exports[`Account menu - Log out button renders renders when auth type is SAML 1`
   <EuiButtonEmpty
     color="danger"
     data-test-subj="log-out-1"
-    href="/auth/logout"
+    onClick={[Function]}
     size="xs"
   >
     Log out
@@ -32,7 +32,7 @@ exports[`Account menu - Log out button renders renders when auth type is not Ope
 <div>
   <EuiButtonEmpty
     color="danger"
-    data-test-subj="log-out-2"
+    data-test-subj="log-out-3"
     onClick={[Function]}
     size="xs"
   >

--- a/public/apps/account/test/log-out-button.test.tsx
+++ b/public/apps/account/test/log-out-button.test.tsx
@@ -68,7 +68,7 @@ describe('Account menu - Log out button', () => {
     const component = shallow(
       <LogoutButton authType="dummy" http={mockHttpStart} divider={mockDivider} />
     );
-    component.find('[data-test-subj="log-out-2"]').simulate('click');
+    component.find('[data-test-subj="log-out-3"]').simulate('click');
 
     expect(logout).toBeCalled();
   });

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -38,6 +38,12 @@ export async function logout(http: HttpStart, logoutUrl?: string): Promise<void>
     logoutUrl || `${http.basePath.serverBasePath}/app/login?nextUrl=${nextUrl}`;
 }
 
+export async function samlLogout(http: HttpStart): Promise<void> {
+  // This will ensure tenancy is picked up from local storage in the next login.
+  setShouldShowTenantPopup(null);
+  window.location.href = `${http.basePath.serverBasePath}${API_AUTH_LOGOUT}`;
+}
+
 export async function updateNewPassword(
   http: HttpStart,
   newPassword: string,

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -159,6 +159,7 @@ export const INDEX_PERMISSIONS: string[] = [
   'indices:admin/open',
   'indices:admin/refresh',
   'indices:admin/refresh*',
+  'indices:admin/resolve/index',
   'indices:admin/rollover',
   'indices:admin/seq_no/global_checkpoint_sync',
   'indices:admin/settings/update',

--- a/release-notes/opensearch-security-dashboards-plugin.release-notes-1.0.1.0.md
+++ b/release-notes/opensearch-security-dashboards-plugin.release-notes-1.0.1.0.md
@@ -1,0 +1,9 @@
+## Version 1.0.1.0
+
+### Bug Fixes
+* add resolve pemission to UI ([#803](https://github.com/opensearch-project/security-dashboards-plugin/pull/803))
+* Add refresh page to account-app.tsx to solve the tenant display issue ([#811](https://github.com/opensearch-project/security-dashboards-plugin/pull/811))
+
+### Maintenance
+* Add Integtest.sh for OpenSearch integtest setups ([#783](https://github.com/opensearch-project/security-dashboards-plugin/pull/783))
+* Bump plugin version to 1.0.1.0 ([#813](https://github.com/opensearch-project/security-dashboards-plugin/pull/813))

--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -131,7 +131,7 @@ export class SamlAuthRoutes {
             context.security_plugin.logger.error('JWT token payload not found');
           }
           const tokenPayload = JSON.parse(
-            Buffer.from(payloadEncoded, 'base64').toString().replace('\\', '\\\\')
+            Buffer.from(payloadEncoded, 'base64').toString()
           );
           if (tokenPayload.exp) {
             expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
@@ -190,7 +190,7 @@ export class SamlAuthRoutes {
             context.security_plugin.logger.error('JWT token payload not found');
           }
           const tokenPayload = JSON.parse(
-            Buffer.from(payloadEncoded, 'base64').toString().replace('\\', '\\\\')
+            Buffer.from(payloadEncoded, 'base64').toString()
           );
           if (tokenPayload.exp) {
             expiryTime = parseInt(tokenPayload.exp, 10) * 1000;

--- a/test/jest_integration/saml_auth.test.ts
+++ b/test/jest_integration/saml_auth.test.ts
@@ -1,0 +1,338 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import * as osdTestServer from '../../../../src/core/test_helpers/osd_server';
+import { Root } from '../../../../src/core/server/root';
+import { resolve } from 'path';
+import { describe, expect, it, beforeAll, afterAll } from '@jest/globals';
+import {
+  ADMIN_CREDENTIALS,
+  OPENSEARCH_DASHBOARDS_SERVER_USER,
+  OPENSEARCH_DASHBOARDS_SERVER_PASSWORD,
+} from '../constant';
+import wreck from '@hapi/wreck';
+import { Builder, By, until } from 'selenium-webdriver';
+import { Options } from 'selenium-webdriver/firefox';
+
+describe('start OpenSearch Dashboards server', () => {
+  let root: Root;
+  let config;
+
+  // XPath Constants
+  const userIconBtnXPath = '//button[@id="user-icon-btn"]';
+  const signInBtnXPath = '//*[@id="btn-sign-in"]';
+  const skipWelcomeBtnXPath = '//button[@data-test-subj="skipWelcomeScreen"]';
+  const tenantNameLabelXPath = '//*[@id="tenantName"]';
+  const pageTitleXPath = '//*[@id="osdOverviewPageHeader__title"]';
+  // Browser Settings
+  const browser = 'firefox';
+  const options = new Options().headless();
+
+  beforeAll(async () => {
+    root = osdTestServer.createRootWithSettings(
+      {
+        plugins: {
+          scanDirs: [resolve(__dirname, '../..')],
+        },
+        server: {
+          host: 'localhost',
+          port: 5601,
+          xsrf: {
+            whitelist: [
+              '/_opendistro/_security/saml/acs/idpinitiated',
+              '/_opendistro/_security/saml/acs',
+              '/_opendistro/_security/saml/logout',
+            ],
+          },
+        },
+        logging: {
+          silent: true,
+          verbose: false,
+        },
+        opensearch: {
+          hosts: ['https://localhost:9200'],
+          ignoreVersionMismatch: true,
+          ssl: { verificationMode: 'none' },
+          username: OPENSEARCH_DASHBOARDS_SERVER_USER,
+          password: OPENSEARCH_DASHBOARDS_SERVER_PASSWORD,
+          requestHeadersWhitelist: ['authorization', 'securitytenant'],
+        },
+        opensearch_security: {
+          auth: {
+            anonymous_auth_enabled: false,
+            type: 'saml',
+          },
+          multitenancy: {
+            enabled: true,
+            tenants: {
+              enable_global: true,
+              enable_private: true,
+              preferred: ['Private', 'Global'],
+            },
+          },
+        },
+      },
+      {
+        // to make ignoreVersionMismatch setting work
+        // can be removed when we have corresponding ES version
+        dev: true,
+      }
+    );
+
+    console.log('Starting OpenSearchDashboards server..');
+    await root.setup();
+    await root.start();
+
+    await wreck.patch('https://localhost:9200/_plugins/_security/api/rolesmapping/all_access', {
+      payload: [
+        {
+          op: 'add',
+          path: '/users',
+          value: ['saml.jackson@example.com'],
+        },
+      ],
+      rejectUnauthorized: false,
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: ADMIN_CREDENTIALS,
+      },
+    });
+    console.log('Starting to Download Flights Sample Data');
+    await wreck.post('http://localhost:5601/api/sample_data/flights', {
+      payload: {},
+      rejectUnauthorized: false,
+      headers: {
+        'Content-Type': 'application/json',
+        authorization: ADMIN_CREDENTIALS,
+        security_tenant: 'global',
+      },
+    });
+    console.log('Downloaded Sample Data');
+    const getConfigResponse = await wreck.get(
+      'https://localhost:9200/_plugins/_security/api/securityconfig',
+      {
+        rejectUnauthorized: false,
+        headers: {
+          authorization: ADMIN_CREDENTIALS,
+        },
+      }
+    );
+    const responseBody = (getConfigResponse.payload as Buffer).toString();
+    config = JSON.parse(responseBody).config;
+    const samlConfig = {
+      http_enabled: true,
+      transport_enabled: false,
+      order: 5,
+      http_authenticator: {
+        challenge: true,
+        type: 'saml',
+        config: {
+          idp: {
+            metadata_url: 'http://localhost:7000/metadata',
+            entity_id: 'urn:example:idp',
+          },
+          sp: {
+            entity_id: 'https://localhost:9200',
+          },
+          kibana_url: 'http://localhost:5601',
+          exchange_key: '6aff3042-1327-4f3d-82f0-40a157ac4464',
+        },
+      },
+      authentication_backend: {
+        type: 'noop',
+        config: {},
+      },
+    };
+    try {
+      config.dynamic!.authc!.saml_auth_domain = samlConfig;
+      config.dynamic!.authc!.basic_internal_auth_domain.http_authenticator.challenge = false;
+      config.dynamic!.http!.anonymous_auth_enabled = false;
+      await wreck.put('https://localhost:9200/_plugins/_security/api/securityconfig/config', {
+        payload: config,
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: ADMIN_CREDENTIALS,
+        },
+      });
+    } catch (error) {
+      console.log('Got an error while updating security config!!', error.stack);
+      fail(error);
+    }
+  });
+
+  afterAll(async () => {
+    console.log('Remove the Sample Data');
+    await wreck
+      .delete('http://localhost:5601/api/sample_data/flights', {
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: ADMIN_CREDENTIALS,
+        },
+      })
+      .then((value) => {
+        Promise.resolve(value);
+      })
+      .catch((value) => {
+        Promise.resolve(value);
+      });
+    console.log('Remove the Role Mapping');
+    await wreck
+      .patch('https://localhost:9200/_plugins/_security/api/rolesmapping/all_access', {
+        payload: [
+          {
+            op: 'remove',
+            path: '/users',
+            users: ['saml.jackson@example.com'],
+          },
+        ],
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: ADMIN_CREDENTIALS,
+        },
+      })
+      .then((value) => {
+        Promise.resolve(value);
+      })
+      .catch((value) => {
+        Promise.resolve(value);
+      });
+    console.log('Remove the Security Config');
+    await wreck
+      .patch('https://localhost:9200/_plugins/_security/api/securityconfig', {
+        payload: [
+          {
+            op: 'remove',
+            path: '/config/dynamic/authc/saml_auth_domain',
+          },
+        ],
+        rejectUnauthorized: false,
+        headers: {
+          'Content-Type': 'application/json',
+          authorization: ADMIN_CREDENTIALS,
+        },
+      })
+      .then((value) => {
+        Promise.resolve(value);
+      })
+      .catch((value) => {
+        Promise.resolve(value);
+      });
+    // shutdown OpenSearchDashboards server
+    await root.shutdown();
+  });
+
+  it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', async () => {
+    const driver = getDriver(browser, options).build();
+    await driver.get('http://localhost:5601/app/opensearch_dashboards_overview#/');
+    await driver.findElement(By.id('btn-sign-in')).click();
+    await driver.wait(until.elementsLocated(By.xpath(pageTitleXPath)), 10000);
+
+    const cookie = await driver.manage().getCookies();
+    expect(cookie.length).toEqual(2);
+    await driver.manage().deleteAllCookies();
+    await driver.quit();
+  });
+
+  it('Login to app/dev_tools#/console when SAML is enabled', async () => {
+    const driver = getDriver(browser, options).build();
+    await driver.get('http://localhost:5601/app/dev_tools#/console');
+    await driver.findElement(By.id('btn-sign-in')).click();
+
+    await driver.wait(
+      until.elementsLocated(By.xpath('//*[@data-test-subj="sendRequestButton"]')),
+      10000
+    );
+
+    const cookie = await driver.manage().getCookies();
+    expect(cookie.length).toEqual(2);
+    await driver.manage().deleteAllCookies();
+    await driver.quit();
+  });
+
+  it('Login to Dashboard with Hash', async () => {
+    const urlWithHash = `http://localhost:5601/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(filters:!(),refreshInterval:(pause:!f,value:900000),time:(from:now-24h,to:now))&_a=(description:'Analyze%20mock%20flight%20data%20for%20OpenSearch-Air,%20Logstash%20Airways,%20OpenSearch%20Dashboards%20Airlines%20and%20BeatsWest',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'%5BFlights%5D%20Global%20Flight%20Dashboard',viewMode:view)`;
+    const driver = getDriver(browser, options).build();
+    await driver.manage().deleteAllCookies();
+    await driver.get(urlWithHash);
+    await driver.findElement(By.xpath(signInBtnXPath)).click();
+    // TODO Use a better XPath.
+    await driver.wait(
+      until.elementsLocated(By.xpath('/html/body/div[1]/div/header/div/div[2]')),
+      20000
+    );
+    const windowHash = await driver.getCurrentUrl();
+    expect(windowHash).toEqual(urlWithHash);
+    const cookie = await driver.manage().getCookies();
+    expect(cookie.length).toEqual(2);
+    await driver.manage().deleteAllCookies();
+    await driver.quit();
+  });
+
+  it('Tenancy persisted after Logout in SAML', async () => {
+    const driver = getDriver(browser, options).build();
+
+    await driver.get('http://localhost:5601/app/opensearch_dashboards_overview#/');
+
+    await driver.findElement(By.xpath(signInBtnXPath)).click();
+
+    await driver.wait(until.elementsLocated(By.xpath(pageTitleXPath)), 10000);
+
+    await driver.wait(
+      until.elementsLocated(By.xpath('//button[@aria-label="Closes this modal window"]')),
+      10000
+    );
+
+    // Select Global Tenant Radio Button
+    const radio = await driver.findElement(By.xpath('//input[@id="global"]'));
+    await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
+    await driver.executeScript('arguments[0].click();', radio);
+
+    await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
+
+    await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
+
+    await driver.findElement(By.xpath(userIconBtnXPath)).click();
+
+    await driver.findElement(By.xpath('//*[@data-test-subj="log-out-1"]')).click();
+
+    // RELOGIN AND CHECK TENANT
+
+    await driver.wait(until.elementsLocated(By.xpath(signInBtnXPath)), 10000);
+
+    await driver.findElement(By.xpath(signInBtnXPath)).click();
+
+    await driver.wait(until.elementsLocated(By.xpath(skipWelcomeBtnXPath)), 10000);
+
+    await driver.findElement(By.xpath(skipWelcomeBtnXPath)).click();
+
+    await driver.findElement(By.xpath(userIconBtnXPath)).click();
+
+    await driver.wait(until.elementsLocated(By.xpath(tenantNameLabelXPath)), 10000);
+
+    const tenantName = await driver.findElement(By.xpath(tenantNameLabelXPath)).getText();
+
+    await driver.manage().deleteAllCookies();
+    await driver.quit();
+
+    expect(tenantName).toEqual('Global');
+  });
+});
+
+function getDriver(browser: string, options: Options) {
+  return new Builder().forBrowser(browser).setFirefoxOptions(options);
+}


### PR DESCRIPTION
### Description
This fix is for ensuring that tenancy information is read from the local storage in SAML Authentication workflow after a user log out of OS Dashboard. 

### Category
Bug Fix

### Why these changes are required?
To have a good user experience and ensure their tenancy is reloaded after logging in into a new session in the same browser. 

### What is the old behavior before changes and new behavior after changes?
Tenancy information was not being read from local storage after logout in old behaviour for SAML authentication enabled domains. After the changes, tenancy information will be read from local storage. This is ensured as the session storage variable `pendistro::security::tenant::show_popup` is set to null after logout in SAML Authentication workflow. 

### Issues Resolved
[Issue](https://github.com/opensearch-project/security-dashboards-plugin/issues/1057) created for this bug

### Testing
The changes have been made in security-dashboards-plugin and the same has been tested for OS Dashboards in SAML authentication enabled domains. 

https://user-images.githubusercontent.com/110471048/183618009-30728f98-f108-490f-9516-d93ecd545f38.mp4


### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).