### PR TITLE
Adding @scrawfor99 to the maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,6 +12,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Peter Nied       | [peternied](https://github.com/peternied)             | Amazon      |
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
+| Stephen Crawford | [scrawfor99](https://github.com/scrawfor99)           | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description
Stephen Crawford (@scrawfor99) has been an avid contributor to Security plugin & Security Dashboard plugin since October '22, clocking in with 137 contributions in the OpenSearch project.  He has earned his place as a maintainer with the following valuable contributions.

- Created [41](https://github.com/search?q=repo%3Aopensearch-project%2Fsecurity+repo%3Aopensearch-project%2Fsecurity-dashboards-plugin+author%3Ascrawfor99&type=pullrequests&ref=advsearch) pull requests.
- Involved in [55 & 31](https://github.com/search?q=repo%3Aopensearch-project%2Fsecurity+repo%3Aopensearch-project%2Fsecurity-dashboards-plugin+-author%3Ascrawfor99+involves%3Ascrawfor99+&type=pullrequests&ref=advsearch) issues and pull requests respectively.
- Mentioned in [52](https://github.com/search?q=repo%3Aopensearch-project%2Fsecurity+repo%3Aopensearch-project%2Fsecurity-dashboards-plugin+mentions%3Ascrawfor99&type=pullrequests&ref=advsearch) issues and pull requests.
- Pioneered security's open triage [opensearch-project#2164](opensearch-project#2164)

### Check List
- [ ] ~New functionality includes testing~
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).