### PR TITLE
Change security CI build version 'latest' into build version '6705' 

### DIFF
--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
       
       - name: Download OpenSearch Security Plugin
-        run: wget --progress=bar:force:noscroll -O opensearch-security.zip https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.OPENSEARCH_VERSION }}/latest/linux/x64/tar/builds/opensearch/plugins/${{ env.PLUGIN_NAME }}-${{ env.PLUGIN_VERSION }}.zip
+        run: wget --progress=bar:force:noscroll -O opensearch-security.zip https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.OPENSEARCH_VERSION }}/6705/linux/x64/tar/builds/opensearch/plugins/${{ env.PLUGIN_NAME }}-${{ env.PLUGIN_VERSION }}.zip
       
       - name: Create Setup Script
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -24,7 +24,7 @@ jobs:
       - run: firefox --version
           
       - name: Download OpenSearch Security Plugin
-        run: wget --progress=bar:force:noscroll -O opensearch-security.zip https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.OPENSEARCH_VERSION }}/latest/linux/x64/tar/builds/opensearch/plugins/${{ env.PLUGIN_NAME }}-${{ env.PLUGIN_VERSION }}.zip
+        run: wget --progress=bar:force:noscroll -O opensearch-security.zip https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ env.OPENSEARCH_VERSION }}/6705/linux/x64/tar/builds/opensearch/plugins/${{ env.PLUGIN_NAME }}-${{ env.PLUGIN_VERSION }}.zip
       
       - name: Create Setup Script
         if: ${{ runner.os == 'Linux' }}


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>

### Description
Change security plugin CI build version 'latest' into build version '6705' to include the change of removing jackson-databind in gradle for security plugin.

### Category
Test fix

### Issues Resolved
* Related https://github.com/opensearch-project/security/issues/2324#issuecomment-1346908811
* Related https://github.com/opensearch-project/security/pull/2325

### Testing
GitHub Action

### Check List
- [x] New functionality includes testing
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).