### PR TITLE
Disable UTs for Windows while stablizing it

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,14 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest , windows-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Enable longer filenames
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: git config --system core.longpaths true
-
       - uses: actions/checkout@v2
 
       - id: install-dashboards


### PR DESCRIPTION
Signed-off-by: Chang Liu <lc12251109@gmail.com>

### Description
UTs are unstable on Windows.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation] Maintenance

### Issues Resolved
https://github.com/opensearch-project/security-dashboards-plugin/issues/1195

### Testing
UTs, ITs

### Check List
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).