### PR TITLE
Fix plugin configuration path

### DIFF
--- a/public/apps/configuration/panels/auth-view/instruction-view.tsx
+++ b/public/apps/configuration/panels/auth-view/instruction-view.tsx
@@ -35,9 +35,9 @@ export function InstructionView(props: { config: ClientConfigType }) {
       <EuiText textAlign="center" size="xs" color="subdued" className="instruction-text">
         In order to use Security plugin, you must decide on authentication <EuiCode>authc</EuiCode>{' '}
         and authorization backends <EuiCode>authz</EuiCode>. Use{' '}
-        <EuiCode>plugins/opensearch-security/securityconfig/config.yml</EuiCode> to define how to
-        retrieve and verify the user credentials, and how to fetch additional roles from backend
-        system if needed.
+        <EuiCode>config/opensearch-security/config.yml</EuiCode> to define how to retrieve and
+        verify the user credentials, and how to fetch additional roles from backend system if
+        needed.
       </EuiText>
 
       <EuiSpacer />

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -41,7 +41,7 @@ const addBackendStep = {
     <>
       <EuiText size="s" color="subdued">
         Add authentication<EuiCode>(authc)</EuiCode>and authorization<EuiCode>(authz)</EuiCode>
-        information to<EuiCode>plugins/opensearch-security/securityconfig/config.yml</EuiCode>. The
+        information to<EuiCode>config/opensearch-security/config.yml</EuiCode>. The
         <EuiCode>authc</EuiCode> section contains the backends to check user credentials against.
         The <EuiCode>authz</EuiCode>
         section contains any backends to fetch backend roles from. The most common example of a

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -264,7 +264,7 @@ exports[`Get started (landing page) renders when backend configuration is enable
                   </EuiCode>
                   information to
                   <EuiCode>
-                    plugins/opensearch-security/securityconfig/config.yml
+                    config/opensearch-security/config.yml
                   </EuiCode>
                   . The
                   <EuiCode>


### PR DESCRIPTION
The dashboard has references to an old path that does not exist anymore:
`plugins/opensearch-security/securityconfig/config.yml`.  It was
replaced by `config/opensearch-security/config.yml` in this commit:

https://github.com/opensearch-project/security/commit/b44d7eafc1250a0d58828ef6f9cef48b5755fefc

Fix the last occurences of `plugins/opensearch-security/securityconfig`.
