### PR TITLE
Update URLs referencing old docs-beta site

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -267,6 +267,8 @@ export const DocLinks = {
     'https://opensearch.org/docs/latest/security-plugin/configuration/configuration/#authorization',
   AuthenticationFlowDoc:
     'https://opensearch.org/docs/latest/security-plugin/configuration/concepts/',
+  AccessControlDoc:
+    'https://opensearch.org/docs/latest/security-plugin/access-control/index/',
   UsersAndRolesDoc:
     'https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/',
   CreateRolesDoc:

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -265,8 +265,10 @@ export const DocLinks = {
     'https://opensearch.org/docs/latest/security-plugin/configuration/configuration/#authentication',
   BackendConfigurationAuthorizationDoc:
     'https://opensearch.org/docs/latest/security-plugin/configuration/configuration/#authorization',
-  AuthenticationFlowDoc: 'https://opensearch.org/docs/latest/security-plugin/configuration/concepts/',
-  UsersAndRolesDoc: 'https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/',
+  AuthenticationFlowDoc:
+    'https://opensearch.org/docs/latest/security-plugin/configuration/concepts/',
+  UsersAndRolesDoc:
+    'https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/',
   CreateRolesDoc:
     'https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#create-roles',
   MapUsersToRolesDoc:

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -260,41 +260,41 @@ export const RoleViewTenantInvalidText = 'N/A';
 // External Links
 export const DocLinks = {
   BackendConfigurationDoc:
-    'https://docs-beta.opensearch.org/docs/security/configuration/configuration/',
+    'https://opensearch.org/docs/latest/security-plugin/configuration/configuration/',
   BackendConfigurationAuthenticationDoc:
-    'https://docs-beta.opensearch.org/docs/security/configuration/configuration/#authentication',
+    'https://opensearch.org/docs/latest/security-plugin/configuration/configuration/#authentication',
   BackendConfigurationAuthorizationDoc:
-    'https://docs-beta.opensearch.org/docs/security/configuration/configuration/#authorization',
-  AuthenticationFlowDoc: 'https://docs-beta.opensearch.org/docs/security/configuration/concepts/',
-  UsersAndRolesDoc: 'https://docs-beta.opensearch.org/docs/security/access-control/users-roles/',
+    'https://opensearch.org/docs/latest/security-plugin/configuration/configuration/#authorization',
+  AuthenticationFlowDoc: 'https://opensearch.org/docs/latest/security-plugin/configuration/concepts/',
+  UsersAndRolesDoc: 'https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/',
   CreateRolesDoc:
-    'https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#create-roles',
+    'https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#create-roles',
   MapUsersToRolesDoc:
-    'https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#map-users-to-roles',
+    'https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#map-users-to-roles',
   CreateUsersDoc:
-    'https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#create-users',
+    'https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#create-users',
   AuditLogsDoc: translateMessage(
     'audit.logs.docLink',
-    'https://docs-beta.opensearch.org/docs/security/audit-logs/'
+    'https://opensearch.org/docs/latest/security-plugin/audit-logs/'
   ),
   AuditLogsStorageDoc: translateMessage(
     'audit.logs.storageDocLink',
-    'https://docs-beta.opensearch.org/docs/security/audit-logs/storage-types/'
+    'https://opensearch.org/docs/latest/security-plugin/audit-logs/storage-types/'
   ),
   PermissionsDoc:
-    'https://docs-beta.opensearch.org/docs/security/access-control/default-action-groups/',
+    'https://opensearch.org/docs/latest/security-plugin/access-control/default-action-groups/',
   ClusterPermissionsDoc:
-    'https://docs-beta.opensearch.org/docs/security/access-control/default-action-groups/#cluster-level',
+    'https://opensearch.org/docs/latest/security-plugin/access-control/default-action-groups/#cluster-level',
   IndexPermissionsDoc:
-    'https://docs-beta.opensearch.org/docs/security/access-control/default-action-groups/#index-level',
+    'https://opensearch.org/docs/latest/security-plugin/access-control/default-action-groups/#index-level',
   DocumentLevelSecurityDoc:
-    'https://docs-beta.opensearch.org/docs/security/access-control/document-level-security/',
+    'https://opensearch.org/docs/latest/security-plugin/access-control/document-level-security/',
   TenantPermissionsDoc:
-    'https://docs-beta.opensearch.org/docs/security/access-control/multi-tenancy/',
+    'https://opensearch.org/docs/latest/security-plugin/multi-tenancy/multi-tenancy-config',
   AttributeBasedSecurityDoc:
-    'https://docs-beta.opensearch.org/docs/security/access-control/document-level-security/#attribute-based-security',
+    'https://opensearch.org/docs/latest/security-plugin/access-control/document-level-security/#attribute-based-security',
   BackendRoleDoc:
-    'https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#map-users-to-roles',
+    'https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#map-users-to-roles',
 };
 
 export enum ToolTipContent {

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -267,8 +267,7 @@ export const DocLinks = {
     'https://opensearch.org/docs/latest/security-plugin/configuration/configuration/#authorization',
   AuthenticationFlowDoc:
     'https://opensearch.org/docs/latest/security-plugin/configuration/concepts/',
-  AccessControlDoc:
-    'https://opensearch.org/docs/latest/security-plugin/access-control/index/',
+  AccessControlDoc: 'https://opensearch.org/docs/latest/security-plugin/access-control/index/',
   UsersAndRolesDoc:
     'https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/',
   CreateRolesDoc:

--- a/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
+++ b/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
@@ -288,7 +288,7 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
             />
              
             <ExternalLink
-              href="https://docs-beta.opensearch.org/docs/security/audit-logs/storage-types/"
+              href="https://opensearch.org/docs/latest/security-plugin/audit-logs/storage-types/"
             />
           </EuiText>
         </EuiFormRow>

--- a/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
@@ -83,7 +83,7 @@ export function BackendRolePanel(props: {
     <PanelWithHeader
       headerText="Backend roles"
       headerSubText="Backend roles are used to map users from external authentication systems, such as LDAP or SAML to OpenSearch security roles."
-      helpLink={DocLinks.AttributeBasedSecurityDoc}
+      helpLink={DocLinks.AccessControlDoc}
       optional
     >
       {generateBackendRolesPanels(state, setState)}

--- a/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
+++ b/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
@@ -100,7 +100,7 @@ export function ExternalIdentitiesPanel(props: {
     <PanelWithHeader
       headerText="Backend roles"
       headerSubText="Use a backend role to directly map to roles through an external authentication system."
-      helpLink={DocLinks.CreateUsersDoc}
+      helpLink={DocLinks.AccessControlDoc}
     >
       {panel}
       <EuiSpacer />

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
@@ -168,7 +168,7 @@ exports[`Role view basic rendering when permission tab is selected 1`] = `
                     You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system.
                      
                     <ExternalLink
-                      href="https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#map-users-to-roles"
+                      href="https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#map-users-to-roles"
                     />
                   </EuiText>
                 </EuiPageContentHeaderSection>
@@ -364,7 +364,7 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                   You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system.
                    
                   <ExternalLink
-                    href="https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#map-users-to-roles"
+                    href="https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#map-users-to-roles"
                   />
                 </EuiText>
               </EuiPageContentHeaderSection>
@@ -551,7 +551,7 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                     You can map two types of users: users and backend roles. A user can have its own backend role and host for an external authentication and authorization. A backend role directly maps to roles through an external authentication system.
                      
                     <ExternalLink
-                      href="https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#map-users-to-roles"
+                      href="https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#map-users-to-roles"
                     />
                   </EuiText>
                 </EuiPageContentHeaderSection>

--- a/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
+++ b/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Tenant list Action menu click Duplicate click 1`] = `
         >
           Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations, dashboards, and other OpenSearch Dashboards objects. Use tenants to safely share your work with other OpenSearch Dashboards users. You can control which roles have access to a tenant and whether those roles have read or write access. The “Current” label indicates which tenant you are using now. Switch to another tenant anytime from your user profile, which is located on the top right of the screen. 
           <ExternalLink
-            href="https://docs-beta.opensearch.org/docs/security/access-control/multi-tenancy/"
+            href="https://opensearch.org/docs/latest/security-plugin/multi-tenancy/multi-tenancy-config"
           />
         </EuiText>
       </EuiPageContentHeaderSection>
@@ -221,7 +221,7 @@ exports[`Tenant list Action menu click Edit click 1`] = `
         >
           Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations, dashboards, and other OpenSearch Dashboards objects. Use tenants to safely share your work with other OpenSearch Dashboards users. You can control which roles have access to a tenant and whether those roles have read or write access. The “Current” label indicates which tenant you are using now. Switch to another tenant anytime from your user profile, which is located on the top right of the screen. 
           <ExternalLink
-            href="https://docs-beta.opensearch.org/docs/security/access-control/multi-tenancy/"
+            href="https://opensearch.org/docs/latest/security-plugin/multi-tenancy/multi-tenancy-config"
           />
         </EuiText>
       </EuiPageContentHeaderSection>

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Get started (landing page) renders when backend configuration is disabl
                   Roles are reusable collections of permissions. The default roles are a great starting point, but you might need to create custom roles that meet your exact needs.
                    
                   <ExternalLink
-                    href="https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#create-roles"
+                    href="https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#create-roles"
                   />
                 </EuiText>
                 <EuiSpacer
@@ -93,7 +93,7 @@ exports[`Get started (landing page) renders when backend configuration is disabl
                   After a user successfully authenticates, the security plugin retrieves that user’s roles. You can map roles directly to users, but you can also map them to backend roles.
                    
                   <ExternalLink
-                    href="https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#map-users-to-roles"
+                    href="https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#map-users-to-roles"
                   />
                 </EuiText>
                 <EuiSpacer
@@ -156,7 +156,7 @@ exports[`Get started (landing page) renders when backend configuration is disabl
           />
            
           <ExternalLink
-            href="https://docs-beta.opensearch.org/docs/security/audit-logs/"
+            href="https://opensearch.org/docs/latest/security-plugin/audit-logs/"
           />
         </p>
         <EuiButton
@@ -276,7 +276,7 @@ exports[`Get started (landing page) renders when backend configuration is enable
                   </EuiCode>
                   section contains any backends to fetch backend roles from. The most common example of a backend role is an LDAP group. 
                   <ExternalLink
-                    href="https://docs-beta.opensearch.org/docs/security/configuration/concepts/"
+                    href="https://opensearch.org/docs/latest/security-plugin/configuration/concepts/"
                   />
                 </EuiText>
                 <EuiSpacer
@@ -291,7 +291,7 @@ exports[`Get started (landing page) renders when backend configuration is enable
                   >
                     <ExternalLinkButton
                       fill={true}
-                      href="https://docs-beta.opensearch.org/docs/security/configuration/configuration/"
+                      href="https://opensearch.org/docs/latest/security-plugin/configuration/configuration/"
                       text="Create config.yml"
                     />
                   </EuiFlexItem>
@@ -321,7 +321,7 @@ exports[`Get started (landing page) renders when backend configuration is enable
                   Roles are reusable collections of permissions. The default roles are a great starting point, but you might need to create custom roles that meet your exact needs.
                    
                   <ExternalLink
-                    href="https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#create-roles"
+                    href="https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#create-roles"
                   />
                 </EuiText>
                 <EuiSpacer
@@ -367,7 +367,7 @@ exports[`Get started (landing page) renders when backend configuration is enable
                   After a user successfully authenticates, the security plugin retrieves that user’s roles. You can map roles directly to users, but you can also map them to backend roles.
                    
                   <ExternalLink
-                    href="https://docs-beta.opensearch.org/docs/security/access-control/users-roles/#map-users-to-roles"
+                    href="https://opensearch.org/docs/latest/security-plugin/access-control/users-roles/#map-users-to-roles"
                   />
                 </EuiText>
                 <EuiSpacer
@@ -430,7 +430,7 @@ exports[`Get started (landing page) renders when backend configuration is enable
           />
            
           <ExternalLink
-            href="https://docs-beta.opensearch.org/docs/security/audit-logs/"
+            href="https://opensearch.org/docs/latest/security-plugin/audit-logs/"
           />
         </p>
         <EuiButton


### PR DESCRIPTION
### Description

Replaced URLs starting with `https://docs-beta.opensearch.org/docs/security` to start with `https://opensearch.org/docs/latest/security-plugin` and updates link to multi-tenancy documentation renamed in this PR: https://github.com/opensearch-project/documentation-website/pull/1786

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Bug fix

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1174

### Testing

Updated snapshots with old URLs

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).