### PR TITLE
Fix tenant label for custom tenant when both Global and Private tenan…

### DIFF
--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -17,7 +17,7 @@ import { isEmpty, findKey, cloneDeep } from 'lodash';
 import { OpenSearchDashboardsRequest } from '../../../../src/core/server';
 import { SecuritySessionCookie } from '../session/security_cookie';
 import { SecurityPluginConfigType } from '..';
-import { GLOBAL_TENANT_SYMBOL, PRIVATE_TENANT_SYMBOL } from '../../common';
+import { GLOBAL_TENANT_SYMBOL, PRIVATE_TENANT_SYMBOL, globalTenantName } from '../../common';
 
 export const PRIVATE_TENANTS: string[] = [PRIVATE_TENANT_SYMBOL, 'private'];
 export const GLOBAL_TENANTS: string[] = ['global', GLOBAL_TENANT_SYMBOL];
@@ -143,7 +143,18 @@ function resolve(
     return PRIVATE_TENANT_SYMBOL;
   }
 
-  // fall back to the first tenant in the available tenants
+  /**
+   * fall back to the first tenant in the available tenants
+   * Under the condition of enabling multitenancy, if the user has disabled both 'Global' and 'Private' tenants:
+   * it will remove the default global tenant key for custom tenant.
+   */
+  if (
+    Object.keys(availableTenantsClone).length > 1 &&
+    availableTenantsClone.hasOwnProperty(globalTenantName)
+  ) {
+    delete availableTenantsClone[globalTenantName];
+    return findKey(availableTenantsClone, () => true);
+  }
   return findKey(availableTenantsClone, () => true);
 }
 

--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -79,7 +79,7 @@ export function resolveTenant(
   );
 }
 
-function resolve(
+export function resolve(
   username: string,
   requestedTenant: string | undefined,
   preferredTenants: string[] | undefined,
@@ -144,7 +144,7 @@ function resolve(
   }
 
   /**
-   * fall back to the first tenant in the available tenants
+   * Fall back to the first tenant in the available tenants
    * Under the condition of enabling multitenancy, if the user has disabled both 'Global' and 'Private' tenants:
    * it will remove the default global tenant key for custom tenant.
    */
@@ -153,7 +153,6 @@ function resolve(
     availableTenantsClone.hasOwnProperty(globalTenantName)
   ) {
     delete availableTenantsClone[globalTenantName];
-    return findKey(availableTenantsClone, () => true);
   }
   return findKey(availableTenantsClone, () => true);
 }

--- a/server/multitenancy/test/tenant_resolver.test.ts
+++ b/server/multitenancy/test/tenant_resolver.test.ts
@@ -27,7 +27,7 @@ describe("Resolve tenants when multitenancy is enabled and both 'Global' and 'Pr
     );
   }
 
-  it('Resolve tenants list for admin user', () => {
+  it('Resolve tenant with custom tenants, Global and Private disabled', () => {
     const adminConfig = {
       username: 'admin',
       requestedTenant: 'admin_tenant',
@@ -41,7 +41,7 @@ describe("Resolve tenants when multitenancy is enabled and both 'Global' and 'Pr
     expect(adminResult).toEqual('admin_tenant');
   });
 
-  it('Resolve tenants list for non-admin user', () => {
+  it('Resolve tenant without custom tenants, Global and Private disabled', () => {
     const nonadminConfig = {
       username: 'testuser',
       requestedTenant: undefined,

--- a/server/multitenancy/test/tenant_resolver.test.ts
+++ b/server/multitenancy/test/tenant_resolver.test.ts
@@ -1,0 +1,57 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { resolve } from '../tenant_resolver';
+
+describe("Resolve tenants when multitenancy is enabled and both 'Global' and 'Private' tenants are disabled", () => {
+  function resolveWithConfig(config: any) {
+    return resolve(
+      config.username,
+      config.requestedTenant,
+      config.preferredTenants,
+      config.availableTenants,
+      config.globalTenantEnabled,
+      config.privateTenantEnabled
+    );
+  }
+
+  it('Resolve tenants list for admin user', () => {
+    const adminConfig = {
+      username: 'admin',
+      requestedTenant: 'admin_tenant',
+      preferredTenants: undefined,
+      availableTenants: { global_tenant: true, admin_tenant: true, test_tenant: true, admin: true },
+      globalTenantEnabled: false,
+      privateTenantEnabled: false,
+    };
+
+    const adminResult = resolveWithConfig(adminConfig);
+    expect(adminResult).toEqual('admin_tenant');
+  });
+
+  it('Resolve tenants list for non-admin user', () => {
+    const nonadminConfig = {
+      username: 'testuser',
+      requestedTenant: undefined,
+      preferredTenants: undefined,
+      availableTenants: { global_tenant: true, testuser: true },
+      globalTenantEnabled: false,
+      privateTenantEnabled: false,
+    };
+
+    const nonadminResult = resolveWithConfig(nonadminConfig);
+    expect(nonadminResult).toEqual('global_tenant');
+  });
+});


### PR DESCRIPTION
Signed-off-by: Ryan Liang <jiallian@amazon.com>
### Description
Fix tenant label for custom tenant when both Global and Private tenants are disabled
### Category
Bug fix
### Issues Resolved
* Resolved #1248 
### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).