### PR TITLE
Add retry and enable UTs for Windows

### DIFF
--- a/.github/actions/install-dashboards/action.yml
+++ b/.github/actions/install-dashboards/action.yml
@@ -78,6 +78,8 @@ runs:
       working-directory: OpenSearch-Dashboards
       shell: bash
 
-    - run: yarn osd bootstrap --oss
-      working-directory: OpenSearch-Dashboards
-      shell: bash
+    - uses: nick-fields/retry@v2
+      with:
+        timeout_minutes: 20
+        max_attempts: 2
+        command: yarn --cwd OpenSearch-Dashboards osd bootstrap --oss

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,10 +8,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest , windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Enable longer filenames
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: git config --system core.longpaths true
+
       - uses: actions/checkout@v2
 
       - id: install-dashboards


### PR DESCRIPTION
### Description
Added a retry around the the bootstrap that previously failed due to network issues.  Ran the new version of this workflow 100 iterations on linux and windows, both passed at 100% [1].

Without the retry during a run of 100 iterations [2], the windows test failed once during the bootstrap.  If we see future issues, we could attempt to add retries to them following this same pattern.

[1] https://github.com/peternied/security-dashboards-plugin/actions/runs/3449518073
[2] https://github.com/peternied/security-dashboards-plugin/actions/runs/3449040181

### Issues Resolved
- Resolves #1211
- Resolves #1195

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).