### PR TITLE
Add auto-release workflow

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,29 @@
+name: Releases
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+      - name: Get tag
+        id: tag
+        uses: dawidd6/action-get-tag@v1
+      - uses: actions/checkout@v2
+      - uses: ncipollo/release-action@v1
+        with:
+          github_token: ${{ steps.github_app_token.outputs.token }}
+          bodyFile: release-notes/opensearch-security-dashboards-plugin.release-notes-${{steps.tag.outputs.tag}}.md


### PR DESCRIPTION
### Description

This adds an auto-release workflow to automatically generate a release with the corresponding release notes when a tag is created.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Enhancement

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1324

### Testing

Tested by creating a Github App and running the workflow in my personal fork. I believe the installation_id corresponds to the opensearch-trigger-bot installation, but I'm not positive. The number is also referenced in the backport workflow here: https://github.com/opensearch-project/security-dashboards-plugin/blob/main/.github/workflows/backport.yml#L19-L22

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).