### PR TITLE
Use deflate to compress authentication header payload in Dashboard cookie

### DIFF
--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -25,6 +25,7 @@ import { SecurityClient } from '../../../backend/opensearch_security_client';
 import { CoreSetup } from '../../../../../../src/core/server';
 import { validateNextUrl } from '../../../utils/next_url';
 import { AuthType, SAML_AUTH_LOGIN, SAML_AUTH_LOGOUT } from '../../../../common';
+import { deflateValue } from '../../../utils/compression';
 
 export class SamlAuthRoutes {
   constructor(
@@ -141,10 +142,11 @@ export class SamlAuthRoutes {
           if (tokenPayload.exp) {
             expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
           }
+          const compressedBuffer: Buffer = deflateValue(credentials.authorization);
           const cookie: SecuritySessionCookie = {
             username: user.username,
             credentials: {
-              authHeaderValue: credentials.authorization,
+              authHeaderValueCompressed: compressedBuffer.toString('base64'),
             },
             authType: AuthType.SAML, // TODO: create constant
             expiryTime,
@@ -209,10 +211,11 @@ export class SamlAuthRoutes {
             expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
           }
 
+          const compressedBuffer: Buffer = deflateValue(credentials.authorization);
           const cookie: SecuritySessionCookie = {
             username: user.username,
             credentials: {
-              authHeaderValue: credentials.authorization,
+              authHeaderValueCompressed: compressedBuffer.toString('base64'),
             },
             authType: AuthType.SAML, // TODO: create constant
             expiryTime,

--- a/server/utils/compression.ts
+++ b/server/utils/compression.ts
@@ -1,0 +1,14 @@
+import zlib, { ZlibOptions } from 'node:zlib';
+
+
+export function deflateValue(value: string, options: ZlibOptions = {}): Buffer {
+  const compressedBuffer: Buffer = zlib.deflateSync(value, options);
+
+  return compressedBuffer;
+}
+
+export function inflateValue(value: Buffer, options: ZlibOptions = {}): Buffer {
+  const uncompressedBuffer: Buffer = zlib.inflateSync(value, options);
+
+  return uncompressedBuffer;
+}


### PR DESCRIPTION
### Description

First shot at a compression-based solution for #1311 . More a RFC on the approach than a final pull request. Covers so far only SAML. OIDC will come when we have the concept straight.

Uses deflate compression to compress the main payload of the Dashboards security cookie when SAML auth is active. This might help with issues in environments where users have big amounts of roles or attributes. Such users can have trouble with logging into Dashboards because the security cookie - which carries this information encoded in a JWT - gets too big.

The deflated value is written into the attribute authHeaderValueCompressed inside the cookie. This allows us to tell new cookies apart from cookies written with an earlier version and to support both.

#### Issues and Limitations

- Obviously, this only moves the bar at which users might get issues. 
- By default, dashboards (and the underlying Hapi) manage the session storage as follows: First, the payload is JSON encoded. Then, the payload is encrypted using Iron encryption and base64 encoded. As the deflate output is binary, we need to encode it to base64 in order to properly represent it in JSON. However, this again blows the payload size up a bit which we just compressed before.
- We still need some example payloads to verify the actual effectiveness of this change.


### Category

- Bug fix

### Why these changes are required?

Allow users with many roles to authenticate with SAML in Dashboards.

### What is the old behavior before changes and new behavior after changes?

Such users could not log in into Dashboards.

### Issues Resolved

- #1311 
- #516 

### Testing

- Unit testing
- We still need some sample payloads to verify the effectiveness

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
