### PR TITLE
Revert "add maintainers"

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,3 @@
 | Dave Lago        | [davidlago](https://github.com/davidlago)             | Amazon      |
 | Peter Nied       | [peternied](https://github.com/peternied)             | Amazon      |
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
-| Yan Zeng         | [zengyan-amazon](https://github.com/zengyan-amazon)   | Amazon      |
-| Bandini          | [bandinib-amzn](https://github.com/bandinib-amzn)     | Amazon      |
-| Tianle Huang     | [tianleh](https://github.com/tianleh)                 | Amazon      |


### PR DESCRIPTION
Reverts opensearch-project/security-dashboards-plugin#1128

This was accidentally done, we just need to make sure we follow our published process before accepting.  Sorry for the hot/cold on this change.  https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md#becoming-a-maintainer