### PR TITLE
Saved Object Aggregation View

### DIFF
--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -116,8 +116,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ${{ env.FTR_PATH }}
-          repository: RyanL1997/opensearch-dashboards-functional-test
-          ref: 'saved-objects-test'
+          repository: opensearch-project/opensearch-dashboards-functional-test
+          ref: 'main'
 
       - name: Get Cypress version
         id: cypress_version

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -17,12 +17,12 @@ jobs:
     steps:
       - name: Download OpenSearch Core
         run: |
-          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.4.0/latest/linux/x64/tar/builds/opensearch/dist/opensearch-min-2.4.0-linux-x64.tar.gz
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/3.0.0/latest/linux/x64/tar/builds/opensearch/dist/opensearch-min-3.0.0-linux-x64.tar.gz
           tar -xzf opensearch-*.tar.gz
           rm -f opensearch-*.tar.gz
           
       - name: Download OpenSearch Security Plugin
-        run: wget -O opensearch-security.zip https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.4.0/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-2.4.0.0.zip
+        run: wget -O opensearch-security.zip https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/3.0.0/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-3.0.0.0.zip
         
 
       - name: Run OpenSearch with plugin
@@ -53,7 +53,7 @@ jobs:
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
-          ref: '2.x'
+          ref: 'main'
           fetch-depth: 0
       
       - name: Create plugins dir

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -8,7 +8,7 @@ env:
   FTR_PATH: 'ftr'
   START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch --opensearch_security.multitenancy.enable_aggregation_view=true'
   OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot'
-  SPEC: 'cypress/integration/plugins/security-dashboard-plugin/aggregation_view.js,'
+  SPEC: 'cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js,'
 
 jobs:
   tests:

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -1,0 +1,131 @@
+name: Cypress Tests
+
+on: [push, pull_request]
+
+env:
+  TEST_BROWSER_HEADLESS: 1
+  CI: 1
+  FTR_PATH: 'ftr'
+  START_CMD: 'node ../scripts/opensearch_dashboards --dev --no-base-path --no-watch --opensearch_security.multitenancy.enable_aggregation_view=true'
+  OPENSEARCH_SNAPSHOT_CMD: 'node ../scripts/opensearch snapshot'
+  SPEC: 'cypress/integration/plugins/security-dashboard-plugin/aggregation_view.js,'
+
+jobs:
+  tests:
+    name: Run aggregation view cypress test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download OpenSearch Core
+        run: |
+          wget https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.4.0/latest/linux/x64/tar/builds/opensearch/dist/opensearch-min-2.4.0-linux-x64.tar.gz
+          tar -xzf opensearch-*.tar.gz
+          rm -f opensearch-*.tar.gz
+          
+      - name: Download OpenSearch Security Plugin
+        run: wget -O opensearch-security.zip https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/2.4.0/latest/linux/x64/tar/builds/opensearch/plugins/opensearch-security-2.4.0.0.zip
+        
+
+      - name: Run OpenSearch with plugin
+        run: |
+          cat > os-ep.sh <<EOF
+          yes | opensearch-plugin install file:///docker-host/security-plugin.zip
+          chmod +x plugins/opensearch-security/tools/install_demo_configuration.sh
+          yes | plugins/opensearch-security/tools/install_demo_configuration.sh
+          echo "plugins.security.unsupported.restapi.allow_securityconfig_modification: true" >> /opensearch/config/opensearch.yml
+          chown 1001:1001 -R /opensearch
+          su -c "/opensearch/bin/opensearch" -s /bin/bash opensearch
+          EOF
+          docker build -t opensearch-test:latest -f- . <<EOF
+          FROM ubuntu:latest
+          COPY --chown=1001:1001 os-ep.sh /docker-host/
+          COPY --chown=1001:1001 opensearch-security.zip /docker-host/security-plugin.zip
+          COPY --chown=1001:1001 opensearch* /opensearch/
+          RUN chmod +x /docker-host/os-ep.sh
+          RUN useradd -u 1001 -s /sbin/nologin opensearch
+          ENV PATH="/opensearch/bin:${PATH}"
+          WORKDIR /opensearch/
+          ENTRYPOINT /docker-host/os-ep.sh
+          EOF
+          docker run -d -p 9200:9200 -p 9600:9600 -i opensearch-test:latest
+
+      - name: Checkout OpenSearch Dashboard
+        uses: actions/checkout@v2
+        with:
+          path: OpenSearch-Dashboards
+          repository: opensearch-project/OpenSearch-Dashboards
+          ref: '2.x'
+          fetch-depth: 0
+      
+      - name: Create plugins dir
+        run: |
+          cd ./OpenSearch-Dashboards
+          mkdir -p plugins
+      
+      - name: Checkout OpenSearch Dashboard Security plugin
+        uses: actions/checkout@v2
+        with:
+          path: OpenSearch-Dashboards/plugins/security-dashboards-plugin
+          ref: ${{ github.ref }}
+
+      - name: Check OpenSearch Running
+        continue-on-error: true
+        run: curl -XGET https://localhost:9200 -u 'admin:admin' -k
+
+      - name: Get node and yarn versions
+        id: versions
+        run: |
+          echo "::set-output name=node_version::$(cat ./OpenSearch-Dashboards/.node-version)"
+          echo "::set-output name=yarn_version::$(jq -r '.engines.yarn' ./OpenSearch-Dashboards/package.json)"
+      
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.versions.outputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+      
+      - name: Install correct yarn version for OpenSearch Dashboards
+        run: |
+          npm uninstall -g yarn
+          echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
+          npm i -g yarn@${{ steps.versions.outputs.yarn_version }}
+      
+      - name: Check OpenSearch Running
+        continue-on-error: true
+        run: curl -XGET https://localhost:9200 -u 'admin:admin' -k
+
+      - name: Bootstrap OpenSearch Dashboards
+        continue-on-error: false
+        run: |
+          cd ./OpenSearch-Dashboards
+          yarn osd bootstrap
+          echo 'server.host: "0.0.0.0"' >> ./config/opensearch_dashboards.yml
+          echo 'opensearch.hosts: ["https://localhost:9200"]' >> ./config/opensearch_dashboards.yml
+          echo 'opensearch.ssl.verificationMode: none' >> ./config/opensearch_dashboards.yml
+          echo 'opensearch.username: "kibanaserver"' >> ./config/opensearch_dashboards.yml
+          echo 'opensearch.password: "kibanaserver"' >> ./config/opensearch_dashboards.yml
+          echo 'opensearch.requestHeadersWhitelist: [ authorization,securitytenant ]' >> ./config/opensearch_dashboards.yml
+          echo 'opensearch_security.multitenancy.enabled: true' >> ./config/opensearch_dashboards.yml
+          echo 'opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]' >> ./config/opensearch_dashboards.yml
+          echo 'opensearch_security.readonly_mode.roles: ["kibana_read_only"]' >> ./config/opensearch_dashboards.yml
+          echo 'opensearch_security.cookie.secure: false' >> ./config/opensearch_dashboards.yml
+          echo 'opensearch_security.multitenancy.enable_aggregation_view: true' >> ./config/opensearch_dashboards.yml
+          yarn start --no-base-path --no-watch &
+          sleep 300
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: ${{ env.FTR_PATH }}
+          repository: RyanL1997/opensearch-dashboards-functional-test
+          ref: 'saved-objects-test'
+
+      - name: Get Cypress version
+        id: cypress_version
+        run: |
+          echo "::set-output name=cypress_version::$(cat ./${{ env.FTR_PATH }}/package.json | jq '.devDependencies.cypress' | tr -d '"')"
+      
+      - name: Run tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: ${{ env.FTR_PATH }}
+          command: yarn cypress:run-with-security-and-aggregation-view --browser chromium --spec ${{ env.SPEC }}

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -3,7 +3,7 @@
   "version": "3.0.0.0",
   "opensearchDashboardsVersion": "3.0.0",
   "configPath": ["opensearch_security"],
-  "requiredPlugins": ["navigation"],
+  "requiredPlugins": ["navigation", "savedObjectsManagement"],
   "server": true,
   "ui": true
 }

--- a/public/apps/account/account-app.tsx
+++ b/public/apps/account/account-app.tsx
@@ -37,7 +37,6 @@ function tenantSpecifiedInUrl() {
 
 export async function setupTopNavButton(coreStart: CoreStart, config: ClientConfigType) {
   const accountInfo = (await fetchAccountInfoSafe(coreStart.http))?.data;
-  const currentTenant = await fetchCurrentTenant(coreStart.http);
   if (accountInfo) {
     // Missing role error
     if (accountInfo.roles.length === 0 && !window.location.href.includes(CUSTOM_ERROR_PAGE_URI)) {
@@ -46,11 +45,12 @@ export async function setupTopNavButton(coreStart: CoreStart, config: ClientConf
     }
 
     let tenant: string | undefined;
-    if (config.multitenancy.enable_aggregation_view) {
-      tenant = currentTenant;
+    if (config.multitenancy.enabled && config.multitenancy.enable_aggregation_view) {
+      tenant = await fetchCurrentTenant(coreStart.http);
     } else {
       tenant = accountInfo.user_requested_tenant;
     }
+
     let shouldShowTenantPopup = true;
 
     if (tenantSpecifiedInUrl() || getShouldShowTenantPopup() === false) {

--- a/public/apps/account/account-app.tsx
+++ b/public/apps/account/account-app.tsx
@@ -49,6 +49,7 @@ export async function setupTopNavButton(coreStart: CoreStart, config: ClientConf
       try {
         tenant = await fetchCurrentTenant(coreStart.http);
       } catch (e) {
+        tenant = undefined;
         console.log(e);
       }
     }

--- a/public/apps/account/account-app.tsx
+++ b/public/apps/account/account-app.tsx
@@ -45,14 +45,12 @@ export async function setupTopNavButton(coreStart: CoreStart, config: ClientConf
     }
 
     let tenant: string | undefined;
-    if (config.multitenancy.enabled && config.multitenancy.enable_aggregation_view) {
+    if (config.multitenancy.enabled) {
       try {
         tenant = await fetchCurrentTenant(coreStart.http);
       } catch (e) {
         console.log(e);
       }
-    } else {
-      tenant = accountInfo.user_requested_tenant;
     }
 
     let shouldShowTenantPopup = true;

--- a/public/apps/account/account-app.tsx
+++ b/public/apps/account/account-app.tsx
@@ -46,7 +46,11 @@ export async function setupTopNavButton(coreStart: CoreStart, config: ClientConf
 
     let tenant: string | undefined;
     if (config.multitenancy.enabled && config.multitenancy.enable_aggregation_view) {
-      tenant = await fetchCurrentTenant(coreStart.http);
+      try {
+        tenant = await fetchCurrentTenant(coreStart.http);
+      } catch (e) {
+        console.log(e);
+      }
     } else {
       tenant = accountInfo.user_requested_tenant;
     }

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -61,9 +61,10 @@ export function AccountNavButton(props: {
             setModal(null);
             window.location.reload();
           }}
+          tenant={props.tenant!}
         />
       ),
-    [props.config, props.coreStart]
+    [props.config, props.coreStart, props.tenant]
   );
 
   // Check if the tenant modal should be shown on load

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -48,6 +48,7 @@ interface TenantSwitchPanelProps {
   handleClose: () => void;
   handleSwitchAndClose: () => void;
   config: ClientConfigType;
+  tenant: string;
 }
 
 const GLOBAL_TENANT_KEY_NAME = 'global_tenant';
@@ -91,7 +92,12 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         setUsername(currentUserName);
 
         // @ts-ignore
-        const currentRawTenantName = accountInfo.data.user_requested_tenant;
+        let currentRawTenantName: string | undefined;
+        if (props.config.multitenancy.enable_aggregation_view) {
+          currentRawTenantName = props.tenant;
+        } else {
+          currentRawTenantName = accountInfo.data.user_requested_tenant;
+        }
         setCurrentTenant(currentRawTenantName || '', currentUserName);
       } catch (e) {
         // TODO: switch to better error display.
@@ -100,7 +106,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
     };
 
     fetchData();
-  }, [props.coreStart.http]);
+  }, [props.coreStart.http, props.tenant, props.config.multitenancy.enable_aggregation_view]);
 
   // Custom tenant super select related.
   const onCustomTenantChange = (selectedOption: EuiComboBoxOptionOption[]) => {

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -92,10 +92,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         setUsername(currentUserName);
 
         let currentRawTenantName: string | undefined;
-        if (
-          props.config.multitenancy.enabled &&
-          props.config.multitenancy.enable_aggregation_view
-        ) {
+        if (props.config.multitenancy.enable_aggregation_view) {
           currentRawTenantName = props.tenant;
         } else {
           currentRawTenantName = accountInfo.data.user_requested_tenant;

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -91,9 +91,11 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         const currentUserName = accountInfo.data.user_name;
         setUsername(currentUserName);
 
-        // @ts-ignore
         let currentRawTenantName: string | undefined;
-        if (props.config.multitenancy.enable_aggregation_view) {
+        if (
+          props.config.multitenancy.enabled &&
+          props.config.multitenancy.enable_aggregation_view
+        ) {
           currentRawTenantName = props.tenant;
         } else {
           currentRawTenantName = accountInfo.data.user_requested_tenant;
@@ -106,7 +108,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
     };
 
     fetchData();
-  }, [props.coreStart.http, props.tenant, props.config.multitenancy.enable_aggregation_view]);
+  }, [props.coreStart.http, props.tenant, props.config.multitenancy]);
 
   // Custom tenant super select related.
   const onCustomTenantChange = (selectedOption: EuiComboBoxOptionOption[]) => {

--- a/public/apps/account/test/account-app.test.tsx
+++ b/public/apps/account/test/account-app.test.tsx
@@ -22,7 +22,7 @@ import {
   getSavedTenant,
 } from '../../../utils/storage-utils';
 import { fetchAccountInfoSafe } from '../utils';
-import { selectTenant } from '../../configuration/utils/tenant-utils';
+import { fetchCurrentTenant, selectTenant } from '../../configuration/utils/tenant-utils';
 
 jest.mock('../../../utils/storage-utils', () => ({
   getShouldShowTenantPopup: jest.fn(),
@@ -36,6 +36,7 @@ jest.mock('../utils', () => ({
 
 jest.mock('../../configuration/utils/tenant-utils', () => ({
   selectTenant: jest.fn(),
+  fetchCurrentTenant: jest.fn(),
 }));
 
 describe('Account app', () => {
@@ -47,6 +48,12 @@ describe('Account app', () => {
     },
   };
 
+  const mockConfig = {
+    multitenancy: {
+      enable_aggregation_view: true,
+    },
+  };
+
   const mockAccountInfo = {
     data: {
       roles: {
@@ -55,8 +62,11 @@ describe('Account app', () => {
     },
   };
 
+  const mockTenant = 'test1';
+
   beforeAll(() => {
     (fetchAccountInfoSafe as jest.Mock).mockResolvedValue(mockAccountInfo);
+    (fetchCurrentTenant as jest.Mock).mockResolvedValue(mockTenant);
   });
 
   it('Should skip if auto swich if securitytenant in url', (done) => {
@@ -65,7 +75,7 @@ describe('Account app', () => {
     delete window.location;
     window.location = new URL('http://www.example.com?securitytenant=abc') as any;
 
-    setupTopNavButton(mockCoreStart, {} as any);
+    setupTopNavButton(mockCoreStart, mockConfig as any);
 
     process.nextTick(() => {
       expect(setShouldShowTenantPopup).toBeCalledWith(false);
@@ -77,7 +87,7 @@ describe('Account app', () => {
   it('Should switch to saved tenant when securitytenant not in url', (done) => {
     (getSavedTenant as jest.Mock).mockReturnValueOnce('tenant1');
 
-    setupTopNavButton(mockCoreStart, {} as any);
+    setupTopNavButton(mockCoreStart, mockConfig as any);
 
     process.nextTick(() => {
       expect(getSavedTenant).toBeCalledTimes(1);
@@ -92,7 +102,7 @@ describe('Account app', () => {
   it('Should show tenant selection popup when neither securitytenant in url nor saved tenant', (done) => {
     (getSavedTenant as jest.Mock).mockReturnValueOnce(null);
 
-    setupTopNavButton(mockCoreStart, {} as any);
+    setupTopNavButton(mockCoreStart, mockConfig as any);
 
     process.nextTick(() => {
       expect(getSavedTenant).toBeCalledTimes(1);

--- a/public/apps/configuration/configuration-app.tsx
+++ b/public/apps/configuration/configuration-app.tsx
@@ -19,12 +19,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { I18nProvider } from '@osd/i18n/react';
 import { AppMountParameters, CoreStart } from '../../../../../src/core/public';
-import { AppPluginStartDependencies, ClientConfigType } from '../../types';
+import { SecurityPluginStartDependencies, ClientConfigType } from '../../types';
 import { AppRouter } from './app-router';
 
 export function renderApp(
   coreStart: CoreStart,
-  navigation: AppPluginStartDependencies,
+  navigation: SecurityPluginStartDependencies,
   params: AppMountParameters,
   config: ClientConfigType
 ) {

--- a/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
@@ -49,6 +49,7 @@ export function ClusterPermissionPanel(props: {
                 options={optionUniverse}
                 selectedOptions={state}
                 onChange={setState}
+                id="cluster-permission-box"
               />
             </EuiFlexItem>
             {/* TODO: 'Browse and select' button with a pop-up modal for selection */}

--- a/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
@@ -49,7 +49,7 @@ export function ClusterPermissionPanel(props: {
                 options={optionUniverse}
                 selectedOptions={state}
                 onChange={setState}
-                id="cluster-permission-box"
+                id="roles-cluster-permission-box"
               />
             </EuiFlexItem>
             {/* TODO: 'Browse and select' button with a pop-up modal for selection */}

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -119,13 +119,16 @@ export function IndexPatternRow(props: {
 }) {
   return (
     <FormRow headerText="Index" helpText="Specify index pattern using *">
-      <EuiComboBox
-        noSuggestions
-        placeholder="Search for index name or type in index pattern"
-        selectedOptions={props.value}
-        onChange={props.onChangeHandler}
-        onCreateOption={props.onCreateHandler}
-      />
+      <EuiFlexItem className={LIMIT_WIDTH_INPUT_CLASS}>
+        <EuiComboBox
+          noSuggestions
+          placeholder="Search for index name or type in index pattern"
+          selectedOptions={props.value}
+          onChange={props.onChangeHandler}
+          onCreateOption={props.onCreateHandler}
+          id="index-input-box"
+        />
+      </EuiFlexItem>
     </FormRow>
   );
 }
@@ -150,6 +153,7 @@ export function IndexPermissionRow(props: {
             options={props.permisionOptionsSet}
             selectedOptions={props.value}
             onChange={props.onChangeHandler}
+            id="index-permission-box"
           />
         </EuiFlexItem>
         {/* TODO: 'Browse and select' button with a pop-up modal for selection */}

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -153,7 +153,7 @@ export function IndexPermissionRow(props: {
             options={props.permisionOptionsSet}
             selectedOptions={props.value}
             onChange={props.onChangeHandler}
-            id="index-permission-box"
+            id="roles-index-permission-box"
           />
         </EuiFlexItem>
         {/* TODO: 'Browse and select' button with a pop-up modal for selection */}

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -91,6 +91,7 @@ function generateTenantPermissionPanels(
               onChange={onValueChangeHandler('tenantPatterns')}
               onCreateOption={onCreateOptionHandler('tenantPatterns')}
               options={permisionOptionsSet}
+              id="tenant-permission-box"
             />
           </EuiFlexItem>
           <EuiFlexItem style={{ maxWidth: '170px' }}>

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -91,7 +91,7 @@ function generateTenantPermissionPanels(
               onChange={onValueChangeHandler('tenantPatterns')}
               onCreateOption={onCreateOptionHandler('tenantPatterns')}
               options={permisionOptionsSet}
-              id="tenant-permission-box"
+              id="roles-tenant-permission-box"
             />
           </EuiFlexItem>
           <EuiFlexItem style={{ maxWidth: '170px' }}>

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -15,6 +15,8 @@
 
 import { HttpStart } from 'opensearch-dashboards/public';
 import { map } from 'lodash';
+import React from 'react';
+import { i18n } from '@osd/i18n';
 import {
   API_ENDPOINT_TENANTS,
   API_ENDPOINT_MULTITENANCY,
@@ -39,6 +41,8 @@ export const globalTenantName = 'global_tenant';
 export const GLOBAL_TENANT = '';
 export const PRIVATE_TENANT = '__user__';
 export const DEFAULT_TENANT = 'default';
+export const GLOBAL_TENANT_RENDERING_TEXT = 'Global';
+export const PRIVATE_TENANT_RENDERING_TEXT = 'Private';
 export const GLOBAL_USER_DICT: { [key: string]: string } = {
   Label: 'Global',
   Value: GLOBAL_TENANT,
@@ -181,3 +185,25 @@ export function isPrivateTenant(selectedTenant: string | null) {
 export function isGlobalTenant(selectedTenant: string | null) {
   return selectedTenant !== null && selectedTenant === GLOBAL_TENANT;
 }
+
+export const tenantColumn = {
+  id: 'tenant_column',
+  euiColumn: {
+    field: 'namespaces',
+    name: <div>Tenant</div>,
+    dataType: 'string',
+    render: (value: any[][]) => {
+      let text = value.flat()[0];
+      if (isGlobalTenant(text)) {
+        text = GLOBAL_TENANT_RENDERING_TEXT;
+      } else if (isPrivateTenant(text)) {
+        text = PRIVATE_TENANT_RENDERING_TEXT;
+      }
+      text = i18n.translate('savedObjectsManagement.objectsTable.table.columnTenantName', {
+        defaultMessage: text,
+      });
+      return <div>{text}</div>;
+    },
+  },
+  loadData: () => {},
+};

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -38,15 +38,15 @@ import { httpDelete, httpGet, httpPost } from './request-utils';
 import { getResourceUrl } from './resource-utils';
 
 export const globalTenantName = 'global_tenant';
-export const GLOBAL_TENANT = '';
-export const PRIVATE_TENANT = '__user__';
+export const GLOBAL_TENANT_SYMBOL = '';
+export const PRIVATE_TENANT_SYMBOL = '__user__';
 export const DEFAULT_TENANT = 'default';
 export const GLOBAL_TENANT_RENDERING_TEXT = 'Global';
 export const PRIVATE_TENANT_RENDERING_TEXT = 'Private';
 
 export const GLOBAL_USER_DICT: { [key: string]: string } = {
   Label: 'Global',
-  Value: GLOBAL_TENANT,
+  Value: GLOBAL_TENANT_SYMBOL,
   Description: 'Everyone can see it',
 };
 
@@ -70,10 +70,10 @@ export function transformTenantData(
 ): Tenant[] {
   // @ts-ignore
   const tenantList: Tenant[] = map<Tenant, Tenant>(rawTenantData, (v: Tenant, k?: string) => ({
-    tenant: k === globalTenantName ? GLOBAL_USER_DICT.Label : k || GLOBAL_TENANT,
+    tenant: k === globalTenantName ? GLOBAL_USER_DICT.Label : k || GLOBAL_TENANT_SYMBOL,
     reserved: v.reserved,
     description: k === globalTenantName ? GLOBAL_USER_DICT.Description : v.description,
-    tenantValue: k === globalTenantName ? GLOBAL_USER_DICT.Value : k || GLOBAL_TENANT,
+    tenantValue: k === globalTenantName ? GLOBAL_USER_DICT.Value : k || GLOBAL_TENANT_SYMBOL,
   }));
   if (isPrivateEnabled) {
     // Insert Private Tenant in List
@@ -180,11 +180,15 @@ export function transformRoleTenantPermissions(
 }
 
 export function isPrivateTenant(selectedTenant: string | null) {
-  return selectedTenant !== null && selectedTenant?.startsWith(PRIVATE_TENANT);
+  return selectedTenant !== null && selectedTenant === PRIVATE_TENANT_SYMBOL;
+}
+
+export function isRenderingPrivateTenant(selectedTenant: string | null) {
+  return selectedTenant !== null && selectedTenant?.startsWith(PRIVATE_TENANT_SYMBOL);
 }
 
 export function isGlobalTenant(selectedTenant: string | null) {
-  return selectedTenant !== null && selectedTenant === GLOBAL_TENANT;
+  return selectedTenant !== null && selectedTenant === GLOBAL_TENANT_SYMBOL;
 }
 
 export const tenantColumn = {
@@ -197,7 +201,7 @@ export const tenantColumn = {
       let text = value.flat()[0];
       if (isGlobalTenant(text)) {
         text = GLOBAL_TENANT_RENDERING_TEXT;
-      } else if (isPrivateTenant(text)) {
+      } else if (isRenderingPrivateTenant(text)) {
         text = PRIVATE_TENANT_RENDERING_TEXT;
       }
       text = i18n.translate('savedObjectsManagement.objectsTable.table.columnTenantName', {

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -43,6 +43,7 @@ export const PRIVATE_TENANT = '__user__';
 export const DEFAULT_TENANT = 'default';
 export const GLOBAL_TENANT_RENDERING_TEXT = 'Global';
 export const PRIVATE_TENANT_RENDERING_TEXT = 'Private';
+
 export const GLOBAL_USER_DICT: { [key: string]: string } = {
   Label: 'Global',
   Value: GLOBAL_TENANT,

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -36,9 +36,12 @@ import { httpDelete, httpGet, httpPost } from './request-utils';
 import { getResourceUrl } from './resource-utils';
 
 export const globalTenantName = 'global_tenant';
+export const GLOBAL_TENANT = '';
+export const PRIVATE_TENANT = '__user__';
+export const DEFAULT_TENANT = 'default';
 export const GLOBAL_USER_DICT: { [key: string]: string } = {
   Label: 'Global',
-  Value: '',
+  Value: GLOBAL_TENANT,
   Description: 'Everyone can see it',
 };
 
@@ -62,10 +65,10 @@ export function transformTenantData(
 ): Tenant[] {
   // @ts-ignore
   const tenantList: Tenant[] = map<Tenant, Tenant>(rawTenantData, (v: Tenant, k?: string) => ({
-    tenant: k === globalTenantName ? GLOBAL_USER_DICT.Label : k || '',
+    tenant: k === globalTenantName ? GLOBAL_USER_DICT.Label : k || GLOBAL_TENANT,
     reserved: v.reserved,
     description: k === globalTenantName ? GLOBAL_USER_DICT.Description : v.description,
-    tenantValue: k === globalTenantName ? GLOBAL_USER_DICT.Value : k || '',
+    tenantValue: k === globalTenantName ? GLOBAL_USER_DICT.Value : k || GLOBAL_TENANT,
   }));
   if (isPrivateEnabled) {
     // Insert Private Tenant in List
@@ -169,4 +172,12 @@ export function transformRoleTenantPermissions(
     tenant_patterns: tenantPermission.tenant_patterns,
     permissionType: getTenantPermissionType(tenantPermission.allowed_actions),
   }));
+}
+
+export function isPrivateTenant(selectedTenant: string | null) {
+  return selectedTenant !== null && selectedTenant?.startsWith(PRIVATE_TENANT);
+}
+
+export function isGlobalTenant(selectedTenant: string | null) {
+  return selectedTenant !== null && selectedTenant === GLOBAL_TENANT;
 }

--- a/public/apps/types.ts
+++ b/public/apps/types.ts
@@ -14,11 +14,11 @@
  */
 
 import { AppMountParameters, CoreStart } from '../../../../src/core/public';
-import { AppPluginStartDependencies, ClientConfigType } from '../types';
+import { SecurityPluginStartDependencies, ClientConfigType } from '../types';
 
 export interface AppDependencies {
   coreStart: CoreStart;
-  navigation: AppPluginStartDependencies;
+  navigation: SecurityPluginStartDependencies;
   params: AppMountParameters;
   config: ClientConfigType;
 }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -15,8 +15,6 @@
 
 import { BehaviorSubject } from 'rxjs';
 import { SavedObjectsManagementColumn } from 'src/plugins/saved_objects_management/public';
-import React from 'react';
-import { i18n } from '@osd/i18n';
 import {
   AppMountParameters,
   AppStatus,
@@ -48,7 +46,7 @@ import {
 } from './types';
 import { addTenantToShareURL } from './services/shared-link';
 import { interceptError } from './utils/logout-utils';
-import { isGlobalTenant, isPrivateTenant } from './apps/configuration/utils/tenant-utils';
+import { tenantColumn } from './apps/configuration/utils/tenant-utils';
 
 async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
   try {
@@ -156,27 +154,9 @@ export class SecurityPlugin
     );
 
     if (config.multitenancy.enabled && config.multitenancy.enable_aggregation_view) {
-      deps.savedObjectsManagement.columns.register(({
-        id: 'tenant_column',
-        euiColumn: {
-          field: 'namespaces',
-          name: <div>Tenant</div>,
-          dataType: 'string',
-          render: (value: any[][]) => {
-            let text = value.flat()[0];
-            if (isGlobalTenant(text)) {
-              text = GLOBAL_TENANT_RENDERING_TEXT;
-            } else if (isPrivateTenant(text)) {
-              text = PRIVATE_TENANT_RENDERING_TEXT;
-            }
-            text = i18n.translate('savedObjectsManagement.objectsTable.table.columnTenantName', {
-              defaultMessage: text,
-            });
-            return <div>{text}</div>;
-          },
-        },
-        loadData: () => {},
-      } as unknown) as SavedObjectsManagementColumn<string>);
+      deps.savedObjectsManagement.columns.register(
+        (tenantColumn as unknown) as SavedObjectsManagementColumn<string>
+      );
     }
 
     // Return methods that should be available to other plugins

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -74,6 +74,7 @@ const APP_LIST_FOR_READONLY_ROLE = [APP_ID_HOME, APP_ID_DASHBOARDS, APP_ID_OPENS
 const GLOBAL_TENANT_RENDERING_TEXT = 'Global';
 const PRIVATE_TENANT_RENDERING_TEXT = 'Private';
 const GLOBAL_TENANT = '';
+const PRIVATE_TENANT = '__user__';
 
 export class SecurityPlugin
   implements
@@ -169,9 +170,9 @@ export class SecurityPlugin
           dataType: 'string',
           render: (value: any[][]) => {
             let text = value[0][0];
-            if (text === null || text === GLOBAL_TENANT) {
+            if (isGlobalTenant(text)) {
               text = GLOBAL_TENANT_RENDERING_TEXT;
-            } else if (text.startsWith('__user__')) {
+            } else if (isPrivateTenant(text)) {
               text = PRIVATE_TENANT_RENDERING_TEXT;
             }
             text = i18n.translate('savedObjectsManagement.objectsTable.table.columnTenantName', {
@@ -212,4 +213,12 @@ export class SecurityPlugin
   }
 
   public stop() {}
+}
+
+function isPrivateTenant(selectedTenant: string) {
+  return selectedTenant.startsWith('__user__');
+}
+
+function isGlobalTenant(selectedTenant: string) {
+  return selectedTenant === null || selectedTenant === GLOBAL_TENANT;
 }

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -14,12 +14,7 @@
  */
 
 import { BehaviorSubject } from 'rxjs';
-import {
-  SavedObjectsManagementColumn,
-  SavedObjectsManagementRecord,
-} from 'src/plugins/saved_objects_management/public';
-import { EuiTableFieldDataColumnType } from '@elastic/eui';
-import { string } from 'joi';
+import { SavedObjectsManagementColumn } from 'src/plugins/saved_objects_management/public';
 import React from 'react';
 import { i18n } from '@osd/i18n';
 import {
@@ -53,6 +48,7 @@ import {
 } from './types';
 import { addTenantToShareURL } from './services/shared-link';
 import { interceptError } from './utils/logout-utils';
+import { isGlobalTenant, isPrivateTenant } from './apps/configuration/utils/tenant-utils';
 
 async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
   try {
@@ -73,8 +69,6 @@ const APP_ID_OPENSEARCH_DASHBOARDS = 'kibana';
 const APP_LIST_FOR_READONLY_ROLE = [APP_ID_HOME, APP_ID_DASHBOARDS, APP_ID_OPENSEARCH_DASHBOARDS];
 const GLOBAL_TENANT_RENDERING_TEXT = 'Global';
 const PRIVATE_TENANT_RENDERING_TEXT = 'Private';
-const GLOBAL_TENANT = '';
-const PRIVATE_TENANT = '__user__';
 
 export class SecurityPlugin
   implements
@@ -161,7 +155,7 @@ export class SecurityPlugin
       })
     );
 
-    if (config.multitenancy.enable_aggregation_view) {
+    if (config.multitenancy.enabled && config.multitenancy.enable_aggregation_view) {
       deps.savedObjectsManagement.columns.register(({
         id: 'tenant_column',
         euiColumn: {
@@ -169,7 +163,7 @@ export class SecurityPlugin
           name: <div>Tenant</div>,
           dataType: 'string',
           render: (value: any[][]) => {
-            let text = value[0][0];
+            let text = value.flat()[0];
             if (isGlobalTenant(text)) {
               text = GLOBAL_TENANT_RENDERING_TEXT;
             } else if (isPrivateTenant(text)) {
@@ -204,21 +198,8 @@ export class SecurityPlugin
     if (config.multitenancy.enabled) {
       addTenantToShareURL(core);
     }
-
-    if (config.multitenancy.enable_aggregation_view) {
-      const columns = deps.savedObjectsManagement.columns.getAll();
-    }
-
     return {};
   }
 
   public stop() {}
-}
-
-function isPrivateTenant(selectedTenant: string) {
-  return selectedTenant.startsWith('__user__');
-}
-
-function isGlobalTenant(selectedTenant: string) {
-  return selectedTenant === null || selectedTenant === GLOBAL_TENANT;
 }

--- a/public/plugin.tsx
+++ b/public/plugin.tsx
@@ -71,6 +71,9 @@ const APP_ID_DASHBOARDS = 'dashboards';
 // OpenSearchDashboards app is for legacy url migration
 const APP_ID_OPENSEARCH_DASHBOARDS = 'kibana';
 const APP_LIST_FOR_READONLY_ROLE = [APP_ID_HOME, APP_ID_DASHBOARDS, APP_ID_OPENSEARCH_DASHBOARDS];
+const GLOBAL_TENANT_RENDERING_TEXT = 'Global';
+const PRIVATE_TENANT_RENDERING_TEXT = 'Private';
+const GLOBAL_TENANT = '';
 
 export class SecurityPlugin
   implements
@@ -166,10 +169,10 @@ export class SecurityPlugin
           dataType: 'string',
           render: (value: any[][]) => {
             let text = value[0][0];
-            if (text === null || text === '') {
-              text = 'Global';
+            if (text === null || text === GLOBAL_TENANT) {
+              text = GLOBAL_TENANT_RENDERING_TEXT;
             } else if (text.startsWith('__user__')) {
-              text = 'Private';
+              text = PRIVATE_TENANT_RENDERING_TEXT;
             }
             text = i18n.translate('savedObjectsManagement.objectsTable.table.columnTenantName', {
               defaultMessage: text,

--- a/public/types.ts
+++ b/public/types.ts
@@ -14,14 +14,23 @@
  */
 
 import { NavigationPublicPluginStart } from '../../../src/plugins/navigation/public';
+import {
+  SavedObjectsManagementPluginSetup,
+  SavedObjectsManagementPluginStart,
+} from '../../../src/plugins/saved_objects_management/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SecurityPluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SecurityPluginStart {}
 
-export interface AppPluginStartDependencies {
+export interface SecurityPluginSetupDependencies {
+  savedObjectsManagement: SavedObjectsManagementPluginSetup;
+}
+
+export interface SecurityPluginStartDependencies {
   navigation: NavigationPublicPluginStart;
+  savedObjectsManagement: SavedObjectsManagementPluginStart;
 }
 
 export interface AuthInfo {
@@ -49,6 +58,7 @@ export interface ClientConfigType {
     backend_configurable: boolean;
   };
   multitenancy: {
+    enable_aggregation_view: boolean;
     enabled: boolean;
     tenants: {
       enable_private: boolean;

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -35,7 +35,7 @@ import {
   isValidTenant,
 } from '../../multitenancy/tenant_resolver';
 import { UnauthenticatedError } from '../../errors';
-import { GLOBAL_TENANT } from '../../../public/apps/configuration/utils/tenant-utils';
+import { GLOBAL_TENANT_SYMBOL } from '../../../public/apps/configuration/utils/tenant-utils';
 
 export interface IAuthenticationType {
   type: string;
@@ -185,7 +185,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
         // set tenant in header
         if (this.config.multitenancy.enabled && this.config.multitenancy.enable_aggregation_view) {
           // Store all saved objects in a single kibana index.
-          Object.assign(authHeaders, { securitytenant: GLOBAL_TENANT });
+          Object.assign(authHeaders, { securitytenant: GLOBAL_TENANT_SYMBOL });
         } else {
           Object.assign(authHeaders, { securitytenant: tenant });
         }

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -26,6 +26,7 @@ import {
   IOpenSearchDashboardsResponse,
   AuthResult,
 } from 'opensearch-dashboards/server';
+import { any } from 'joi';
 import { SecurityPluginConfigType } from '../..';
 import { SecuritySessionCookie } from '../../session/security_cookie';
 import { SecurityClient } from '../../backend/opensearch_security_client';
@@ -101,6 +102,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
     }
 
     const authState: OpenSearchDashboardsAuthState = {};
+    const globalTenant = '';
 
     // if browser request, auth logic is:
     //   1. check if request includes auth header or paramter(e.g. jwt in url params) is present, if so, authenticate with auth header.
@@ -126,7 +128,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
         }
 
         this.sessionStorageFactory.asScoped(request).set(cookie);
-      } catch (error) {
+      } catch (error: any) {
         return response.unauthorized({
           body: error.message,
         });
@@ -135,7 +137,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
       // no auth header in request, try cookie
       try {
         cookie = await this.sessionStorageFactory.asScoped(request).get();
-      } catch (error) {
+      } catch (error: any) {
         this.logger.error(`Error parsing cookie: ${error.message}`);
         cookie = undefined;
       }
@@ -183,7 +185,6 @@ export abstract class AuthenticationType implements IAuthenticationType {
 
         // set tenant in header
         if (this.config.multitenancy.enable_aggregation_view) {
-          const globalTenant = '';
           // Store all saved objects in a single kibana index.
           Object.assign(authHeaders, { securitytenant: globalTenant });
         } else {

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -26,7 +26,6 @@ import {
   IOpenSearchDashboardsResponse,
   AuthResult,
 } from 'opensearch-dashboards/server';
-import { any } from 'joi';
 import { SecurityPluginConfigType } from '../..';
 import { SecuritySessionCookie } from '../../session/security_cookie';
 import { SecurityClient } from '../../backend/opensearch_security_client';
@@ -36,6 +35,7 @@ import {
   isValidTenant,
 } from '../../multitenancy/tenant_resolver';
 import { UnauthenticatedError } from '../../errors';
+import { GLOBAL_TENANT } from '../../../public/apps/configuration/utils/tenant-utils';
 
 export interface IAuthenticationType {
   type: string;
@@ -102,7 +102,6 @@ export abstract class AuthenticationType implements IAuthenticationType {
     }
 
     const authState: OpenSearchDashboardsAuthState = {};
-    const globalTenant = '';
 
     // if browser request, auth logic is:
     //   1. check if request includes auth header or paramter(e.g. jwt in url params) is present, if so, authenticate with auth header.
@@ -184,9 +183,9 @@ export abstract class AuthenticationType implements IAuthenticationType {
         authState.selectedTenant = tenant;
 
         // set tenant in header
-        if (this.config.multitenancy.enable_aggregation_view) {
+        if (this.config.multitenancy.enabled && this.config.multitenancy.enable_aggregation_view) {
           // Store all saved objects in a single kibana index.
-          Object.assign(authHeaders, { securitytenant: globalTenant });
+          Object.assign(authHeaders, { securitytenant: GLOBAL_TENANT });
         } else {
           Object.assign(authHeaders, { securitytenant: tenant });
         }
@@ -245,7 +244,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
     if (!authInfo) {
       try {
         authInfo = await this.securityClient.authinfo(request, authHeader);
-      } catch (error) {
+      } catch (error: any) {
         throw new UnauthenticatedError(error);
       }
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -104,6 +104,7 @@ export const configSchema = schema.object({
     show_roles: schema.boolean({ defaultValue: false }),
     enable_filter: schema.boolean({ defaultValue: false }),
     debug: schema.boolean({ defaultValue: false }),
+    enable_aggregation_view: schema.boolean({ defaultValue: false }),
     tenants: schema.object({
       enable_private: schema.boolean({ defaultValue: true }),
       enable_global: schema.boolean({ defaultValue: true }),

--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -17,9 +17,10 @@ import { isEmpty, findKey, cloneDeep } from 'lodash';
 import { OpenSearchDashboardsRequest } from '../../../../src/core/server';
 import { SecuritySessionCookie } from '../session/security_cookie';
 import { SecurityPluginConfigType } from '..';
-
-const PRIVATE_TENANT_SYMBOL: string = '__user__';
-const GLOBAL_TENANT_SYMBOL: string = '';
+import {
+  GLOBAL_TENANT_SYMBOL,
+  PRIVATE_TENANT_SYMBOL,
+} from '../../public/apps/configuration/utils/tenant-utils';
 
 export const PRIVATE_TENANTS: string[] = [PRIVATE_TENANT_SYMBOL, 'private'];
 export const GLOBAL_TENANTS: string[] = ['global', GLOBAL_TENANT_SYMBOL];

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -15,6 +15,7 @@
 
 import { first } from 'rxjs/operators';
 import { Observable } from 'rxjs';
+import _ from 'lodash';
 import {
   PluginInitializerContext,
   CoreSetup,
@@ -38,11 +39,15 @@ import {
   ISavedObjectTypeRegistry,
 } from '../../../src/core/server/saved_objects';
 import { setupIndexTemplate, migrateTenantIndices } from './multitenancy/tenant_index';
-import { IAuthenticationType } from './auth/types/authentication_type';
+import {
+  IAuthenticationType,
+  OpenSearchDashboardsAuthState,
+} from './auth/types/authentication_type';
 import { getAuthenticationHandler } from './auth/auth_handler_factory';
 import { setupMultitenantRoutes } from './multitenancy/routes';
 import { defineAuthTypeRoutes } from './routes/auth_type_routes';
 import { createMigrationOpenSearchClient } from '../../../src/core/server/saved_objects/migrations/core';
+import { SecuritySavedObjectsClientWrapper } from './saved_objects/saved_objects_wrapper';
 
 export interface SecurityPluginRequestContext {
   logger: Logger;
@@ -73,8 +78,11 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
   // @ts-ignore: property not initialzied in constructor
   private securityClient: SecurityClient;
 
+  private savedObjectClientWrapper: SecuritySavedObjectsClientWrapper;
+
   constructor(private readonly initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get();
+    this.savedObjectClientWrapper = new SecuritySavedObjectsClientWrapper();
   }
 
   public async setup(core: CoreSetup) {
@@ -126,6 +134,14 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
       setupMultitenantRoutes(router, securitySessionStorageFactory, this.securityClient);
     }
 
+    if (config.multitenancy.enable_aggregation_view) {
+      core.savedObjects.addClientWrapper(
+        1,
+        'security-saved-object-client-wrapper',
+        this.savedObjectClientWrapper.wrapperFactory
+      );
+    }
+
     return {
       config$,
       securityConfigClient: esClient,
@@ -135,6 +151,9 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
   // TODO: add more logs
   public async start(core: CoreStart) {
     this.logger.debug('opendistro_security: Started');
+
+    this.savedObjectClientWrapper.httpStart = core.http;
+
     const config$ = this.initializerContext.config.create<SecurityPluginConfigType>();
     const config = await config$.pipe(first()).toPromise();
     if (config.multitenancy?.enabled) {
@@ -161,6 +180,7 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
     }
 
     return {
+      http: core.http,
       es: core.opensearch.legacy,
     };
   }

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -15,7 +15,6 @@
 
 import { first } from 'rxjs/operators';
 import { Observable } from 'rxjs';
-import _ from 'lodash';
 import {
   PluginInitializerContext,
   CoreSetup,
@@ -134,9 +133,9 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
       setupMultitenantRoutes(router, securitySessionStorageFactory, this.securityClient);
     }
 
-    if (config.multitenancy.enable_aggregation_view) {
+    if (config.multitenancy.enabled && config.multitenancy.enable_aggregation_view) {
       core.savedObjects.addClientWrapper(
-        1,
+        2,
         'security-saved-object-client-wrapper',
         this.savedObjectClientWrapper.wrapperFactory
       );
@@ -152,10 +151,12 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
   public async start(core: CoreStart) {
     this.logger.debug('opendistro_security: Started');
 
-    this.savedObjectClientWrapper.httpStart = core.http;
-
     const config$ = this.initializerContext.config.create<SecurityPluginConfigType>();
     const config = await config$.pipe(first()).toPromise();
+
+    this.savedObjectClientWrapper.httpStart = core.http;
+    this.savedObjectClientWrapper.config = config;
+
     if (config.multitenancy?.enabled) {
       const globalConfig$: Observable<SharedGlobalConfig> = this.initializerContext.config.legacy
         .globalConfig$;

--- a/server/saved_objects/saved_objects_wrapper.ts
+++ b/server/saved_objects/saved_objects_wrapper.ts
@@ -1,0 +1,194 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import _ from 'lodash';
+import {
+  HttpServiceStart,
+  SavedObject,
+  SavedObjectsBaseOptions,
+  SavedObjectsBulkCreateObject,
+  SavedObjectsBulkGetObject,
+  SavedObjectsBulkResponse,
+  SavedObjectsBulkUpdateObject,
+  SavedObjectsBulkUpdateOptions,
+  SavedObjectsBulkUpdateResponse,
+  SavedObjectsCheckConflictsObject,
+  SavedObjectsCheckConflictsResponse,
+  SavedObjectsClientWrapperFactory,
+  SavedObjectsCreateOptions,
+  SavedObjectsDeleteOptions,
+  SavedObjectsFindOptions,
+  SavedObjectsFindResponse,
+  SavedObjectsUpdateOptions,
+  SavedObjectsUpdateResponse,
+} from 'opensearch-dashboards/server';
+import { OpenSearchDashboardsAuthState } from '../auth/types/authentication_type';
+
+export class SecuritySavedObjectsClientWrapper {
+  public httpStart?: HttpServiceStart;
+
+  constructor() {}
+
+  public wrapperFactory: SavedObjectsClientWrapperFactory = (wrapperOptions) => {
+    const state: OpenSearchDashboardsAuthState =
+      (this.httpStart!.auth.get(wrapperOptions.request).state as OpenSearchDashboardsAuthState) ||
+      {};
+
+    const createWithNamespace = async <T = unknown>(
+      type: string,
+      attributes: T,
+      options?: SavedObjectsCreateOptions
+    ) => {
+      const selectedTenant = state.selectedTenant;
+      const username = state.authInfo?.user_name;
+      let namespaceValue = selectedTenant;
+      if (selectedTenant === '__user__') {
+        namespaceValue = selectedTenant + username;
+      }
+      _.assign(options, { namespace: [namespaceValue] });
+      return await wrapperOptions.client.create(type, attributes, options);
+    };
+
+    const bulkGetWithNamespace = async <T = unknown>(
+      objects: SavedObjectsBulkGetObject[] = [],
+      options: SavedObjectsBaseOptions = {}
+    ): Promise<SavedObjectsBulkResponse<T>> => {
+      const selectedTenant = state.selectedTenant;
+      const username = state.authInfo?.user_name;
+      let namespaceValue = selectedTenant;
+      if (selectedTenant === '__user__') {
+        namespaceValue = selectedTenant + username;
+      }
+      _.assign(options, { namespace: [namespaceValue] });
+      return await wrapperOptions.client.bulkGet(objects, options);
+    };
+
+    const findWithNamespace = async <T = unknown>(
+      options: SavedObjectsFindOptions
+    ): Promise<SavedObjectsFindResponse<T>> => {
+      const tenants = state.authInfo?.tenants;
+      const availableTenantNames = Object.keys(tenants!);
+      availableTenantNames.push('default');
+      availableTenantNames.push('');
+      availableTenantNames.push('__user__' + state.authInfo?.user_name);
+      _.assign(options, { namespaces: availableTenantNames });
+      return await wrapperOptions.client.find(options);
+    };
+
+    const getWithNamespace = async <T = unknown>(
+      type: string,
+      id: string,
+      options: SavedObjectsBaseOptions = {}
+    ): Promise<SavedObject<T>> => {
+      const selectedTenant = state.selectedTenant;
+      const username = state.authInfo?.user_name;
+      let namespaceValue = selectedTenant;
+      if (selectedTenant === '__user__') {
+        namespaceValue = selectedTenant + username;
+      }
+      _.assign(options, { namespace: [namespaceValue] });
+      return await wrapperOptions.client.get(type, id, options);
+    };
+
+    const updateWithNamespace = async <T = unknown>(
+      type: string,
+      id: string,
+      attributes: Partial<T>,
+      options: SavedObjectsUpdateOptions = {}
+    ): Promise<SavedObjectsUpdateResponse<T>> => {
+      const selectedTenant = state.selectedTenant;
+      const username = state.authInfo?.user_name;
+      let namespaceValue = selectedTenant;
+      if (selectedTenant === '__user__') {
+        namespaceValue = selectedTenant + username;
+      }
+      _.assign(options, { namespace: [namespaceValue] });
+      return await wrapperOptions.client.update(type, id, attributes, options);
+    };
+
+    const bulkCreateWithNamespace = async <T = unknown>(
+      objects: Array<SavedObjectsBulkCreateObject<T>>,
+      options?: SavedObjectsCreateOptions
+    ): Promise<SavedObjectsBulkResponse<T>> => {
+      const selectedTenant = state.selectedTenant;
+      const username = state.authInfo?.user_name;
+      let namespaceValue = selectedTenant;
+      if (selectedTenant === '__user__') {
+        namespaceValue = selectedTenant + username;
+      }
+      _.assign(options, { namespace: [namespaceValue] });
+      return await wrapperOptions.client.bulkCreate(objects, options);
+    };
+
+    const bulkUpdateWithNamespace = async <T = unknown>(
+      objects: Array<SavedObjectsBulkUpdateObject<T>>,
+      options?: SavedObjectsBulkUpdateOptions
+    ): Promise<SavedObjectsBulkUpdateResponse<T>> => {
+      const selectedTenant = state.selectedTenant;
+      const username = state.authInfo?.user_name;
+      let namespaceValue = selectedTenant;
+      if (selectedTenant === '__user__') {
+        namespaceValue = selectedTenant + username;
+      }
+      _.assign(options, { namespace: [namespaceValue] });
+      return await wrapperOptions.client.bulkUpdate(objects, options);
+    };
+
+    const deleteWithNamespace = async (
+      type: string,
+      id: string,
+      options: SavedObjectsDeleteOptions = {}
+    ) => {
+      const selectedTenant = state.selectedTenant;
+      const username = state.authInfo?.user_name;
+      let namespaceValue = selectedTenant;
+      if (selectedTenant === '__user__') {
+        namespaceValue = selectedTenant + username;
+      }
+      _.assign(options, { namespace: [namespaceValue] });
+      return await wrapperOptions.client.delete(type, id, options);
+    };
+
+    const checkConflictsWithNamespace = async (
+      objects: SavedObjectsCheckConflictsObject[] = [],
+      options: SavedObjectsBaseOptions = {}
+    ): Promise<SavedObjectsCheckConflictsResponse> => {
+      const selectedTenant = state.selectedTenant;
+      const username = state.authInfo?.user_name;
+      let namespaceValue = selectedTenant;
+      if (selectedTenant === '__user__') {
+        namespaceValue = selectedTenant + username;
+      }
+      _.assign(options, { namespace: [namespaceValue] });
+      return await wrapperOptions.client.checkConflicts(objects, options);
+    };
+
+    return {
+      ...wrapperOptions.client,
+      get: getWithNamespace,
+      update: updateWithNamespace,
+      bulkCreate: bulkCreateWithNamespace,
+      bulkGet: bulkGetWithNamespace,
+      bulkUpdate: bulkUpdateWithNamespace,
+      create: createWithNamespace,
+      delete: deleteWithNamespace,
+      errors: wrapperOptions.client.errors,
+      checkConflicts: checkConflictsWithNamespace,
+      addToNamespaces: wrapperOptions.client.addToNamespaces,
+      find: findWithNamespace,
+      deleteFromNamespaces: wrapperOptions.client.deleteFromNamespaces,
+    };
+  };
+}

--- a/server/saved_objects/saved_objects_wrapper.ts
+++ b/server/saved_objects/saved_objects_wrapper.ts
@@ -46,15 +46,20 @@ export class SecuritySavedObjectsClientWrapper {
       (this.httpStart!.auth.get(wrapperOptions.request).state as OpenSearchDashboardsAuthState) ||
       {};
 
+    const selectedTenant = state.selectedTenant;
+    const username = state.authInfo?.user_name;
+    const globalTenant = '';
+    const defaultTenant = 'default';
+    const privateTenant = '__user__';
+
+    let namespaceValue = selectedTenant;
+
     const createWithNamespace = async <T = unknown>(
       type: string,
       attributes: T,
       options?: SavedObjectsCreateOptions
     ) => {
-      const selectedTenant = state.selectedTenant;
-      const username = state.authInfo?.user_name;
-      let namespaceValue = selectedTenant;
-      if (selectedTenant === '__user__') {
+      if (selectedTenant !== undefined && isPrivateTenant(selectedTenant)) {
         namespaceValue = selectedTenant + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
@@ -65,10 +70,7 @@ export class SecuritySavedObjectsClientWrapper {
       objects: SavedObjectsBulkGetObject[] = [],
       options: SavedObjectsBaseOptions = {}
     ): Promise<SavedObjectsBulkResponse<T>> => {
-      const selectedTenant = state.selectedTenant;
-      const username = state.authInfo?.user_name;
-      let namespaceValue = selectedTenant;
-      if (selectedTenant === '__user__') {
+      if (selectedTenant !== undefined && isPrivateTenant(selectedTenant)) {
         namespaceValue = selectedTenant + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
@@ -80,9 +82,9 @@ export class SecuritySavedObjectsClientWrapper {
     ): Promise<SavedObjectsFindResponse<T>> => {
       const tenants = state.authInfo?.tenants;
       const availableTenantNames = Object.keys(tenants!);
-      availableTenantNames.push('default');
-      availableTenantNames.push('');
-      availableTenantNames.push('__user__' + state.authInfo?.user_name);
+      availableTenantNames.push(defaultTenant);
+      availableTenantNames.push(globalTenant);
+      availableTenantNames.push(privateTenant + state.authInfo?.user_name);
       _.assign(options, { namespaces: availableTenantNames });
       return await wrapperOptions.client.find(options);
     };
@@ -92,10 +94,7 @@ export class SecuritySavedObjectsClientWrapper {
       id: string,
       options: SavedObjectsBaseOptions = {}
     ): Promise<SavedObject<T>> => {
-      const selectedTenant = state.selectedTenant;
-      const username = state.authInfo?.user_name;
-      let namespaceValue = selectedTenant;
-      if (selectedTenant === '__user__') {
+      if (selectedTenant !== undefined && isPrivateTenant(selectedTenant)) {
         namespaceValue = selectedTenant + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
@@ -108,10 +107,7 @@ export class SecuritySavedObjectsClientWrapper {
       attributes: Partial<T>,
       options: SavedObjectsUpdateOptions = {}
     ): Promise<SavedObjectsUpdateResponse<T>> => {
-      const selectedTenant = state.selectedTenant;
-      const username = state.authInfo?.user_name;
-      let namespaceValue = selectedTenant;
-      if (selectedTenant === '__user__') {
+      if (selectedTenant !== undefined && isPrivateTenant(selectedTenant)) {
         namespaceValue = selectedTenant + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
@@ -122,10 +118,7 @@ export class SecuritySavedObjectsClientWrapper {
       objects: Array<SavedObjectsBulkCreateObject<T>>,
       options?: SavedObjectsCreateOptions
     ): Promise<SavedObjectsBulkResponse<T>> => {
-      const selectedTenant = state.selectedTenant;
-      const username = state.authInfo?.user_name;
-      let namespaceValue = selectedTenant;
-      if (selectedTenant === '__user__') {
+      if (selectedTenant !== undefined && isPrivateTenant(selectedTenant)) {
         namespaceValue = selectedTenant + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
@@ -136,10 +129,7 @@ export class SecuritySavedObjectsClientWrapper {
       objects: Array<SavedObjectsBulkUpdateObject<T>>,
       options?: SavedObjectsBulkUpdateOptions
     ): Promise<SavedObjectsBulkUpdateResponse<T>> => {
-      const selectedTenant = state.selectedTenant;
-      const username = state.authInfo?.user_name;
-      let namespaceValue = selectedTenant;
-      if (selectedTenant === '__user__') {
+      if (selectedTenant !== undefined && isPrivateTenant(selectedTenant)) {
         namespaceValue = selectedTenant + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
@@ -151,10 +141,7 @@ export class SecuritySavedObjectsClientWrapper {
       id: string,
       options: SavedObjectsDeleteOptions = {}
     ) => {
-      const selectedTenant = state.selectedTenant;
-      const username = state.authInfo?.user_name;
-      let namespaceValue = selectedTenant;
-      if (selectedTenant === '__user__') {
+      if (selectedTenant !== undefined && isPrivateTenant(selectedTenant)) {
         namespaceValue = selectedTenant + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
@@ -165,10 +152,7 @@ export class SecuritySavedObjectsClientWrapper {
       objects: SavedObjectsCheckConflictsObject[] = [],
       options: SavedObjectsBaseOptions = {}
     ): Promise<SavedObjectsCheckConflictsResponse> => {
-      const selectedTenant = state.selectedTenant;
-      const username = state.authInfo?.user_name;
-      let namespaceValue = selectedTenant;
-      if (selectedTenant === '__user__') {
+      if (selectedTenant !== undefined && isPrivateTenant(selectedTenant)) {
         namespaceValue = selectedTenant + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
@@ -191,4 +175,8 @@ export class SecuritySavedObjectsClientWrapper {
       deleteFromNamespaces: wrapperOptions.client.deleteFromNamespaces,
     };
   };
+}
+
+function isPrivateTenant(selectedTenant: string | undefined) {
+  return selectedTenant === '__user__';
 }

--- a/server/saved_objects/saved_objects_wrapper.ts
+++ b/server/saved_objects/saved_objects_wrapper.ts
@@ -39,9 +39,9 @@ import { SecurityPluginConfigType } from '..';
 import {
   DEFAULT_TENANT,
   globalTenantName,
-  GLOBAL_TENANT,
+  GLOBAL_TENANT_SYMBOL,
   isPrivateTenant,
-  PRIVATE_TENANT,
+  PRIVATE_TENANT_SYMBOL,
 } from '../../public/apps/configuration/utils/tenant-utils';
 import { OpenSearchDashboardsAuthState } from '../auth/types/authentication_type';
 
@@ -68,8 +68,8 @@ export class SecuritySavedObjectsClientWrapper {
       attributes: T,
       options?: SavedObjectsCreateOptions
     ) => {
-      if (selectedTenant !== undefined && isPrivateEnabled && isPrivateTenant(selectedTenant)) {
-        namespaceValue = selectedTenant + username;
+      if (this.isAPrivateTenant(selectedTenant, isPrivateEnabled)) {
+        namespaceValue = selectedTenant! + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
       return await wrapperOptions.client.create(type, attributes, options);
@@ -79,8 +79,8 @@ export class SecuritySavedObjectsClientWrapper {
       objects: SavedObjectsBulkGetObject[] = [],
       options: SavedObjectsBaseOptions = {}
     ): Promise<SavedObjectsBulkResponse<T>> => {
-      if (selectedTenant !== undefined && isPrivateEnabled && isPrivateTenant(selectedTenant)) {
-        namespaceValue = selectedTenant + username;
+      if (this.isAPrivateTenant(selectedTenant, isPrivateEnabled)) {
+        namespaceValue = selectedTenant! + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
       return await wrapperOptions.client.bulkGet(objects, options);
@@ -93,10 +93,10 @@ export class SecuritySavedObjectsClientWrapper {
       const availableTenantNames = Object.keys(tenants!);
       availableTenantNames.push(DEFAULT_TENANT);
       if (isGlobalEnabled) {
-        availableTenantNames.push(GLOBAL_TENANT);
+        availableTenantNames.push(GLOBAL_TENANT_SYMBOL);
       }
       if (isPrivateEnabled) {
-        availableTenantNames.push(PRIVATE_TENANT + username);
+        availableTenantNames.push(PRIVATE_TENANT_SYMBOL + username);
       }
       if (availableTenantNames.includes(globalTenantName)) {
         let index = availableTenantNames.indexOf(globalTenantName);
@@ -142,8 +142,8 @@ export class SecuritySavedObjectsClientWrapper {
       id: string,
       options: SavedObjectsBaseOptions = {}
     ): Promise<SavedObject<T>> => {
-      if (selectedTenant !== undefined && isPrivateEnabled && isPrivateTenant(selectedTenant)) {
-        namespaceValue = selectedTenant + username;
+      if (this.isAPrivateTenant(selectedTenant, isPrivateEnabled)) {
+        namespaceValue = selectedTenant! + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
       return await wrapperOptions.client.get(type, id, options);
@@ -155,8 +155,8 @@ export class SecuritySavedObjectsClientWrapper {
       attributes: Partial<T>,
       options: SavedObjectsUpdateOptions = {}
     ): Promise<SavedObjectsUpdateResponse<T>> => {
-      if (selectedTenant !== undefined && isPrivateEnabled && isPrivateTenant(selectedTenant)) {
-        namespaceValue = selectedTenant + username;
+      if (this.isAPrivateTenant(selectedTenant, isPrivateEnabled)) {
+        namespaceValue = selectedTenant! + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
       return await wrapperOptions.client.update(type, id, attributes, options);
@@ -166,8 +166,8 @@ export class SecuritySavedObjectsClientWrapper {
       objects: Array<SavedObjectsBulkCreateObject<T>>,
       options?: SavedObjectsCreateOptions
     ): Promise<SavedObjectsBulkResponse<T>> => {
-      if (selectedTenant !== undefined && isPrivateEnabled && isPrivateTenant(selectedTenant)) {
-        namespaceValue = selectedTenant + username;
+      if (this.isAPrivateTenant(selectedTenant, isPrivateEnabled)) {
+        namespaceValue = selectedTenant! + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
       return await wrapperOptions.client.bulkCreate(objects, options);
@@ -177,8 +177,8 @@ export class SecuritySavedObjectsClientWrapper {
       objects: Array<SavedObjectsBulkUpdateObject<T>>,
       options?: SavedObjectsBulkUpdateOptions
     ): Promise<SavedObjectsBulkUpdateResponse<T>> => {
-      if (selectedTenant !== undefined && isPrivateEnabled && isPrivateTenant(selectedTenant)) {
-        namespaceValue = selectedTenant + username;
+      if (this.isAPrivateTenant(selectedTenant, isPrivateEnabled)) {
+        namespaceValue = selectedTenant! + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
       return await wrapperOptions.client.bulkUpdate(objects, options);
@@ -189,8 +189,8 @@ export class SecuritySavedObjectsClientWrapper {
       id: string,
       options: SavedObjectsDeleteOptions = {}
     ) => {
-      if (selectedTenant !== undefined && isPrivateEnabled && isPrivateTenant(selectedTenant)) {
-        namespaceValue = selectedTenant + username;
+      if (this.isAPrivateTenant(selectedTenant, isPrivateEnabled)) {
+        namespaceValue = selectedTenant! + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
       return await wrapperOptions.client.delete(type, id, options);
@@ -200,8 +200,8 @@ export class SecuritySavedObjectsClientWrapper {
       objects: SavedObjectsCheckConflictsObject[] = [],
       options: SavedObjectsBaseOptions = {}
     ): Promise<SavedObjectsCheckConflictsResponse> => {
-      if (selectedTenant !== undefined && isPrivateEnabled && isPrivateTenant(selectedTenant)) {
-        namespaceValue = selectedTenant + username;
+      if (this.isAPrivateTenant(selectedTenant, isPrivateEnabled)) {
+        namespaceValue = selectedTenant! + username;
       }
       _.assign(options, { namespace: [namespaceValue] });
       return await wrapperOptions.client.checkConflicts(objects, options);
@@ -223,4 +223,8 @@ export class SecuritySavedObjectsClientWrapper {
       deleteFromNamespaces: wrapperOptions.client.deleteFromNamespaces,
     };
   };
+
+  private isAPrivateTenant(selectedTenant: string | undefined, isPrivateEnabled: boolean) {
+    return selectedTenant !== undefined && isPrivateEnabled && isPrivateTenant(selectedTenant);
+  }
 }

--- a/server/saved_objects/saved_objects_wrapper.ts
+++ b/server/saved_objects/saved_objects_wrapper.ts
@@ -97,7 +97,31 @@ export class SecuritySavedObjectsClientWrapper {
       if (isPrivateEnabled) {
         availableTenantNames.push(PRIVATE_TENANT + state.authInfo?.user_name);
       }
-      _.assign(options, { namespaces: availableTenantNames });
+      const typeToNamespacesMap = {};
+      if (selectedTenant === '__user__') {
+        namespaceValue = selectedTenant + username;
+      }
+      const searchTypes = Array.isArray(options.type) ? options.type : [options.type];
+      searchTypes.forEach((t) => {
+        if (t === 'config') {
+          if ('namespaces' in options) {
+            if (options.namespaces.includes(namespaceValue)) {
+              typeToNamespacesMap[t] = [namespaceValue];
+            }
+          } else {
+            typeToNamespacesMap[t] = [namespaceValue];
+          }
+        } else {
+          if ('namespaces' in options) {
+            typeToNamespacesMap[t] = options.namespaces;
+          } else {
+            typeToNamespacesMap[t] = availableTenantNames;
+          }
+        }
+      });
+      options.typeToNamespacesMap = new Map(Object.entries(typeToNamespacesMap));
+      options.type = '';
+      options.namespaces = [];
       return await wrapperOptions.client.find(options);
     };
 


### PR DESCRIPTION
### Description
Enable saved object table to show saved objects across all permitted tenants on a single panel. This is the 1st milestone of [the new saved object sharing experience](https://github.com/opensearch-project/security/issues/1869).

### Category
New feature

### Why these changes are required?
The 1st milestone of [the new saved object sharing experience](https://github.com/opensearch-project/security/issues/1869).

### What is the old behavior before changes and new behavior after changes?
(See [the issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2249))
**Current Behavior**:
The Saved Object table shows only the saved objects in the selected tenants.
**New Behavior**:
The Saved Object table shows all the saved objects across all tenants that the logged in user has permissions to.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2249

### Testing

- [Functional Tests](https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/334)
- Existing UTs and ITs

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).