### PR TITLE
Updated MAINTAINERS.md format.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,9 @@
-# OpenSearch Security Maintainers
+## Overview
 
-## Maintainers
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
 | Maintainer       | GitHub ID                                             | Affiliation |
 | ---------------- | ----------------------------------------------------- | ----------- |
 | Chang Liu        | [cliu123](https://github.com/cliu123)                 | Amazon      |
@@ -10,11 +13,10 @@
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
 
-
 ## Emeritus
 
-| Maintainer | GitHub ID | Affiliation |
-| --------------- | --------- | ----------- |
-| Yan Zeng         | [zengyan-amazon](https://github.com/zengyan-amazon)   | Amazon      |
-| Bandini Bhopi    | [bandinib-amzn](https://github.com/bandinib-amzn)     | Amazon      |
-| Tianle Huang     | [tianleh](https://github.com/tianleh)                 | Amazon      |
+| Maintainer    | GitHub ID                                           | Affiliation |
+| ------------- | --------------------------------------------------- | ----------- |
+| Yan Zeng      | [zengyan-amazon](https://github.com/zengyan-amazon) | Amazon      |
+| Bandini Bhopi | [bandinib-amzn](https://github.com/bandinib-amzn)   | Amazon      |
+| Tianle Huang  | [tianleh](https://github.com/tianleh)               | Amazon      |


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/.github/issues/121, updated MAINTAINERS.md to match opensearch-project recommended format.