### PR TITLE
[Backport opendistro-1.11] Set order of tenant_template to the highest to avoid being overridden by custom templates

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -29,6 +29,8 @@ export const API_AUTH_LOGOUT = '/auth/logout';
 
 export const ERROR_MISSING_ROLE_PATH = '/missing-role';
 
+export const MAX_INTEGER = 2147483647;
+
 export enum AuthType {
   BASIC = 'basicauth',
   OPEN_ID = 'openid',

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -38,7 +38,6 @@ export async function logout(http: HttpStart, logoutUrl?: string): Promise<void>
     logoutUrl || `${http.basePath.serverBasePath}/app/login?nextUrl=${nextUrl}`;
 }
 
-
 export async function updateNewPassword(
   http: HttpStart,
   newPassword: string,

--- a/server/index.ts
+++ b/server/index.ts
@@ -69,7 +69,9 @@ export const configSchema = schema.object({
       },
     }),
     anonymous_auth_enabled: schema.boolean({ defaultValue: false }),
-    unauthenticated_routes: schema.arrayOf(schema.string(), { defaultValue: ['/api/status', '/api/reporting/stats'] }),
+    unauthenticated_routes: schema.arrayOf(schema.string(), {
+      defaultValue: ['/api/status', '/api/reporting/stats'],
+    }),
     forbidden_usernames: schema.arrayOf(schema.string(), { defaultValue: [] }),
     logout_url: schema.string({ defaultValue: '' }),
   }),

--- a/server/multitenancy/tenant_index.ts
+++ b/server/multitenancy/tenant_index.ts
@@ -30,6 +30,7 @@ import { createIndexMap } from '../../../../src/core/server/saved_objects/migrat
 import { mergeTypes } from '../../../../src/core/server/saved_objects/migrations/kibana/kibana_migrator';
 // import { MigrationLogger } from '../../../../src/core/server/saved_objects/migrations/core/migration_logger';
 import { SecurityClient } from '../backend/opendistro_security_client';
+import { MAX_INTEGER } from '../../common';
 
 export async function setupIndexTemplate(
   esClient: ILegacyClusterClient,
@@ -42,6 +43,8 @@ export async function setupIndexTemplate(
     await esClient.callAsInternalUser('indices.putTemplate', {
       name: 'tenant_template',
       body: {
+        // Setting order to the max value to avoid being overridden by custom templates.
+        order: MAX_INTEGER,
         index_patterns: [
           kibanaIndex + '_-*_*',
           kibanaIndex + '_0*_*',

--- a/server/multitenancy/test/tenant_index.test.ts
+++ b/server/multitenancy/test/tenant_index.test.ts
@@ -1,0 +1,43 @@
+/*
+ *   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { MAX_INTEGER } from '../../../common';
+
+describe('Tenant index template', () => {
+  const mockESClient = {
+    indices: {
+      putTemplate: jest.fn().mockImplementation((template) => {
+        return template;
+      }),
+    },
+  };
+
+  const order = MAX_INTEGER;
+
+  it('put template', () => {
+    const result = mockESClient.indices.putTemplate({
+      name: 'test_index_template_a',
+      body: {
+        order,
+        index_patterns: 'test_index_patterns_a',
+        mappings: {
+          dynamic: 'strict',
+          properties: { baz: { type: 'text' } },
+        },
+      },
+    });
+    expect(result.body.order).toEqual(order);
+  });
+});


### PR DESCRIPTION
Backport dcf75c49543997e0e85dde9be314d5df81e60491 from #1247