### PR TITLE
Automatically add `untriaged` label on issues

### DIFF
--- a/.github/workflows/add-untriaged.yml
+++ b/.github/workflows/add-untriaged.yml
@@ -1,0 +1,19 @@
+name: Apply 'untriaged' label during issue lifecycle
+
+on:
+  issues:
+    types: [opened, reopened, transferred]
+
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['untriaged']
+            })


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>

### Description
Automatically add `untriaged` label on issues
### Category
Enhancement
### Issues Resolved
* Related https://github.com/opensearch-project/security/pull/2297
### Testing
Tested this on my own fork of this repo with two cases:
- Test of reopened issue: https://github.com/RyanL1997/security-dashboards-plugin/issues/1
- Test of opened issue: https://github.com/RyanL1997/security-dashboards-plugin/issues/3
### Check List
- [x] New functionality includes testing
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).