### PR TITLE
Switch to maven to download plugin snapshots

### DIFF
--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -17,20 +17,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Download OpenSearch for Linux
-      uses: peternied/download-file@v2
-      if: ${{ runner.os == 'Linux' }}
-      with:
-        url: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ inputs.opensearch-version }}/latest/linux/x64/tar/builds/opensearch/plugins/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}.zip
-
-    - name: Download OpenSearch for Windows
-      uses: peternied/download-file@v2
-      if: ${{ runner.os == 'Windows' }}
-      with:
-        url: https://ci.opensearch.org/ci/dbc/distribution-build-opensearch/${{ inputs.opensearch-version }}/latest/windows/x64/zip/builds/opensearch/plugins/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}.zip
-
-    - name: Rename the Plugin Files
-      run: mv opensearch-security-${{ inputs.plugin-version }}.zip opensearch-security.zip
+    - run: |
+        mvn dependency:get \
+        -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots/ \
+        -Dartifact=org.opensearch.plugin:${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip \
+        -Dtransitive=false \
+        -Ddest=${{ inputs.plugin-name }}.zip
       shell: bash
 
     - name: Create Setup Script for Linux


### PR DESCRIPTION
### Description
The Security Plugin publishing snapshots of its build through maven.  Switching from the distribution build to these maven based artifacts.

Note; The security plugin does not publish these artifacts for version 1.x so this change should not be backported.

### Issues Resolved
- Resolves https://github.com/opensearch-project/security-dashboards-plugin/issues/1328

### Testing
This change is tested through GitHub Actions associated with this project

### Check List
- [X] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).