### PR TITLE
Remove multi-tenant path check in auth handler

### DIFF
--- a/server/auth/types/authentication_type.test.ts
+++ b/server/auth/types/authentication_type.test.ts
@@ -84,7 +84,6 @@ describe('test tenant header', () => {
       authenticated: jest.fn((value) => value),
     };
     const result = await dummyAuthType.authHandler(request, response, toolkit);
-    console.log(result);
     expect(result.requestHeaders.securitytenant).toEqual('dummy_tenant');
   });
 
@@ -97,7 +96,6 @@ describe('test tenant header', () => {
       authenticated: jest.fn((value) => value),
     };
     const result = await dummyAuthType.authHandler(request, response, toolkit);
-    console.log(result);
     expect(result.requestHeaders.securitytenant).toEqual('dummy_tenant');
   });
 });

--- a/server/auth/types/authentication_type.test.ts
+++ b/server/auth/types/authentication_type.test.ts
@@ -1,0 +1,88 @@
+import { SecurityPluginConfigType } from '../..';
+import { AuthenticationType } from './authentication_type';
+import { httpServerMock } from '../../../../../src/core/server/mocks';
+
+class DummyAuthType extends AuthenticationType {
+  buildAuthHeaderFromCookie() {}
+  getAdditionalAuthHeader() {}
+  handleUnauthedRequest() {}
+  getCookie() {
+    return {};
+  }
+  isValidCookie() {
+    return Promise.resolve(true);
+  }
+  requestIncludesAuthInfo() {
+    return false;
+  }
+  resolveTenant(): Promise<string | undefined> {
+    return Promise.resolve('dummy_tenant');
+  }
+}
+
+describe('test tenant header', () => {
+  const config = {
+    multitenancy: {
+      enabled: true,
+    },
+    auth: {
+      unauthenticated_routes: [] as string[],
+    },
+    session: {
+      keepalive: false,
+    },
+  } as SecurityPluginConfigType;
+  const sessionStorageFactory = {
+    asScoped: jest.fn(() => {
+      return {
+        clear: jest.fn(),
+        get: () => {
+          return {
+            tenant: 'dummy_tenant',
+          };
+        },
+      };
+    }),
+  };
+  const router = jest.fn();
+  const esClient = jest.fn();
+  const coreSetup = jest.fn();
+  const logger = {
+    error: jest.fn(),
+  };
+
+  const dummyAuthType = new DummyAuthType(
+    config,
+    sessionStorageFactory,
+    router,
+    esClient,
+    coreSetup,
+    logger
+  );
+
+  it(`common API includes tenant info`, async () => {
+    const request = httpServerMock.createOpenSearchDashboardsRequest({
+      path: '/api/v1',
+    });
+    const response = jest.fn();
+    const toolkit = {
+      authenticated: jest.fn((value) => value),
+    };
+    const result = await dummyAuthType.authHandler(request, response, toolkit);
+    console.log(result);
+    expect(result.requestHeaders.securitytenant).toEqual('dummy_tenant');
+  });
+
+  it(`internal API includes tenant info`, async () => {
+    const request = httpServerMock.createOpenSearchDashboardsRequest({
+      path: '/internal/v1',
+    });
+    const response = jest.fn();
+    const toolkit = {
+      authenticated: jest.fn((value) => value),
+    };
+    const result = await dummyAuthType.authHandler(request, response, toolkit);
+    console.log(result);
+    expect(result.requestHeaders.securitytenant).toEqual('dummy_tenant');
+  });
+});

--- a/server/auth/types/authentication_type.test.ts
+++ b/server/auth/types/authentication_type.test.ts
@@ -60,7 +60,15 @@ describe('test tenant header', () => {
     }),
   };
   const router = jest.fn();
-  const esClient = jest.fn();
+  const esClient = {
+    asScoped: jest.fn().mockImplementation(() => {
+      return {
+        callAsCurrentUser: jest.fn().mockImplementation(() => {
+          return { username: 'dummy-username' };
+        }),
+      };
+    }),
+  };
   const coreSetup = jest.fn();
   const logger = {
     error: jest.fn(),

--- a/server/auth/types/authentication_type.test.ts
+++ b/server/auth/types/authentication_type.test.ts
@@ -1,3 +1,18 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
 import { SecurityPluginConfigType } from '../..';
 import { AuthenticationType } from './authentication_type';
 import { httpServerMock } from '../../../../../src/core/server/mocks';

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -30,7 +30,6 @@ import { SecurityPluginConfigType } from '../..';
 import { SecuritySessionCookie } from '../../session/security_cookie';
 import { SecurityClient } from '../../backend/opensearch_security_client';
 import {
-  isMultitenantPath,
   resolveTenant,
   isValidTenant,
 } from '../../multitenancy/tenant_resolver';
@@ -147,7 +146,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
     }
 
     // resolve tenant if necessary
-    if (this.config.multitenancy?.enabled && isMultitenantPath(request)) {
+    if (this.config.multitenancy?.enabled) {
       try {
         const tenant = await this.resolveTenant(request, cookie!, authHeaders, authInfo);
         // return 401 if no tenant available

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -29,10 +29,7 @@ import {
 import { SecurityPluginConfigType } from '../..';
 import { SecuritySessionCookie } from '../../session/security_cookie';
 import { SecurityClient } from '../../backend/opensearch_security_client';
-import {
-  resolveTenant,
-  isValidTenant,
-} from '../../multitenancy/tenant_resolver';
+import { resolveTenant, isValidTenant } from '../../multitenancy/tenant_resolver';
 import { UnauthenticatedError } from '../../errors';
 
 export interface IAuthenticationType {

--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -81,25 +81,6 @@ export function resolveTenant(
   );
 }
 
-/**
- * Determines whether the request requires tenant info.
- * @param request opensearch-dashboards request.
- *
- * @returns true if the request requires tenant info, otherwise false.
- */
-export function isMultitenantPath(request: OpenSearchDashboardsRequest): boolean {
-  return (
-    request.url.pathname?.startsWith('/opensearch') ||
-    request.url.pathname?.startsWith('/api') ||
-    request.url.pathname?.startsWith('/app') ||
-    // short url path
-    request.url.pathname?.startsWith('/goto') ||
-    // bootstrap.js depends on tenant info to fetch opensearch-dashboards configs in tenant index
-    (request.url.pathname?.indexOf('bootstrap.js') || -1) > -1 ||
-    request.url.pathname === '/'
-  );
-}
-
 function resolve(
   username: string,
   requestedTenant: string | undefined,


### PR DESCRIPTION
### Description

The Opensearch Dashboards tenant only impacts the saved objects access. The multi-tenant path check in the auth handler was meant to by pass the resolve tenant logic for some APIs which doesn't deal with saved objects. However with the new datasource support feature in OpenSearch Dashboards, Dashboards APIs which used to not dealing with saved objects such as data queries and index resolve operations will require the new data source saved object type under the hood.

This change removes the multi-tenant path check, so that tenant header will be injected to all route handlers. So that all route handlers can work with the right tenant in case they need to deal with any saved objects.

Signed-off-by: Yan Zeng <zengyan@amazon.com>

### Category
Bug fix

### Why these changes are required?
This change is required for OpenSearch Dashboards data source support feature to work with correct tenant when querying remote data sources.


### What is the old behavior before changes and new behavior after changes?
Old behavior: auth handler will not inject tenant header for some APIs (e.g. APIs starts with `/internal`)
New behavior: auth handler will inject tenant header to all OSD APIs

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2634

### Testing
Manually tested
Old behavior causing error getting saved objects:
![image](https://user-images.githubusercontent.com/46499415/197017271-cf41930a-056f-4174-9912-a0570b08dae3.png)

New behavior solved the issue:
![image](https://user-images.githubusercontent.com/46499415/197016726-297cd10a-b93b-49f6-9e46-1b6ecbd581ae.png)



### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).