### PR TITLE
Change the reference branch to 2.5 for Cypress test

### DIFF
--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           path: OpenSearch-Dashboards
           repository: opensearch-project/OpenSearch-Dashboards
-          ref: '2.x'
+          ref: '2.5'
           fetch-depth: 0
       
       - name: Create plugins dir
@@ -117,7 +117,7 @@ jobs:
         with:
           path: ${{ env.FTR_PATH }}
           repository: opensearch-project/opensearch-dashboards-functional-test
-          ref: '2.x'
+          ref: '2.5'
 
       - name: Get Cypress version
         id: cypress_version


### PR DESCRIPTION
### Description
Change the reference branch to 2.5 for Cypress test
### Category
Maintenance
### Issues Resolved
* Relate https://github.com/opensearch-project/security-dashboards-plugin/issues/1286

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).