### PR TITLE
No blank backend role before adding a new one in Create User page

### DIFF
--- a/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
@@ -38,7 +38,6 @@ function generateBackendRolesPanels(
   roleEmptyErrorMessage: string,
   setRoleEmptyErrorMessage: Dispatch<SetStateAction<string>>
 ) {
-
   const panels = backendRoles.map((backendRole, arrayIndex) => {
     return (
       <Fragment key={`backend-role-${arrayIndex}`}>
@@ -47,16 +46,16 @@ function generateBackendRolesPanels(
             <EuiFormRow
               label={arrayIndex === 0 ? 'Backend role' : ''}
               error={roleEmptyErrorMessage}
-              isInvalid={arrayIndex === emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}>
+              isInvalid={arrayIndex === emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}
+            >
               <EuiFieldText
                 isInvalid={arrayIndex === emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}
                 id={`backend-role-${arrayIndex}`}
                 value={backendRole}
                 onChange={(e) => {
                   updateElementInArrayHandler(setBackendRoles, [arrayIndex])(e.target.value);
-                  setRoleEmptyErrorMessage("");
-                }
-                }
+                  setRoleEmptyErrorMessage('');
+                }}
                 placeholder="Type in backend role"
               />
             </EuiFormRow>
@@ -85,7 +84,7 @@ export function BackendRolePanel(props: {
   setState: Dispatch<SetStateAction<string[]>>;
 }) {
   const { state, setState } = props;
-  const [roleEmptyErrorMessage, setRoleEmptyErrorMessage] = useState("");
+  const [roleEmptyErrorMessage, setRoleEmptyErrorMessage] = useState('');
   const [emptyRoleIndex, setEmptyRoleIndex] = useState(-1);
   // Show one empty row if there is no data.
   if (isEmpty(state)) {
@@ -103,17 +102,17 @@ export function BackendRolePanel(props: {
         setState,
         emptyRoleIndex,
         roleEmptyErrorMessage,
-        setRoleEmptyErrorMessage,
+        setRoleEmptyErrorMessage
       )}
       <EuiSpacer />
       <EuiButton
         id="backend-role-add-row"
         onClick={() => {
           if (state.indexOf('') !== -1) {
-            setRoleEmptyErrorMessage("Type a backend role before adding a new one")
+            setRoleEmptyErrorMessage('Type a backend role before adding a new one');
             setEmptyRoleIndex(state.indexOf(''));
           } else {
-            setRoleEmptyErrorMessage("");
+            setRoleEmptyErrorMessage('');
             appendElementToArray(setState, [], '');
           }
         }}

--- a/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
@@ -34,8 +34,9 @@ import { DocLinks, LIMIT_WIDTH_INPUT_CLASS } from '../../constants';
 function generateBackendRolesPanels(
   backendRoles: string[],
   setBackendRoles: Dispatch<SetStateAction<string[]>>,
-  lastRoleEmptyErrorMessage: string,
-  setLastRoleEmptyErrorMessage: Dispatch<SetStateAction<string>>
+  emptyRoleIndex: number,
+  roleEmptyErrorMessage: string,
+  setRoleEmptyErrorMessage: Dispatch<SetStateAction<string>>
 ) {
 
   const panels = backendRoles.map((backendRole, arrayIndex) => {
@@ -45,15 +46,15 @@ function generateBackendRolesPanels(
           <EuiFlexItem className={LIMIT_WIDTH_INPUT_CLASS}>
             <EuiFormRow
               label={arrayIndex === 0 ? 'Backend role' : ''}
-              error={lastRoleEmptyErrorMessage}
-              isInvalid={arrayIndex == backendRoles.length - 1 && !isEmpty(lastRoleEmptyErrorMessage)}>
+              error={roleEmptyErrorMessage}
+              isInvalid={arrayIndex === emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}>
               <EuiFieldText
-                isInvalid={arrayIndex == backendRoles.length - 1 && !isEmpty(lastRoleEmptyErrorMessage)}
+                isInvalid={arrayIndex == emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}
                 id={`backend-role-${arrayIndex}`}
                 value={backendRole}
                 onChange={(e) => {
                   updateElementInArrayHandler(setBackendRoles, [arrayIndex])(e.target.value);
-                  setLastRoleEmptyErrorMessage("");
+                  setRoleEmptyErrorMessage("");
                 }
                 }
                 placeholder="Type in backend role"
@@ -84,7 +85,8 @@ export function BackendRolePanel(props: {
   setState: Dispatch<SetStateAction<string[]>>;
 }) {
   const { state, setState } = props;
-  const [lastRoleEmptyErrorMessage, setLastRoleEmptyErrorMessage] = useState("");
+  const [roleEmptyErrorMessage, setRoleEmptyErrorMessage] = useState("");
+  const [emptyRoleIndex, setEmptyRoleIndex] = useState(-1);
   // Show one empty row if there is no data.
   if (isEmpty(state)) {
     setState(['']);
@@ -99,19 +101,20 @@ export function BackendRolePanel(props: {
       {generateBackendRolesPanels(
         state,
         setState,
-        lastRoleEmptyErrorMessage,
-        setLastRoleEmptyErrorMessage,
+        emptyRoleIndex,
+        roleEmptyErrorMessage,
+        setRoleEmptyErrorMessage,
       )}
       <EuiSpacer />
       <EuiButton
         id="backend-role-add-row"
         onClick={() => {
-          if (state[state.length - 1] === '') {
-            setLastRoleEmptyErrorMessage("Type a backend role before adding a new one")
+          if (state.indexOf('') != -1) {
+            setRoleEmptyErrorMessage("Type a backend role before adding a new one")
+            setEmptyRoleIndex(state.indexOf(''));
           } else {
-            setLastRoleEmptyErrorMessage("");
+            setRoleEmptyErrorMessage("");
             appendElementToArray(setState, [], '');
-
           }
         }}
       >

--- a/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
@@ -49,7 +49,7 @@ function generateBackendRolesPanels(
               error={roleEmptyErrorMessage}
               isInvalid={arrayIndex === emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}>
               <EuiFieldText
-                isInvalid={arrayIndex == emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}
+                isInvalid={arrayIndex === emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}
                 id={`backend-role-${arrayIndex}`}
                 value={backendRole}
                 onChange={(e) => {
@@ -109,7 +109,7 @@ export function BackendRolePanel(props: {
       <EuiButton
         id="backend-role-add-row"
         onClick={() => {
-          if (state.indexOf('') != -1) {
+          if (state.indexOf('') !== -1) {
             setRoleEmptyErrorMessage("Type a backend role before adding a new one")
             setEmptyRoleIndex(state.indexOf(''));
           } else {

--- a/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
@@ -22,35 +22,43 @@ import {
   EuiFormRow,
 } from '@elastic/eui';
 import { isEmpty } from 'lodash';
-import React, { Dispatch, Fragment, SetStateAction } from 'react';
+import React, { Dispatch, Fragment, SetStateAction, useState } from 'react';
 import {
   appendElementToArray,
   removeElementFromArray,
   updateElementInArrayHandler,
 } from '../../utils/array-state-utils';
 import { PanelWithHeader } from '../../utils/panel-with-header';
-import { FormRow } from '../../utils/form-row';
 import { DocLinks, LIMIT_WIDTH_INPUT_CLASS } from '../../constants';
 
 function generateBackendRolesPanels(
   backendRoles: string[],
-  setBackendRoles: Dispatch<SetStateAction<string[]>>
+  setBackendRoles: Dispatch<SetStateAction<string[]>>,
+  lastRoleEmptyErrorMessage: string,
+  setLastRoleEmptyErrorMessage: Dispatch<SetStateAction<string>>
 ) {
+
   const panels = backendRoles.map((backendRole, arrayIndex) => {
     return (
       <Fragment key={`backend-role-${arrayIndex}`}>
         <EuiFlexGroup>
           <EuiFlexItem className={LIMIT_WIDTH_INPUT_CLASS}>
-            <FormRow headerText={arrayIndex === 0 ? 'Backend role' : ''}>
+            <EuiFormRow
+              label={arrayIndex === 0 ? 'Backend role' : ''}
+              error={lastRoleEmptyErrorMessage}
+              isInvalid={arrayIndex == backendRoles.length - 1 && !isEmpty(lastRoleEmptyErrorMessage)}>
               <EuiFieldText
+                isInvalid={arrayIndex == backendRoles.length - 1 && !isEmpty(lastRoleEmptyErrorMessage)}
                 id={`backend-role-${arrayIndex}`}
                 value={backendRole}
-                onChange={(e) =>
-                  updateElementInArrayHandler(setBackendRoles, [arrayIndex])(e.target.value)
+                onChange={(e) => {
+                  updateElementInArrayHandler(setBackendRoles, [arrayIndex])(e.target.value);
+                  setLastRoleEmptyErrorMessage("");
+                }
                 }
                 placeholder="Type in backend role"
               />
-            </FormRow>
+            </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFormRow hasEmptyLabelSpace={arrayIndex === 0 ? true : false}>
@@ -67,6 +75,7 @@ function generateBackendRolesPanels(
       </Fragment>
     );
   });
+
   return <>{panels}</>;
 }
 
@@ -75,6 +84,7 @@ export function BackendRolePanel(props: {
   setState: Dispatch<SetStateAction<string[]>>;
 }) {
   const { state, setState } = props;
+  const [lastRoleEmptyErrorMessage, setLastRoleEmptyErrorMessage] = useState("");
   // Show one empty row if there is no data.
   if (isEmpty(state)) {
     setState(['']);
@@ -86,12 +96,23 @@ export function BackendRolePanel(props: {
       helpLink={DocLinks.AccessControlDoc}
       optional
     >
-      {generateBackendRolesPanels(state, setState)}
+      {generateBackendRolesPanels(
+        state,
+        setState,
+        lastRoleEmptyErrorMessage,
+        setLastRoleEmptyErrorMessage,
+      )}
       <EuiSpacer />
       <EuiButton
         id="backend-role-add-row"
         onClick={() => {
-          appendElementToArray(setState, [], '');
+          if (state[state.length - 1] === '') {
+            setLastRoleEmptyErrorMessage("Type a backend role before adding a new one")
+          } else {
+            setLastRoleEmptyErrorMessage("");
+            appendElementToArray(setState, [], '');
+
+          }
         }}
       >
         Add another backend role

--- a/public/apps/configuration/panels/internal-user-edit/test/__snapshots__/backend-role-panel.test.tsx.snap
+++ b/public/apps/configuration/panels/internal-user-edit/test/__snapshots__/backend-role-panel.test.tsx.snap
@@ -1,0 +1,125 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`User editing - backend role panel BackendRolePanel add backend role when one of the previous roles is blank 1`] = `
+<PanelWithHeader
+  headerSubText="Backend roles are used to map users from external authentication systems, such as LDAP or SAML to OpenSearch security roles."
+  headerText="Backend roles"
+  helpLink="https://opensearch.org/docs/latest/security-plugin/access-control/index/"
+  optional={true}
+>
+  <EuiFlexGroup>
+    <EuiFlexItem
+      className="limit-width-input"
+    >
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        error=""
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        isInvalid={false}
+        label="Backend role"
+        labelType="label"
+      >
+        <EuiFieldText
+          id="backend-role-0"
+          isInvalid={false}
+          onChange={[Function]}
+          placeholder="Type in backend role"
+          value="admin"
+        />
+      </EuiFormRow>
+    </EuiFlexItem>
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={true}
+        labelType="label"
+      >
+        <EuiButton
+          color="danger"
+          id="backend-role-delete-0"
+          onClick={[Function]}
+        >
+          Remove
+        </EuiButton>
+      </EuiFormRow>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <EuiFlexGroup>
+    <EuiFlexItem
+      className="limit-width-input"
+    >
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        error=""
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        isInvalid={false}
+        label=""
+        labelType="label"
+      >
+        <EuiFieldText
+          id="backend-role-1"
+          isInvalid={false}
+          onChange={[Function]}
+          placeholder="Type in backend role"
+          value="HR"
+        />
+      </EuiFormRow>
+    </EuiFlexItem>
+    <EuiFlexItem
+      grow={false}
+    >
+      <EuiFormRow
+        describedByIds={Array []}
+        display="row"
+        fullWidth={false}
+        hasChildLabel={true}
+        hasEmptyLabelSpace={false}
+        labelType="label"
+      >
+        <EuiButton
+          color="danger"
+          id="backend-role-delete-1"
+          onClick={[Function]}
+        >
+          Remove
+        </EuiButton>
+      </EuiFormRow>
+    </EuiFlexItem>
+  </EuiFlexGroup>
+  <EuiSpacer />
+  <EuiButton
+    id="backend-role-add-row"
+    onClick={[Function]}
+  >
+    Add another backend role
+  </EuiButton>
+</PanelWithHeader>
+`;
+
+exports[`User editing - backend role panel BackendRolePanel add backend role when the previous role is blank 1`] = `
+<PanelWithHeader
+  headerSubText="Backend roles are used to map users from external authentication systems, such as LDAP or SAML to OpenSearch security roles."
+  headerText="Backend roles"
+  helpLink="https://opensearch.org/docs/latest/security-plugin/access-control/index/"
+  optional={true}
+>
+  <EuiSpacer />
+  <EuiButton
+    id="backend-role-add-row"
+    onClick={[Function]}
+  >
+    Add another backend role
+  </EuiButton>
+</PanelWithHeader>
+`;

--- a/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
@@ -13,8 +13,8 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiFieldText, EuiFlexGroup } from '@elastic/eui';
-import { shallow } from 'enzyme';
+import { EuiFieldText, EuiFlexGroup, EuiFormRow } from '@elastic/eui';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
 import {
   appendElementToArray,
@@ -27,6 +27,7 @@ jest.mock('../../../utils/array-state-utils', () => ({
   appendElementToArray: jest.fn(),
   removeElementFromArray: jest.fn(),
   updateElementInArrayHandler: jest.fn().mockReturnValue(jest.fn()),
+  setRoleEmptyErrorMessage: jest.fn()
 }));
 
 describe('User editing - backend role panel', () => {
@@ -71,5 +72,22 @@ describe('User editing - backend role panel', () => {
 
       expect(removeElementFromArray).toBeCalledWith(setState, [], 0);
     });
+
+    // TODO: Fix the tests for backend role error message
+    it('add backend role when the previous role is blank', () => {
+      const component = shallow(<BackendRolePanel state={[]} setState={setState} />);
+      component.find('#backend-role-add-row').simulate('click');
+      component.find('#backend-role-add-row').simulate('click');
+      expect(component).toMatchSnapshot();
+    });
+
+
+    it('add backend role when one of the previous roles is blank', () => {
+      const component = shallow(<BackendRolePanel state={sampleState} setState={setState} />);
+      component.find('#backend-role-0').simulate('change', { target: { value: '' } });
+      component.find('#backend-role-add-row').simulate('click');
+      expect(component).toMatchSnapshot();
+    });
+
   });
 });

--- a/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
@@ -27,7 +27,7 @@ jest.mock('../../../utils/array-state-utils', () => ({
   appendElementToArray: jest.fn(),
   removeElementFromArray: jest.fn(),
   updateElementInArrayHandler: jest.fn().mockReturnValue(jest.fn()),
-  setRoleEmptyErrorMessage: jest.fn()
+  setRoleEmptyErrorMessage: jest.fn(),
 }));
 
 describe('User editing - backend role panel', () => {
@@ -81,13 +81,11 @@ describe('User editing - backend role panel', () => {
       expect(component).toMatchSnapshot();
     });
 
-
     it('add backend role when one of the previous roles is blank', () => {
       const component = shallow(<BackendRolePanel state={sampleState} setState={setState} />);
       component.find('#backend-role-0').simulate('change', { target: { value: '' } });
       component.find('#backend-role-add-row').simulate('click');
       expect(component).toMatchSnapshot();
     });
-
   });
 });


### PR DESCRIPTION
### Description
Perform a check on the list of backend roles whether it contains an empty value. If it does, display an error message and don't allow the user to create additional backend roles until the existing blank panels are filled with values.

### Category
[Bug fix]

### Why these changes are required?
Those changes help to make UX more intuitive and also prevent undesired user behaviour.

### What is the old behavior before changes and new behavior after changes?
Before the changes, new empty backend roles were added every time the "Add another backend role" button was clicked.
After the change, it is checked whether there are any empty fields before adding a new one.

### Issues Resolved
* Resolve: https://github.com/opensearch-project/security-dashboards-plugin/issues/1307

### Testing
- First case : the user tries to add a new backend role while the last text field is empty.
![image](https://user-images.githubusercontent.com/39532643/227048842-4788db09-d8aa-45a6-870a-424acb2692d9.png)
![image](https://user-images.githubusercontent.com/39532643/227048941-496bc42a-46a7-4aa9-b361-1b3d47cf1657.png)

- Second case: the user tries to add a new backend role while any previously created text field is empty
![image](https://user-images.githubusercontent.com/39532643/227049045-16ca5124-3853-4ab5-81de-743b65b3a57e.png)

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).