### PR TITLE
[Backport 1.0]  Tenancy getting Lost in SAML Authentication

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
+          ref: '1.0'
           fetch-depth: 0
       - name: Create plugins dir
         run: |

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "securityDashboards",
   "version": "1.0.1.0",
-  "opensearchDashboardsVersion": "1.0.0",
+  "opensearchDashboardsVersion": "1.0.1",
   "configPath": ["opensearch_security"],
   "requiredPlugins": ["navigation"],
   "server": true,

--- a/public/apps/account/log-out-button.tsx
+++ b/public/apps/account/log-out-button.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { EuiButtonEmpty } from '@elastic/eui';
 import { HttpStart } from 'opensearch-dashboards/public';
-import { logout } from './utils';
+import { logout, samlLogout } from './utils';
 
 export function LogoutButton(props: {
   authType: string;
@@ -24,7 +24,21 @@ export function LogoutButton(props: {
   divider: JSX.Element;
   logoutUrl?: string;
 }) {
-  if (props.authType === 'openid' || props.authType === 'saml') {
+  if (props.authType === 'openid') {
+    return (
+      <div>
+        {props.divider}
+        <EuiButtonEmpty
+          data-test-subj="log-out-2"
+          color="danger"
+          size="xs"
+          href={`${props.http.basePath.serverBasePath}/auth/logout`}
+        >
+          Log out
+        </EuiButtonEmpty>
+      </div>
+    );
+  } else if (props.authType === 'saml') {
     return (
       <div>
         {props.divider}
@@ -32,7 +46,7 @@ export function LogoutButton(props: {
           data-test-subj="log-out-1"
           color="danger"
           size="xs"
-          href={`${props.http.basePath.serverBasePath}/auth/logout`}
+          onClick={() => samlLogout(props.http)}
         >
           Log out
         </EuiButtonEmpty>
@@ -45,7 +59,7 @@ export function LogoutButton(props: {
       <div>
         {props.divider}
         <EuiButtonEmpty
-          data-test-subj="log-out-2"
+          data-test-subj="log-out-3"
           color="danger"
           size="xs"
           onClick={() => logout(props.http, props.logoutUrl)}

--- a/public/apps/account/test/__snapshots__/log-out-button.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/log-out-button.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Account menu - Log out button renders renders when auth type is OpenId 
 <div>
   <EuiButtonEmpty
     color="danger"
-    data-test-subj="log-out-1"
+    data-test-subj="log-out-2"
     href="/auth/logout"
     size="xs"
   >
@@ -20,7 +20,7 @@ exports[`Account menu - Log out button renders renders when auth type is SAML 1`
   <EuiButtonEmpty
     color="danger"
     data-test-subj="log-out-1"
-    href="/auth/logout"
+    onClick={[Function]}
     size="xs"
   >
     Log out
@@ -32,7 +32,7 @@ exports[`Account menu - Log out button renders renders when auth type is not Ope
 <div>
   <EuiButtonEmpty
     color="danger"
-    data-test-subj="log-out-2"
+    data-test-subj="log-out-3"
     onClick={[Function]}
     size="xs"
   >

--- a/public/apps/account/test/log-out-button.test.tsx
+++ b/public/apps/account/test/log-out-button.test.tsx
@@ -68,7 +68,7 @@ describe('Account menu - Log out button', () => {
     const component = shallow(
       <LogoutButton authType="dummy" http={mockHttpStart} divider={mockDivider} />
     );
-    component.find('[data-test-subj="log-out-2"]').simulate('click');
+    component.find('[data-test-subj="log-out-3"]').simulate('click');
 
     expect(logout).toBeCalled();
   });

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -38,6 +38,12 @@ export async function logout(http: HttpStart, logoutUrl?: string): Promise<void>
     logoutUrl || `${http.basePath.serverBasePath}/app/login?nextUrl=${nextUrl}`;
 }
 
+export async function samlLogout(http: HttpStart): Promise<void> {
+  // This will ensure tenancy is picked up from local storage in the next login.
+  setShouldShowTenantPopup(null);
+  window.location.href = `${http.basePath.serverBasePath}${API_AUTH_LOGOUT}`;
+}
+
 export async function updateNewPassword(
   http: HttpStart,
   newPassword: string,

--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -130,9 +130,7 @@ export class SamlAuthRoutes {
           if (!payloadEncoded) {
             context.security_plugin.logger.error('JWT token payload not found');
           }
-          const tokenPayload = JSON.parse(
-            Buffer.from(payloadEncoded, 'base64').toString()
-          );
+          const tokenPayload = JSON.parse(Buffer.from(payloadEncoded, 'base64').toString());
           if (tokenPayload.exp) {
             expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
           }
@@ -189,9 +187,7 @@ export class SamlAuthRoutes {
           if (!payloadEncoded) {
             context.security_plugin.logger.error('JWT token payload not found');
           }
-          const tokenPayload = JSON.parse(
-            Buffer.from(payloadEncoded, 'base64').toString()
-          );
+          const tokenPayload = JSON.parse(Buffer.from(payloadEncoded, 'base64').toString());
           if (tokenPayload.exp) {
             expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
           }


### PR DESCRIPTION
### Description
This fix is for ensuring that tenancy information is read from the local storage in SAML Authentication workflow after a user log out of OS Dashboard. 

### Category
Bug Fix

### Why these changes are required?
To have a good user experience and ensure their tenancy is reloaded after logging in into a new session in the same browser. 

### What is the old behavior before changes and new behavior after changes?
Tenancy information was not being read from local storage after logout in old behaviour for SAML authentication enabled domains. After the changes, tenancy information will be read from local storage. This is ensured as the session storage variable `pendistro::security::tenant::show_popup` is set to null after logout in SAML Authentication workflow. 

### Issues Resolved
[Issue](https://github.com/opensearch-project/security-dashboards-plugin/issues/1057) created for this bug

### Testing
The changes have been made in security-dashboards-plugin and the same has been tested for OS Dashboards in SAML authentication enabled domains. 

https://user-images.githubusercontent.com/110471048/183618009-30728f98-f108-490f-9516-d93ecd545f38.mp4


### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).