### PR TITLE
Set order of tenant_template to the highest to avoid being overridden by custom templates

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -49,6 +49,8 @@ export const GLOBAL_TENANT_RENDERING_TEXT = 'Global';
 export const PRIVATE_TENANT_RENDERING_TEXT = 'Private';
 export const globalTenantName = 'global_tenant';
 
+export const MAX_INTEGER = 2147483647;
+
 export enum AuthType {
   BASIC = 'basicauth',
   OPEN_ID = 'openid',

--- a/server/multitenancy/tenant_index.ts
+++ b/server/multitenancy/tenant_index.ts
@@ -41,6 +41,7 @@ export async function setupIndexTemplate(
     await esClient.indices.putTemplate({
       name: 'tenant_template',
       body: {
+        order: 2147483647,
         index_patterns: [
           opensearchDashboardsIndex + '_-*_*',
           opensearchDashboardsIndex + '_0*_*',

--- a/server/multitenancy/tenant_index.ts
+++ b/server/multitenancy/tenant_index.ts
@@ -29,6 +29,7 @@ import {
 import { createIndexMap } from '../../../../src/core/server/saved_objects/migrations/core/build_index_map';
 import { mergeTypes } from '../../../../src/core/server/saved_objects/migrations/opensearch_dashboards/opensearch_dashboards_migrator';
 import { SecurityClient } from '../backend/opensearch_security_client';
+import { MAX_INTEGER } from '../../common';
 
 export async function setupIndexTemplate(
   esClient: OpenSearchClient,
@@ -41,7 +42,8 @@ export async function setupIndexTemplate(
     await esClient.indices.putTemplate({
       name: 'tenant_template',
       body: {
-        order: 2147483647,
+        // Setting order to the max value to avoid being overridden by custom templates.
+        order: MAX_INTEGER,
         index_patterns: [
           opensearchDashboardsIndex + '_-*_*',
           opensearchDashboardsIndex + '_0*_*',

--- a/server/multitenancy/test/tenant_index.test.ts
+++ b/server/multitenancy/test/tenant_index.test.ts
@@ -1,0 +1,41 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+describe('Tenant index template', () => {
+  const mockOpenSearchClient = {
+    indices: {
+      putTemplate: jest.fn().mockImplementation((template) => {
+        return template;
+      }),
+    },
+  };
+
+  const order = 2147483647;
+
+  it('put template', () => {
+    const result = mockOpenSearchClient.indices.putTemplate({
+      name: 'test_index_template_a',
+      body: {
+        order,
+        index_patterns: 'test_index_patterns_a',
+        mappings: {
+          dynamic: 'strict',
+          properties: { baz: { type: 'text' } },
+        },
+      },
+    });
+    expect(result.body.order).toEqual(order);
+  });
+});

--- a/server/multitenancy/test/tenant_index.test.ts
+++ b/server/multitenancy/test/tenant_index.test.ts
@@ -13,6 +13,8 @@
  *   permissions and limitations under the License.
  */
 
+import { MAX_INTEGER } from '../../../common';
+
 describe('Tenant index template', () => {
   const mockOpenSearchClient = {
     indices: {
@@ -22,7 +24,7 @@ describe('Tenant index template', () => {
     },
   };
 
-  const order = 2147483647;
+  const order = MAX_INTEGER;
 
   it('put template', () => {
     const result = mockOpenSearchClient.indices.putTemplate({


### PR DESCRIPTION
Signed-off-by: Chang Liu <lc12251109@gmail.com>

### Description
The issue description of https://github.com/opensearch-project/security-dashboards-plugin/issues/1246 explains the issue to be resolved.
The PR title described the approach to fix the issue. 

### Category
Bug fix

### Issues Resolved
https://github.com/opensearch-project/security-dashboards-plugin/issues/1246

### Testing
UTs and ITs

### Check List
- [x] New functionality includes testing
- [x] Commits are signed per the DCO using --signoff

### Screenshots
<img width="1528" alt="Screen Shot 2022-12-08 at 5 09 43 PM" src="https://user-images.githubusercontent.com/16925774/206577980-da57a198-c7cb-4436-bf5c-2e88224cd096.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).