### PR TITLE
Add indices:admin/close* to list of permissible index permissions

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -184,6 +184,7 @@ export const INDEX_PERMISSIONS: string[] = [
   'indices:admin/analyze',
   'indices:admin/cache/clear',
   'indices:admin/close',
+  'indices:admin/close*',
   'indices:admin/create',
   'indices:admin/data_stream/create',
   'indices:admin/data_stream/delete',


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Adds `indices:admin/close*` to list of permissible index permissions to cover associated close actions like [TransportVerifyShardBeforeCloseAction](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/admin/indices/close/TransportVerifyShardBeforeCloseAction.java). (Action name: `indices:admin/close[s]`)

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Bug Fix


### Issues Resolved

https://github.com/opensearch-project/security/issues/1461

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).