### PR TITLE
Adding Emeritus folks to maintainer list.  

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,5 +15,5 @@
 | Maintainer | GitHub ID | Affiliation |
 | --------------- | --------- | ----------- |
 | Yan Zeng         | [zengyan-amazon](https://github.com/zengyan-amazon)   | Amazon      |
-| Bandini Bhopi         | [bandinib-amzn](https://github.com/bandinib-amzn)     | Amazon      |
+| Bandini Bhopi    | [bandinib-amzn](https://github.com/bandinib-amzn)     | Amazon      |
 | Tianle Huang     | [tianleh](https://github.com/tianleh)                 | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,3 +8,12 @@
 | Dave Lago        | [davidlago](https://github.com/davidlago)             | Amazon      |
 | Peter Nied       | [peternied](https://github.com/peternied)             | Amazon      |
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
+
+
+## Emeritus
+
+| Maintainer | GitHub ID | Affiliation |
+| --------------- | --------- | ----------- |
+| Yan Zeng         | [zengyan-amazon](https://github.com/zengyan-amazon)   | Amazon      |
+| Bandini Bhopi         | [bandinib-amzn](https://github.com/bandinib-amzn)     | Amazon      |
+| Tianle Huang     | [tianleh](https://github.com/tianleh)                 | Amazon      |


### PR DESCRIPTION
### Description
This is a PR to add Yan, Bandini and Tianle to the maintainers list as emeritus to recognize their contribution to the creation of the repo in 2021.  This action does not change the active maintainers list, or add any current permissions (but would love for them to become active again)!"


### Check List
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).