### PR TITLE
Fix openid redirect issue to use base_redirect_url when nextUrl is absent

### DIFF
--- a/server/auth/types/openid/helper.test.ts
+++ b/server/auth/types/openid/helper.test.ts
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { composeLogoutUrl, getExpirationDate, getRootUrl } from './helper';
+import { composeLogoutUrl, getExpirationDate, getRootUrl, getNextUrl } from './helper';
 
 describe('test OIDC helper utility', () => {
   test('test compose logout url', () => {
@@ -145,5 +145,40 @@ describe('test OIDC helper utility', () => {
           'eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Imtld2lRcTlqaUM4NEN2U3NKWU9CLU42QThXRkxTVjIwTWIteTdJbFdEU1EifQ.eyJpc3MiOiJodHRwczovL2dpdGxhYi5jb20iLCJzdWIiOiI5ODc5ODQ1IiwiYXVkIjoiOTkzZWM3MTA3YjNlZmJiZTRkZDdjYmE1NDRmMDU4YTMyMmIwN2M0ZmQ5MTljMzdkMGM4ODQ5MjljYzVkM2U5NiIsImV4cCI6MTY1ODU4MjcwMCwiaWF0IjoxNjU4NTgyNTgwLCJhdXRoX3RpbWUiOjE2NTgzMjU1ODgsInN1Yl9sZWdhY3kiOiIxYWNiYzI5ZGFkOWViMGI0MjM3YTVhMTEzNzg2M2E4ZDNlNDFkOGRjOWJhMzJlYzFkOGIwMWJjODY5NzczMGM0IiwiZ3JvdXBzX2RpcmVjdCI6WyJlb3NmaW50ZWsiLCJlNDM4NyJdfQ.CVgOC3K4e95cOY2akmGBWJcSGjkyO517N_784ob2Tj3aeMpyk-O_OsbUhmt_Fu_XvqSk5dY02c1a8Ngav8_7MOsHb6MovYQsnIE0ddxtJSY2uswOWX53cE2SPU-G-s8vVLX-MfIG1_Mfg2cYE-eL2nRlSSrMug9IXiiWGoQuS0vrjuomgoq3gZnNCM-Yn-2TI3YZSsluyaODMnW2yVCeu8ZMJp6ZbCMBwAwq-dMVENF9jEHJqtRgOOP1OXJ9scapS14IHXaUrHkxlyRDRYKMZ727hQs_aMHZAlLyycz_9xI2RgZ4dTOldbXZeBUrOZvwe5ZMdok3a9LYr91clFu-pA24zHFUeFqjcVRMxhYZAD4wYdG26pYk1Otk9auvSaPd6Rsk4fK_tA7hVWCM1NMO1lhQ0RzLl4MRKx4NJrjm4jlodUGx3k_js2YtXYdKGNwWcm2ESTUgPdL1dQus3ll5Lr_wt5uY3GYjCtDA6BcZWhRewgWdmJ8hPx8JNuz3Sw2bDxjgmZqCQ4I4WMa-HncAshfZY-mLlWOkxN9kzHSXIZGa-No6_u9JZwfKdZXkK9UJMAuY4SH5PcvJitVAVDPg6EQa1Ne8AkVFOBfPF0_S3QZnW4D7kRNhs0pr-eyBb3cUACLPjS4maCccQ6MSBZ9RYy3l0wgitRv2SVIBvBH0eN4',
       })
     );
+  });
+
+  test('test getNextUrl when request.query.nextUrl is present', () => {
+    const config = {
+      openid: {
+        base_redirect_url: 'http://localhost:5601/ui',
+      },
+    };
+
+    const core = {};
+
+    const request = {
+      query: {
+        nextUrl: 'http://localhost:5601/ui/app/home',
+      },
+    };
+
+    expect('http://localhost:5601/ui/app/home').toEqual(getNextUrl(config, core, request));
+  });
+
+  test('test getNextUrl when request.query.nextUrl is absent', () => {
+    const config = {
+      openid: {
+        base_redirect_url: 'http://localhost:5601/ui',
+      },
+    };
+
+    const core = {};
+
+    const request = {
+      query: {},
+    };
+
+    // Should go to config.openid?.base_redirect_url
+    expect('http://localhost:5601/ui').toEqual(getNextUrl(config, core, request));
   });
 });

--- a/server/auth/types/openid/helper.ts
+++ b/server/auth/types/openid/helper.ts
@@ -72,6 +72,14 @@ export function getBaseRedirectUrl(
   return rootUrl;
 }
 
+export function getNextUrl(
+  config: SecurityPluginConfigType,
+  core: CoreSetup,
+  request: OpenSearchDashboardsRequest
+): string {
+  return request.query.nextUrl || getBaseRedirectUrl(config, core, request) || '/';
+}
+
 export async function callTokenEndpoint(
   tokenEndpoint: string,
   query: any,

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -27,9 +27,14 @@ import { SecuritySessionCookie } from '../../../session/security_cookie';
 import { SecurityPluginConfigType } from '../../..';
 import { OpenIdAuthConfig } from './openid_auth';
 import { SecurityClient } from '../../../backend/opensearch_security_client';
-import { getBaseRedirectUrl, callTokenEndpoint, composeLogoutUrl } from './helper';
+import {
+  getBaseRedirectUrl,
+  callTokenEndpoint,
+  composeLogoutUrl,
+  getNextUrl,
+  getExpirationDate,
+} from './helper';
 import { validateNextUrl } from '../../../utils/next_url';
-import { getExpirationDate } from './helper';
 import {
   AuthType,
   OPENID_AUTH_LOGIN,
@@ -110,7 +115,7 @@ export class OpenIdAuthRoutes {
           const cookie: SecuritySessionCookie = {
             oidc: {
               state: nonce,
-              nextUrl: request.query.nextUrl || '/',
+              nextUrl: getNextUrl(this.config, this.core, request),
             },
             authType: AuthType.OPEN_ID,
           };


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Fixes an issue on openid login that redirects to  `/` when a `opensearch_security.openid.base_redirect_url` is present and a `nextUrl` query param is absent. `opensearch_security.openid.base_redirect_url` is configured in `opensearch_dashboards.yml` and often matches the `server.basePath` which is the root url for OSD. On successful login, the user should be routed to the redirect url if nextUrl is absent. 

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Bug fix

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1098

### Testing

Adds 2 new unit tests to test when request.query.nextUrl is present and when it is absent to use the config.openid?.base_redirect_url

### Check List
- [X] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).