### PR TITLE
Always wait and locate button before clicking in flaky SAML integ test

### DIFF
--- a/test/jest_integration/saml_auth.test.ts
+++ b/test/jest_integration/saml_auth.test.ts
@@ -288,6 +288,8 @@ describe('start OpenSearch Dashboards server', () => {
 
     await driver.get('http://localhost:5601/app/opensearch_dashboards_overview#/');
 
+    await driver.wait(until.elementsLocated(By.xpath(signInBtnXPath)), 10000);
+
     await driver.findElement(By.xpath(signInBtnXPath)).click();
 
     await driver.wait(until.elementsLocated(By.xpath(pageTitleXPath)), 10000);
@@ -321,6 +323,8 @@ describe('start OpenSearch Dashboards server', () => {
     await driver.wait(until.elementsLocated(By.xpath(skipWelcomeBtnXPath)), 10000);
 
     await driver.findElement(By.xpath(skipWelcomeBtnXPath)).click();
+
+    await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
 
     await driver.findElement(By.xpath(userIconBtnXPath)).click();
 


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Always waits to locate a button before clicking in flaky SAML test

### Category

Test fix

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1193

### Check List
- [X] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).