### PR TITLE
Wait for tenant radio to be selected in flaky SAML integ test

### DIFF
--- a/test/jest_integration/saml_auth.test.ts
+++ b/test/jest_integration/saml_auth.test.ts
@@ -302,7 +302,7 @@ describe('start OpenSearch Dashboards server', () => {
     await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
     await driver.executeScript('arguments[0].click();', radio);
 
-    await new Promise(r => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, 500));
 
     await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
 

--- a/test/jest_integration/saml_auth.test.ts
+++ b/test/jest_integration/saml_auth.test.ts
@@ -302,6 +302,8 @@ describe('start OpenSearch Dashboards server', () => {
     await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
     await driver.executeScript('arguments[0].click();', radio);
 
+    await new Promise(r => setTimeout(r, 500));
+
     await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
 
     await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);

--- a/test/jest_integration/saml_auth.test.ts
+++ b/test/jest_integration/saml_auth.test.ts
@@ -302,7 +302,7 @@ describe('start OpenSearch Dashboards server', () => {
     await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
     await driver.executeScript('arguments[0].click();', radio);
 
-    await new Promise((r) => setTimeout(r, 500));
+    await driver.wait(until.elementIsSelected(radio));
 
     await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
 


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Fixes flaky SAML integration test that tests tenancy persistence on logout. Adds a step to wait for the radio button to be selected before selenium proceeds to confirm the tenant selection modal.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Test fix

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1193

### Testing

To run the flaky test use:

```
yarn run test:jest_server -- saml_auth.test.ts -t "Tenancy persisted after Logout in SAML"
```

### Check List
- [X] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).