### PR TITLE
Dynamic tenancy configurations

### DIFF
--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -70,3 +70,5 @@ jobs:
           cd opensearch-dashboards-functional-test
           npm install cypress --save-dev
           yarn cypress:run-with-security-and-aggregation-view --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js"
+          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js"
+          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/default_tenant.js"

--- a/common/index.ts
+++ b/common/index.ts
@@ -23,6 +23,7 @@ export const OPENDISTRO_SECURITY_ANONYMOUS = 'opendistro_security_anonymous';
 export const API_PREFIX = '/api/v1';
 export const CONFIGURATION_API_PREFIX = 'configuration';
 export const API_ENDPOINT_AUTHINFO = API_PREFIX + '/auth/authinfo';
+export const API_ENDPOINT_DASHBOARDSINFO = API_PREFIX + '/auth/dashboardsinfo';
 export const API_ENDPOINT_AUTHTYPE = API_PREFIX + '/auth/type';
 export const LOGIN_PAGE_URI = '/app/' + APP_ID_LOGIN;
 export const CUSTOM_ERROR_PAGE_URI = '/app/' + APP_ID_CUSTOMERROR;

--- a/public/apps/account/test/account-nav-button.test.tsx
+++ b/public/apps/account/test/account-nav-button.test.tsx
@@ -17,11 +17,24 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { AccountNavButton } from '../account-nav-button';
 import { getShouldShowTenantPopup, setShouldShowTenantPopup } from '../../../utils/storage-utils';
+import { getDashboardsInfo } from '../../../utils/dashboards-info-utils';
 
 jest.mock('../../../utils/storage-utils', () => ({
   getShouldShowTenantPopup: jest.fn(),
   setShouldShowTenantPopup: jest.fn(),
 }));
+
+jest.mock('../../../utils/dashboards-info-utils', () => ({
+  getDashboardsInfo: jest.fn().mockImplementation(() => {
+    return mockDashboardsInfo;
+  }),
+}));
+
+const mockDashboardsInfo = {
+  multitenancy_enabled: true,
+  private_tenant_enabled: true,
+  default_tenant: '',
+};
 
 describe('Account navigation button', () => {
   const mockCoreStart = {
@@ -49,6 +62,9 @@ describe('Account navigation button', () => {
 
   beforeEach(() => {
     useStateSpy.mockImplementation((init) => [init, setState]);
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
     component = shallow(
       <AccountNavButton
         coreStart={mockCoreStart}
@@ -66,10 +82,16 @@ describe('Account navigation button', () => {
   });
 
   it('renders', () => {
+    (getDashboardsInfo as jest.Mock).mockImplementationOnce(() => {
+      return mockDashboardsInfo;
+    });
     expect(component).toMatchSnapshot();
   });
 
   it('should set modal when show popup is true', () => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
     (getShouldShowTenantPopup as jest.Mock).mockReturnValueOnce(true);
     shallow(
       <AccountNavButton
@@ -132,6 +154,13 @@ describe('Account navigation button, multitenancy disabled', () => {
   });
 
   it('should not set modal when show popup is true', () => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return {
+        multitenancy_enabled: false,
+        private_tenant_enabled: false,
+        default_tenant: '',
+      };
+    });
     (getShouldShowTenantPopup as jest.Mock).mockReturnValueOnce(true);
     shallow(
       <AccountNavButton
@@ -142,6 +171,6 @@ describe('Account navigation button, multitenancy disabled', () => {
         currAuthType={'dummy'}
       />
     );
-    expect(setState).toBeCalledTimes(0);
+    expect(setState).toBeCalledTimes(1);
   });
 });

--- a/public/apps/account/test/tenant-switch-panel.test.tsx
+++ b/public/apps/account/test/tenant-switch-panel.test.tsx
@@ -16,6 +16,7 @@
 import { shallow } from 'enzyme';
 import React from 'react';
 import { fetchAccountInfo } from '../utils';
+import { getDashboardsInfo } from '../../../utils/dashboards-info-utils';
 import {
   CUSTOM_TENANT_RADIO_ID,
   GLOBAL_TENANT_RADIO_ID,
@@ -39,9 +40,21 @@ const mockAccountInfo = {
   },
 };
 
+const mockDashboardsInfo = {
+  multitenancy_enabled: true,
+  private_tenant_enabled: true,
+  default_tenant: '',
+};
+
 jest.mock('../utils', () => ({
   fetchAccountInfo: jest.fn().mockImplementation(() => {
     return mockAccountInfo;
+  }),
+}));
+
+jest.mock('../../../utils/dashboards-info-utils', () => ({
+  getDashboardsInfo: jest.fn().mockImplementation(() => {
+    return mockDashboardsInfo;
   }),
 }));
 
@@ -76,9 +89,15 @@ describe('Account menu -tenant switch panel', () => {
   beforeEach(() => {
     useEffect.mockImplementationOnce((f) => f());
     useState.mockImplementation((initialValue) => [initialValue, setState]);
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
   });
 
   it('fetch data when user requested tenant is Global', (done) => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
     shallow(
       <TenantSwitchPanel
         coreStart={mockCoreStart as any}
@@ -98,6 +117,9 @@ describe('Account menu -tenant switch panel', () => {
   });
 
   it('fetch data when user requested tenant is Private', (done) => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
     (fetchAccountInfo as jest.Mock).mockImplementationOnce(() => {
       return {
         data: {
@@ -126,6 +148,9 @@ describe('Account menu -tenant switch panel', () => {
   });
 
   it('fetch data when user requested tenant is Custom', (done) => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
     (fetchAccountInfo as jest.Mock).mockImplementationOnce(() => {
       return {
         data: {
@@ -155,6 +180,9 @@ describe('Account menu -tenant switch panel', () => {
   });
 
   it('error occurred while fetching data', (done) => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
     (fetchAccountInfo as jest.Mock).mockImplementationOnce(() => {
       throw new Error();
     });
@@ -174,6 +202,9 @@ describe('Account menu -tenant switch panel', () => {
   });
 
   it('handle modal close', () => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
     const component = shallow(
       <TenantSwitchPanel
         coreStart={mockCoreStart as any}
@@ -187,6 +218,13 @@ describe('Account menu -tenant switch panel', () => {
   });
 
   it('Confirm button should be disabled when multitenancy is disabled in Config', () => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return {
+        multitenancy_enabled: false,
+        private_tenant_enabled: true,
+        default_tenant: '',
+      };
+    });
     const config = {
       multitenancy: {
         enabled: false,
@@ -204,11 +242,16 @@ describe('Account menu -tenant switch panel', () => {
         config={config as any}
       />
     );
-    const confirmButton = component.find('[data-test-subj="confirm"]');
-    expect(confirmButton.prop('disabled')).toBe(true);
+    process.nextTick(() => {
+      const confirmButton = component.find('[data-test-subj="confirm"]');
+      expect(confirmButton.prop('disabled')).toBe(true);
+    });
   });
 
   it('selected radio id should be change on onChange event', () => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
     const component = shallow(
       <TenantSwitchPanel
         coreStart={mockCoreStart as any}
@@ -226,6 +269,9 @@ describe('Account menu -tenant switch panel', () => {
   });
 
   it('should set error call out when tenant name is undefined', () => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
     const component = shallow(
       <TenantSwitchPanel
         coreStart={mockCoreStart as any}
@@ -319,6 +365,9 @@ describe('Account menu -tenant switch panel', () => {
     });
 
     it('renders when both global and private tenant enabled', () => {
+      (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+        return mockDashboardsInfo;
+      });
       const component = shallow(
         <TenantSwitchPanel
           coreStart={mockCoreStart as any}
@@ -331,6 +380,9 @@ describe('Account menu -tenant switch panel', () => {
     });
 
     it('renders when global tenant disabled', () => {
+      (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+        return mockDashboardsInfo;
+      });
       const config = {
         multitenancy: {
           enabled: true,
@@ -351,7 +403,14 @@ describe('Account menu -tenant switch panel', () => {
       expect(component).toMatchSnapshot();
     });
 
-    it('renders when private tenant disabled', (done) => {
+    it('renders when private tenant disabled', () => {
+      (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+        return {
+          multitenancy_enabled: true,
+          private_tenant_enabled: false,
+          default_tenant: '',
+        };
+      });
       const config = {
         multitenancy: {
           enabled: true,
@@ -369,13 +428,13 @@ describe('Account menu -tenant switch panel', () => {
           config={config as any}
         />
       );
-      process.nextTick(() => {
-        expect(component).toMatchSnapshot();
-        done();
-      });
+      expect(component).toMatchSnapshot();
     });
 
-    it('renders when user has read only role', (done) => {
+    it('renders when user has read only role', () => {
+      (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+        return mockDashboardsInfo;
+      });
       useState.mockImplementationOnce(() => [['readonly'], setState]);
       useState.mockImplementationOnce(() => ['', setState]);
       const config = {
@@ -398,13 +457,13 @@ describe('Account menu -tenant switch panel', () => {
           config={config as any}
         />
       );
-      process.nextTick(() => {
-        expect(component).toMatchSnapshot();
-        done();
-      });
+      expect(component).toMatchSnapshot();
     });
 
-    it('renders when user has default read only role', (done) => {
+    it('renders when user has default read only role', () => {
+      (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+        return mockDashboardsInfo;
+      });
       useState.mockImplementationOnce(() => [['kibana_read_only'], setState]);
       useState.mockImplementationOnce(() => ['', setState]);
       const config = {
@@ -427,10 +486,7 @@ describe('Account menu -tenant switch panel', () => {
           config={config as any}
         />
       );
-      process.nextTick(() => {
-        expect(component).toMatchSnapshot();
-        done();
-      });
+      expect(component).toMatchSnapshot();
     });
   });
 });

--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -62,6 +62,14 @@ const ROUTE_MAP: { [key: string]: RouteItem } = {
     name: 'Tenants',
     href: buildUrl(ResourceType.tenants),
   },
+  [ResourceType.tenantsManageTab]: {
+    name: 'TenantsManageTab',
+    href: buildUrl(ResourceType.tenantsManageTab),
+  },
+  [ResourceType.tenantsConfigureTab]: {
+    name: '',
+    href: buildUrl(ResourceType.tenantsConfigureTab),
+  },
   [ResourceType.auth]: {
     name: 'Authentication',
     href: buildUrl(ResourceType.auth),
@@ -80,6 +88,7 @@ const ROUTE_LIST = [
   ROUTE_MAP[ResourceType.permissions],
   ROUTE_MAP[ResourceType.tenants],
   ROUTE_MAP[ResourceType.auditLogging],
+  ROUTE_MAP[ResourceType.tenantsConfigureTab],
 ];
 
 const allNavPanelUrls = ROUTE_LIST.map((route) => route.href).concat([
@@ -232,7 +241,14 @@ export function AppRouter(props: AppDependencies) {
               path={ROUTE_MAP.tenants.href}
               render={() => {
                 setGlobalBreadcrumbs(ResourceType.tenants);
-                return <TenantList {...props} />;
+                return <TenantList tabID={'Manage'} {...props} />;
+              }}
+            />
+            <Route
+              path={ROUTE_MAP.tenantsConfigureTab.href}
+              render={() => {
+                setGlobalBreadcrumbs(ResourceType.tenants);
+                return <TenantList tabID={'Configure'} {...props} />;
               }}
             />
             <Route

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -22,6 +22,7 @@ export const API_ENDPOINT_ROLESMAPPING = API_ENDPOINT + '/rolesmapping';
 export const API_ENDPOINT_ACTIONGROUPS = API_ENDPOINT + '/actiongroups';
 export const API_ENDPOINT_TENANTS = API_ENDPOINT + '/tenants';
 export const API_ENDPOINT_MULTITENANCY = API_PREFIX + '/multitenancy/tenant';
+export const API_ENDPOINT_TENANCY_CONFIGS = API_ENDPOINT + '/tenancy/config';
 export const API_ENDPOINT_SECURITYCONFIG = API_ENDPOINT + '/securityconfig';
 export const API_ENDPOINT_INTERNALUSERS = API_ENDPOINT + '/internalusers';
 export const API_ENDPOINT_AUDITLOGGING = API_ENDPOINT + '/audit';
@@ -345,6 +346,7 @@ export const DocLinks = {
     'https://opensearch.org/docs/latest/security-plugin/access-control/document-level-security/',
   TenantPermissionsDoc:
     'https://opensearch.org/docs/latest/security-plugin/multi-tenancy/multi-tenancy-config',
+  MultiTenancyDoc: 'https://opensearch.org/docs/latest/security/multi-tenancy/tenant-index/',
   AttributeBasedSecurityDoc:
     'https://opensearch.org/docs/latest/security-plugin/access-control/document-level-security/#attribute-based-security',
   BackendRoleDoc:

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -15,25 +15,31 @@
 
 import {
   EuiButton,
+  EuiCode,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiImage,
+  EuiPageHeader,
+  EuiPanel,
+  EuiSpacer,
+  EuiSteps,
   EuiText,
   EuiTitle,
-  EuiSteps,
-  EuiCode,
-  EuiSpacer,
-  EuiImage,
-  EuiFlexItem,
-  EuiFlexGroup,
-  EuiPanel,
-  EuiPageHeader,
 } from '@elastic/eui';
 import React from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
+import { flow } from 'lodash';
+import { HashRouter as Router, Route } from 'react-router-dom';
 import { AppDependencies } from '../../types';
 import securityStepsDiagram from '../../../assets/get_started.svg';
-import { buildHashUrl } from '../utils/url-builder';
-import { Action, ResourceType } from '../types';
+import { buildHashUrl, buildUrl } from '../utils/url-builder';
+import { Action, ResourceType, RouteItem } from '../types';
 import { API_ENDPOINT_CACHE, DocLinks } from '../constants';
 import { ExternalLink, ExternalLinkButton } from '../utils/display-utils';
+import { TenantList } from './tenant-list/tenant-list';
+import { getBreadcrumbs } from '../app-router';
+
+import { CrossPageToast } from '../cross-page-toast';
 
 const addBackendStep = {
   title: 'Add backends',
@@ -245,6 +251,42 @@ export function GetStarted(props: AppDependencies) {
             >
               Purge cache
             </EuiButton>
+          </EuiText>
+        </EuiPanel>
+
+        <EuiSpacer size="l" />
+
+        <EuiPanel paddingSize="l">
+          <EuiTitle size="s">
+            <h3>Optional: Multi-tenancy</h3>
+          </EuiTitle>
+          <EuiText size="s" color="subdued">
+            <p>
+              By default tenancy is activated in Dashboards. Tenants in OpenSearch Dashboards are
+              spaces for saving index patterns, visualizations, dashboards, and other OpenSearch
+              Dashboards objects.
+            </p>
+            <EuiFlexGroup gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  fill
+                  onClick={() => {
+                    window.location.href = buildHashUrl(ResourceType.tenants);
+                  }}
+                >
+                  Manage Multi-tenancy
+                </EuiButton>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  onClick={() => {
+                    window.location.href = buildHashUrl(ResourceType.tenantsConfigureTab);
+                  }}
+                >
+                  Configure Multi-tenancy
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </EuiText>
         </EuiPanel>
       </div>

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -67,7 +67,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
     const fetchData = async () => {
       try {
         const rawTenantData = await fetchTenants(props.coreStart.http);
-        const processedTenantData = transformTenantData(rawTenantData, false);
+        const processedTenantData = transformTenantData(rawTenantData);
         setTenantPermissionDetail(
           transformRoleTenantPermissionData(props.tenantPermissions, processedTenantData)
         );
@@ -192,7 +192,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
     <>
       <PanelWithHeader
         headerText={headerText}
-        headerSubText="Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations, dashboards, and other OpenSearch Dashboards objects. 
+        headerSubText="Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations, dashboards, and other OpenSearch Dashboards objects.
         Tenants are useful for safely sharing your work with other OpenSearch Dashboards users. You can control which roles have access to a tenant and whether those roles have read or write access."
         helpLink={DocLinks.TenantPermissionsDoc}
         count={tenantPermissionDetail.length}

--- a/public/apps/configuration/panels/tenancy-config/types.tsx
+++ b/public/apps/configuration/panels/tenancy-config/types.tsx
@@ -13,17 +13,8 @@
  *   permissions and limitations under the License.
  */
 
-import { AppMountParameters, CoreStart } from '../../../../src/core/public';
-import { SecurityPluginStartDependencies, ClientConfigType, DashboardsInfo } from '../types';
-
-export interface AppDependencies {
-  coreStart: CoreStart;
-  navigation: SecurityPluginStartDependencies;
-  params: AppMountParameters;
-  config: ClientConfigType;
-  dashboardsInfo: DashboardsInfo;
-}
-
-export interface BreadcrumbsPageDependencies extends AppDependencies {
-  buildBreadcrumbs: (pageTitle: string, subAction?: string) => void;
+export interface TenancyConfigSettings {
+  multitenancy_enabled?: boolean;
+  private_tenant_enabled?: boolean;
+  default_tenant: string;
 }

--- a/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
+++ b/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
@@ -1,0 +1,477 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiInMemoryTable,
+  EuiLink,
+  EuiPageBody,
+  EuiPageContent,
+  EuiPageContentHeader,
+  EuiPageContentHeaderSection,
+  EuiPageHeader,
+  EuiText,
+  EuiTitle,
+  EuiGlobalToastList,
+  EuiSwitch,
+  Query,
+  EuiHorizontalRule,
+  EuiFormRow,
+  EuiDescribedFormGroup,
+  EuiSpacer,
+  EuiCheckbox,
+  EuiModal,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiCodeBlock,
+  EuiCallOut,
+  EuiBottomBar,
+  EuiComboBox,
+  EuiIcon,
+  EuiPanel,
+} from '@elastic/eui';
+import { ChangeEvent } from 'react';
+import React, { ReactNode, useState, useCallback } from 'react';
+import { SaveChangesModalGenerator } from './save_changes_modal';
+import { AppDependencies } from '../../../types';
+import { displayBoolean } from '../../utils/display-utils';
+import { updateAuditLogging } from '../../utils/audit-logging-utils';
+import { AuditLoggingSettings } from '../audit-logging/types';
+import { AuthInfo } from '../../../../types';
+import { updateTenancyConfig } from '../../utils/tenancy-config_util';
+import { TenancyConfigSettings } from '../tenancy-config/types';
+import { getAuthInfo } from '../../../../utils/auth-info-utils';
+import {
+  fetchTenants,
+  transformTenantData,
+  updateTenancyConfiguration,
+  updateTenant,
+} from '../../utils/tenant-utils';
+import { Action, Tenant } from '../../types';
+import { showTableStatusMessage } from '../../utils/loading-spinner-utils';
+import { useContextMenuState } from '../../utils/context-menu';
+import { TenantEditModal } from './edit-modal';
+import {
+  createTenancyErrorToast,
+  createTenancySuccessToast,
+  createUnknownErrorToast,
+  getSuccessToastMessage,
+  useToastState,
+} from '../../utils/toast-utils';
+import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
+
+export function ConfigureTab1(props: AppDependencies) {
+  const [isMultiTenancyEnabled, setIsMultiTenancyEnabled] = useState(false);
+  const [isPrivateTenantEnabled, setIsPrivateTenantEnabled] = useState(false);
+  const [dashboardsDefaultTenant, setDashboardsDefaultTenant] = useState(false);
+
+  const [originalConfiguration, setOriginalConfiguration] = React.useState<TenancyConfigSettings>({
+    multitenancy_enabled: isMultiTenancyEnabled,
+    private_tenant_enabled: isPrivateTenantEnabled,
+    default_tenant: dashboardsDefaultTenant,
+  });
+
+  const [updatedConfiguration, setUpdatedConfiguration] = React.useState<TenancyConfigSettings>({
+    multitenancy_enabled: isMultiTenancyEnabled,
+    private_tenant_enabled: isPrivateTenantEnabled,
+    default_tenant: dashboardsDefaultTenant,
+  });
+
+  const [showErrorWarning, setShowErrorWarning] = React.useState(false);
+
+  const [changeInMultiTenancyOption, setChangeInMultiTenancyOption] = useState(0);
+  const [changeInPrivateTenantOption, setChangeInPrivateTenantOption] = useState(0);
+  const [changeInDefaultTenantOption, setChangeInDefaultTenantOption] = useState(0);
+
+  const [toasts, addToast, removeToast] = useToastState();
+  const [selectedComboBoxOptions, setSelectedComboBoxOptions] = useState();
+
+  const discardChangesFunction = async () => {
+    await setUpdatedConfiguration(originalConfiguration);
+    setSelectedComboBoxOptions();
+    await setChangeInMultiTenancyOption(0);
+    await setChangeInPrivateTenantOption(0);
+    await setChangeInDefaultTenantOption(0);
+  };
+
+  const [saveChangesModal, setSaveChangesModal] = useState<ReactNode>(null);
+
+  const showSaveChangesModal = (
+    originalConfigurationPassed: TenancyConfigSettings,
+    updatedConfigurationPassed: TenancyConfigSettings
+  ) => {
+    setSaveChangesModal(
+      <SaveChangesModalGenerator
+        originalTenancyConfig={originalConfigurationPassed}
+        updatedTenancyConfig={updatedConfigurationPassed}
+        handleClose={() => setSaveChangesModal(null)}
+        handleSave={async (updatedConfiguration1: TenancyConfigSettings) => {
+          try {
+            console.log('Calling API');
+            await updateTenancyConfiguration(props.coreStart.http, updatedConfiguration1);
+            setSaveChangesModal(null);
+            setChangeInMultiTenancyOption(0);
+            setChangeInPrivateTenantOption(0);
+            setChangeInDefaultTenantOption(0);
+            setOriginalConfiguration(updatedConfiguration1);
+            setSelectedComboBoxOptions();
+            addToast(
+              createTenancySuccessToast(
+                'savePassed',
+                'Tenancy changes applied',
+                'Tenancy changes applied.'
+              )
+            );
+          } catch (e) {
+            console.log(e);
+            setSaveChangesModal(null);
+            setChangeInMultiTenancyOption(0);
+            setChangeInPrivateTenantOption(0);
+            setChangeInDefaultTenantOption(0);
+            setSelectedComboBoxOptions();
+            setUpdatedConfiguration(originalConfigurationPassed);
+            addToast(createTenancyErrorToast('saveFailed', 'Changes not applied', e.message));
+          }
+          setSaveChangesModal(null);
+        }}
+      />
+    );
+  };
+
+  let bottomBar;
+  if (changeInMultiTenancyOption + changeInPrivateTenantOption + changeInDefaultTenantOption > 0) {
+    bottomBar = (
+      <EuiBottomBar>
+        <EuiFlexGroup justifyContent="spaceBetween">
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s">
+              {/* <EuiFlexItem grow={false}>*/}
+              {/* </EuiFlexItem>*/}
+              <EuiFlexItem grow={false}>
+                <EuiText>
+                  {changeInMultiTenancyOption +
+                    changeInPrivateTenantOption +
+                    changeInDefaultTenantOption}{' '}
+                  Unsaved change(s)
+                </EuiText>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiFlexGroup gutterSize="s">
+              <EuiFlexItem grow={false}>
+                <EuiButton color="#FFF" size="s" onClick={() => discardChangesFunction()}>
+                  Discard changes
+                </EuiButton>
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButton
+                  color="primary"
+                  fill
+                  size="s"
+                  onClick={() => showSaveChangesModal(originalConfiguration, updatedConfiguration)}
+                >
+                  Save Changes
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiBottomBar>
+    );
+  }
+  const [tenantData, setTenantData] = React.useState<Tenant[]>([]);
+
+  React.useEffect(() => {
+    const fetchData = async () => {
+      try {
+        await setOriginalConfiguration({
+          multitenancy_enabled: (await getDashboardsInfo(props.coreStart.http))
+            .multitenancy_enabled,
+          private_tenant_enabled: (await getDashboardsInfo(props.coreStart.http))
+            .private_tenant_enabled,
+          default_tenant: (await getDashboardsInfo(props.coreStart.http)).default_tenant,
+        });
+
+        await setUpdatedConfiguration({
+          multitenancy_enabled: (await getDashboardsInfo(props.coreStart.http))
+            .multitenancy_enabled,
+          private_tenant_enabled: (await getDashboardsInfo(props.coreStart.http))
+            .private_tenant_enabled,
+          default_tenant: (await getDashboardsInfo(props.coreStart.http)).default_tenant,
+        });
+
+        const rawTenantData = await fetchTenants(props.coreStart.http);
+        const processedTenantData = transformTenantData(rawTenantData);
+        setTenantData(processedTenantData);
+      } catch (e) {
+        // TODO: switch to better error display.
+        console.error(e);
+      }
+    };
+    fetchData();
+  }, [props.coreStart.http, props.tenant]);
+
+  const onSwitchChangeTenancyEnabled = async () => {
+    try {
+      await setUpdatedConfiguration({
+        multitenancy_enabled: !updatedConfiguration.multitenancy_enabled,
+        private_tenant_enabled: updatedConfiguration.private_tenant_enabled,
+        default_tenant: updatedConfiguration.default_tenant,
+      });
+
+      if (
+        originalConfiguration.multitenancy_enabled === updatedConfiguration.multitenancy_enabled
+      ) {
+        await setChangeInMultiTenancyOption(1);
+      } else {
+        await setChangeInMultiTenancyOption(0);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const onSwitchChangePrivateTenantEnabled = async () => {
+    try {
+      await setUpdatedConfiguration({
+        multitenancy_enabled: updatedConfiguration.multitenancy_enabled,
+        private_tenant_enabled: !updatedConfiguration.private_tenant_enabled,
+        default_tenant: updatedConfiguration.default_tenant,
+      });
+
+      if (
+        originalConfiguration.private_tenant_enabled === updatedConfiguration.private_tenant_enabled
+      ) {
+        await setChangeInPrivateTenantOption(1);
+      } else {
+        await setChangeInPrivateTenantOption(0);
+      }
+      if (
+        updatedConfiguration.default_tenant === 'Private' &&
+        updatedConfiguration.private_tenant_enabled
+      ) {
+        await setShowErrorWarning(true);
+      } else {
+        await setShowErrorWarning(false);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const updateDefaultTenant = async (newDefaultTenant: string) => {
+    try {
+      await setUpdatedConfiguration({
+        multitenancy_enabled: updatedConfiguration.multitenancy_enabled,
+        private_tenant_enabled: updatedConfiguration.private_tenant_enabled,
+        default_tenant: newDefaultTenant,
+      });
+      if (originalConfiguration.default_tenant === updatedConfiguration.default_tenant) {
+        await setChangeInDefaultTenantOption(1);
+      } else {
+        await setChangeInDefaultTenantOption(0);
+      }
+      if (
+        updatedConfiguration.default_tenant === 'Private' &&
+        !updatedConfiguration.private_tenant_enabled
+      ) {
+        await setShowErrorWarning(true);
+      } else {
+        await setShowErrorWarning(false);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const comboBoxOptions = [];
+
+  for (const tenant in tenantData) {
+    if (tenantData[tenant].tenant) {
+      comboBoxOptions.push({
+        label: tenantData[tenant].tenant,
+      });
+    }
+  }
+
+  const onChangeComboBoxOptions = (selectedComboBoxOptionsAfterChange) => {
+    setSelectedComboBoxOptions(selectedComboBoxOptionsAfterChange);
+    if (selectedComboBoxOptionsAfterChange.length > 0) {
+      updateDefaultTenant(selectedComboBoxOptionsAfterChange[0].label);
+    }
+  };
+
+  const errorCallOut = (
+    <EuiCallOut title="Address the highlighted areas" color="danger" iconType="iInCircle">
+      <p>
+        <EuiIcon type="dot" size={'s'} /> The private tenant is disabled. Select another default
+        tenant.
+      </p>
+    </EuiCallOut>
+  );
+  const errorMessage = (
+    <EuiText color={'danger'}>
+      The private tenant is disabled. Select another default tenant.
+    </EuiText>
+  );
+  return (
+    <>
+      <EuiPageHeader />
+      <EuiCallOut
+        title="Caution: Changes to configurations can have an impact on user access."
+        color="warning"
+        iconType="iInCircle"
+      >
+        <p>
+          Making changes to these configurations may remove users’ access to objects and other work
+          in their tenants and alter the Dashboards user interface accordingly. Keep this in mind
+          before applying changes to configurations.
+        </p>
+      </EuiCallOut>
+      <EuiSpacer size="m" />
+      {showErrorWarning && errorCallOut}
+      {!showErrorWarning && bottomBar}
+      <EuiSpacer size="l" />
+
+      <EuiPageContent>
+        <EuiPageContentHeader>
+          <EuiPageContentHeaderSection>
+            <EuiTitle size="l">
+              <h3>Multi-tenancy</h3>
+            </EuiTitle>
+            <EuiHorizontalRule />
+
+            <EuiDescribedFormGroup
+              title={<h4>Tenancy</h4>}
+              description={
+                <p4>
+                  {' '}
+                  Selecting multi-tenancy allows you to create tenants and save OpenSearch
+                  Dashboards objects, such as index patterns and visualizations. Tenants are useful
+                  for safely sharing your work with other Dashboards users.
+                </p4>
+              }
+              className="described-form-group1"
+            >
+              <EuiCheckbox
+                id="EnableMultitenancyCheckBox"
+                label={'Enabled'}
+                checked={updatedConfiguration.multitenancy_enabled}
+                onChange={() => onSwitchChangeTenancyEnabled()}
+              />
+            </EuiDescribedFormGroup>
+          </EuiPageContentHeaderSection>
+        </EuiPageContentHeader>
+      </EuiPageContent>
+      <EuiSpacer size="l" />
+
+      <EuiPageContent>
+        <EuiPageContentHeader>
+          <EuiPageContentHeaderSection>
+            <EuiTitle size="l">
+              <h3>Tenants</h3>
+            </EuiTitle>
+            <EuiHorizontalRule />
+            <EuiDescribedFormGroup
+              title={<h4>Global Tenant</h4>}
+              description={
+                <p4>
+                  {' '}
+                  Global tenant is shared amaong all Dashboards users and cannot be disabled.{' '}
+                </p4>
+              }
+              className="described-form-group2"
+            >
+              <EuiText>
+                <p>
+                  <small>Global Tenant: Enabled</small>
+                </p>
+              </EuiText>
+            </EuiDescribedFormGroup>
+            <EuiDescribedFormGroup
+              title={<h4>Private Tenant</h4>}
+              description={
+                <p4>
+                  Private tenant is exclusive to each user and keeps a user&apos;s personal objects
+                  private. When using the private tenant, it does not allow access to objects
+                  created by the user&apos;s global tenant.
+                </p4>
+              }
+              className="described-form-group3"
+            >
+              <EuiCheckbox
+                id="EnablePrivateTenantCheckBox"
+                label={'Enable'}
+                checked={updatedConfiguration.private_tenant_enabled}
+                onChange={() => onSwitchChangePrivateTenantEnabled()}
+                disabled={!updatedConfiguration.multitenancy_enabled}
+              />
+            </EuiDescribedFormGroup>
+          </EuiPageContentHeaderSection>
+        </EuiPageContentHeader>
+      </EuiPageContent>
+      {saveChangesModal}
+      <EuiSpacer size="l" />
+      <EuiPageContent>
+        <EuiPageContentHeader>
+          <EuiPageContentHeaderSection>
+            <EuiTitle size="l">
+              <h3>Default tenant</h3>
+            </EuiTitle>
+            <EuiHorizontalRule />
+            <EuiDescribedFormGroup
+              title={<h4>Default Tenant</h4>}
+              description={
+                <p4>
+                  {' '}
+                  This option allows you to select the default tenant when logging into
+                  Dashboards/Kibana for the first time. You can choose from any of the available
+                  tenants.{' '}
+                </p4>
+              }
+              className="described-form-group4"
+            >
+              <EuiFlexGroup>
+                <EuiFlexItem>
+                  <EuiComboBox
+                    placeholder={updatedConfiguration.default_tenant}
+                    options={comboBoxOptions}
+                    selectedOptions={selectedComboBoxOptions}
+                    onChange={onChangeComboBoxOptions}
+                    singleSelection={{ asPlainText: true }}
+                    isClearable={true}
+                    isInvalid={showErrorWarning}
+                    data-test-subj="demoComboBox"
+                    isDisabled={!updatedConfiguration.multitenancy_enabled}
+                  />
+
+                  {showErrorWarning && errorMessage}
+                </EuiFlexItem>
+              </EuiFlexGroup>
+            </EuiDescribedFormGroup>
+          </EuiPageContentHeaderSection>
+        </EuiPageContentHeader>
+        <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={3000} dismissToast={removeToast} />
+      </EuiPageContent>
+    </>
+  );
+}

--- a/public/apps/configuration/panels/tenant-list/manage_tab.tsx
+++ b/public/apps/configuration/panels/tenant-list/manage_tab.tsx
@@ -1,0 +1,553 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiInMemoryTable,
+  EuiLink,
+  EuiPageBody,
+  EuiPageContent,
+  EuiPageContentHeader,
+  EuiPageContentHeaderSection,
+  EuiPageHeader,
+  EuiText,
+  EuiTitle,
+  EuiGlobalToastList,
+  Query,
+  EuiFacetButton,
+  EuiIcon,
+  EuiConfirmModal,
+  EuiCallOut,
+} from '@elastic/eui';
+import React, { ReactNode, useState, useCallback } from 'react';
+import { difference } from 'lodash';
+import { HashRouter as Router, Route } from 'react-router-dom';
+import { flow } from 'lodash';
+import { TenancyConfigSettings } from '../tenancy-config/types';
+import { getCurrentUser } from '../../../../utils/auth-info-utils';
+import { AppDependencies } from '../../../types';
+import { Action, ResourceType, Tenant } from '../../types';
+import { ExternalLink, renderCustomization, tableItemsUIProps } from '../../utils/display-utils';
+import {
+  fetchTenants,
+  transformTenantData,
+  fetchCurrentTenant,
+  resolveTenantName,
+  updateTenant,
+  requestDeleteTenant,
+  selectTenant,
+  updateTenancyConfiguration,
+} from '../../utils/tenant-utils';
+import { getNavLinkById } from '../../../../services/chrome_wrapper';
+import { TenantEditModal } from './edit-modal';
+import {
+  useToastState,
+  createUnknownErrorToast,
+  getSuccessToastMessage,
+} from '../../utils/toast-utils';
+import { PageId } from '../../types';
+import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
+import { showTableStatusMessage } from '../../utils/loading-spinner-utils';
+import { useContextMenuState } from '../../utils/context-menu';
+import { generateResourceName } from '../../utils/resource-utils';
+import { DocLinks } from '../../constants';
+import { TenantInstructionView } from './tenant-instruction-view';
+import { TenantList } from './tenant-list';
+import { getBreadcrumbs, Route_MAP } from '../../app-router';
+import { buildUrl } from '../../utils/url-builder';
+import { CrossPageToast } from '../../cross-page-toast';
+import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
+
+export function ManageTab(props: AppDependencies) {
+  const setGlobalBreadcrumbs = flow(getBreadcrumbs, props.coreStart.chrome.setBreadcrumbs);
+  const [tenantData, setTenantData] = React.useState<Tenant[]>([]);
+  const [errorFlag, setErrorFlag] = React.useState(false);
+  const [selection, setSelection] = React.useState<Tenant[]>([]);
+  const [currentTenant, setCurrentTenant] = useState('');
+  const [currentUsername, setCurrentUsername] = useState('');
+  // Modal state
+  const [editModal, setEditModal] = useState<ReactNode>(null);
+  const [toasts, addToast, removeToast] = useToastState();
+  const [loading, setLoading] = useState(false);
+
+  const [query, setQuery] = useState<Query | null>(null);
+
+  const [isMultiTenancyEnabled, setIsMultiTenancyEnabled] = useState(false);
+  const [isPrivateTenantEnabled, setIsPrivateTenantEnabled] = useState(false);
+  const [dashboardsDefaultTenant, setDashboardsDefaultTenant] = useState('');
+
+  const fetchData = useCallback(async () => {
+    try {
+      setLoading(true);
+      const rawTenantData = await fetchTenants(props.coreStart.http);
+      const processedTenantData = transformTenantData(rawTenantData);
+      const activeTenant = await fetchCurrentTenant(props.coreStart.http);
+      const currentUser = await getCurrentUser(props.coreStart.http);
+      setCurrentUsername(currentUser);
+      setCurrentTenant(resolveTenantName(activeTenant, currentUser));
+      setTenantData(processedTenantData);
+      setIsMultiTenancyEnabled(
+        (await getDashboardsInfo(props.coreStart.http)).multitenancy_enabled
+      );
+      setIsPrivateTenantEnabled(
+        (await getDashboardsInfo(props.coreStart.http)).private_tenant_enabled
+      );
+      setDashboardsDefaultTenant((await getDashboardsInfo(props.coreStart.http)).default_tenant);
+    } catch (e) {
+      console.log(e);
+      setErrorFlag(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [props.coreStart.http]);
+
+  React.useEffect(() => {
+    fetchData();
+  }, [props.coreStart.http, fetchData]);
+
+  const handleDelete = async () => {
+    const tenantsToDelete: string[] = selection.map((r) => r.tenant);
+    try {
+      await requestDeleteTenant(props.coreStart.http, tenantsToDelete);
+      setTenantData(difference(tenantData, selection));
+      setSelection([]);
+    } catch (e) {
+      console.log(e);
+    } finally {
+      closeActionsMenu();
+    }
+  };
+  const [showDeleteConfirmModal, deleteConfirmModal] = useDeleteConfirmState(
+    handleDelete,
+    'tenant(s)'
+  );
+
+  const changeTenant = async (tenantValue: string) => {
+    const selectedTenant = await selectTenant(props.coreStart.http, {
+      tenant: tenantValue,
+      username: currentUsername,
+    });
+    setCurrentTenant(resolveTenantName(selectedTenant, currentUsername));
+  };
+
+  const getTenantName = (tenantValue: string) => {
+    return tenantData.find((tenant: Tenant) => tenant.tenantValue === tenantValue)?.tenant;
+  };
+
+  const switchToSelectedTenant = async (tenantValue: string, tenantName: string) => {
+    try {
+      await changeTenant(tenantValue);
+      // refresh the page to let the page to reload app configs, like dark mode etc.
+      // also refresh the tenant to ensure tenant is set correctly when sharing urls.
+      window.location.reload();
+    } catch (e) {
+      console.log(e);
+      addToast(createUnknownErrorToast('selectFailed', `select ${tenantName} tenant`));
+    } finally {
+      closeActionsMenu();
+    }
+  };
+
+  const [isModalVisible, setIsModalVisible] = useState(false);
+
+  const closeModal = () => setIsModalVisible(false);
+  const showModal = () => setIsModalVisible(true);
+
+  const setSelectedTenantAsGlobalDefaultAPICall = async (tenantName: string) => {
+    try {
+      await updateTenancyConfiguration(props.coreStart.http, {
+        multitenancy_enabled: isMultiTenancyEnabled,
+        private_tenant_enabled: isPrivateTenantEnabled,
+        default_tenant: tenantName,
+      });
+      window.location.reload();
+    } catch (e) {
+      console.log(e);
+      addToast(createUnknownErrorToast('selectFailed', `select ${tenantName} tenant`));
+    } finally {
+      closeModal();
+      closeActionsMenu();
+    }
+  };
+
+  let defaultTenantModal;
+  if (isModalVisible && isMultiTenancyEnabled) {
+    defaultTenantModal = (
+      <EuiConfirmModal
+        style={{ width: 600 }}
+        title="Change default tenant?"
+        onCancel={closeModal}
+        onConfirm={() => setSelectedTenantAsGlobalDefaultAPICall(selection[0].tenant)}
+        cancelButtonText="Discard Changes"
+        confirmButtonText="Change Default Tenant"
+        defaultFocusedButton="confirm"
+      >
+        <p>
+          Users will load into {selection[0].tenant} tenant when they log into Dashboards if they
+          have the appropriate permissions. If users don’t have permissions to a custom tenant they
+          will load into the global tenant. <ExternalLink href={DocLinks.MultiTenancyDoc} />
+        </p>
+      </EuiConfirmModal>
+    );
+  }
+
+  const renderConfigurePage = async () => {
+    return (
+      <Router basename={props.params.appBasePath}>
+        <Route
+          path={buildUrl(ResourceType.tenants)}
+          render={() => {
+            setGlobalBreadcrumbs(ResourceType.tenants);
+            return <TenantList tabID={'Configure'} {...props} />;
+          }}
+        />
+        <CrossPageToast />
+      </Router>
+    );
+  };
+
+  let tenancyDisabledWarning;
+  if (!true) {
+    tenancyDisabledWarning = (
+      <EuiCallOut title="Tenancy is disabled" color="warning" iconType="iInCircle">
+        <p>
+          Tenancy is currently disabled and users don&apos;t have access to this feature. To create,
+          edit tenants you must enabled tenanc throught he configure tenancy page.
+        </p>
+        <EuiButton
+          id="switchToConfigure"
+          color="warning"
+          onClick={() => renderConfigurePage().then()}
+        >
+          Configure tenancy
+        </EuiButton>
+      </EuiCallOut>
+    );
+  }
+
+  const viewOrCreateDashboard = async (tenantValue: string, action: string) => {
+    try {
+      await changeTenant(tenantValue);
+      window.location.href = getNavLinkById(props.coreStart, PageId.dashboardId);
+    } catch (e) {
+      console.log(e);
+      addToast(
+        createUnknownErrorToast(
+          `${action}Dashboard`,
+          `${action} dashboard for ${getTenantName(tenantValue)} tenant`
+        )
+      );
+    }
+  };
+
+  const viewOrCreateVisualization = async (tenantValue: string, action: string) => {
+    try {
+      await changeTenant(tenantValue);
+      window.location.href = getNavLinkById(props.coreStart, PageId.visualizationId);
+    } catch (e) {
+      console.log(e);
+      addToast(
+        createUnknownErrorToast(
+          `${action}Visualization`,
+          `${action} visualization for ${getTenantName(tenantValue)} tenant`
+        )
+      );
+    }
+  };
+
+  function loadTenantStatus(tenantName: string) {
+    if (tenantName === 'Global') {
+      if (
+        !isMultiTenancyEnabled ||
+        tenantName === dashboardsDefaultTenant ||
+        (dashboardsDefaultTenant === 'Private' && !isPrivateTenantEnabled) ||
+        dashboardsDefaultTenant === ''
+      ) {
+        return (
+          <EuiFacetButton icon={<EuiIcon type="dot" color="primary" />}>
+            Default Tenant
+          </EuiFacetButton>
+        );
+      }
+      return <EuiFacetButton icon={<EuiIcon type="dot" color="success" />}>Enabled</EuiFacetButton>;
+    }
+
+    if (tenantName === 'Private') {
+      if (isPrivateTenantEnabled && isMultiTenancyEnabled) {
+        if (tenantName === dashboardsDefaultTenant) {
+          return (
+            <EuiFacetButton icon={<EuiIcon type="dot" color="primary" />}>
+              Default Tenant
+            </EuiFacetButton>
+          );
+        }
+
+        return (
+          <EuiFacetButton icon={<EuiIcon type="dot" color="success" />}>Enabled</EuiFacetButton>
+        );
+      }
+      return (
+        <EuiFacetButton icon={<EuiIcon type="dot" color="#DDDDDD" />}>Disabled</EuiFacetButton>
+      );
+    }
+
+    if (isMultiTenancyEnabled) {
+      if (tenantName === dashboardsDefaultTenant) {
+        return (
+          <EuiFacetButton icon={<EuiIcon type="dot" color="primary" />}>
+            Default Tenant
+          </EuiFacetButton>
+        );
+      }
+      return <EuiFacetButton icon={<EuiIcon type="dot" color="success" />}>Enabled</EuiFacetButton>;
+    }
+
+    return <EuiFacetButton icon={<EuiIcon type="dot" color="#DDDDDD" />}>Disabled</EuiFacetButton>;
+  }
+
+  const columns = [
+    {
+      field: 'tenant',
+      name: 'Name',
+      render: (tenantName: string) => (
+        <>
+          {tenantName}
+          {tenantName === currentTenant && (
+            <>
+              &nbsp;
+              <EuiBadge>Current</EuiBadge>
+            </>
+          )}
+        </>
+      ),
+      sortable: true,
+    },
+    {
+      field: 'tenant',
+      name: 'Status',
+      render: (tenantName: string) => <>{loadTenantStatus(tenantName)}</>,
+    },
+    {
+      field: 'description',
+      name: 'Description',
+      truncateText: true,
+    },
+    {
+      field: 'tenantValue',
+      name: 'Dashboard',
+      render: (tenant: string) => (
+        <>
+          <EuiLink onClick={() => viewOrCreateDashboard(tenant, Action.view)}>
+            View dashboard
+          </EuiLink>
+        </>
+      ),
+    },
+    {
+      field: 'tenantValue',
+      name: 'Visualizations',
+      render: (tenant: string) => (
+        <>
+          <EuiLink onClick={() => viewOrCreateVisualization(tenant, Action.view)}>
+            View visualizations
+          </EuiLink>
+        </>
+      ),
+    },
+    {
+      field: 'reserved',
+      name: 'Customization',
+      render: (reserved: boolean) => {
+        return renderCustomization(reserved, tableItemsUIProps);
+      },
+    },
+  ];
+
+  const actionsMenuItems = [
+    <EuiButtonEmpty
+      id="switchTenant"
+      key="switchTenant"
+      disabled={selection.length !== 1}
+      onClick={() => switchToSelectedTenant(selection[0].tenantValue, selection[0].tenant)}
+    >
+      Switch to selected tenant
+    </EuiButtonEmpty>,
+    <EuiButtonEmpty
+      id="edit"
+      key="edit"
+      disabled={selection.length !== 1 || selection[0].reserved}
+      onClick={() => showEditModal(selection[0].tenant, Action.edit, selection[0].description)}
+    >
+      Edit
+    </EuiButtonEmpty>,
+    <EuiButtonEmpty
+      id="duplicate"
+      key="duplicate"
+      disabled={selection.length !== 1}
+      onClick={() =>
+        showEditModal(
+          generateResourceName(Action.duplicate, selection[0].tenant),
+          Action.duplicate,
+          selection[0].description
+        )
+      }
+    >
+      Duplicate
+    </EuiButtonEmpty>,
+    <EuiButtonEmpty
+      id="createDashboard"
+      key="createDashboard"
+      disabled={selection.length !== 1}
+      onClick={() => viewOrCreateDashboard(selection[0].tenantValue, Action.create)}
+    >
+      Create dashboard
+    </EuiButtonEmpty>,
+    <EuiButtonEmpty
+      id="createVisualizations"
+      key="createVisualizations"
+      disabled={selection.length !== 1}
+      onClick={() => viewOrCreateVisualization(selection[0].tenantValue, Action.create)}
+    >
+      Create visualizations
+    </EuiButtonEmpty>,
+    <EuiButtonEmpty
+      id="set as Global Default"
+      key="Set as Global Default key"
+      disabled={selection.length !== 1 || !isMultiTenancyEnabled}
+      onClick={showModal}
+    >
+      Set as Default Tenant
+    </EuiButtonEmpty>,
+    <EuiButtonEmpty
+      id="delete"
+      key="delete"
+      color="danger"
+      onClick={showDeleteConfirmModal}
+      disabled={selection.length === 0 || selection.some((tenant) => tenant.reserved)}
+    >
+      Delete
+    </EuiButtonEmpty>,
+  ];
+
+  const [actionsMenu, closeActionsMenu] = useContextMenuState('Actions', {}, actionsMenuItems);
+
+  const showEditModal = (
+    initialTenantName: string,
+    action: Action,
+    initialTenantDescription: string
+  ) => {
+    setEditModal(
+      <TenantEditModal
+        tenantName={initialTenantName}
+        tenantDescription={initialTenantDescription}
+        action={action}
+        handleClose={() => setEditModal(null)}
+        handleSave={async (tenantName: string, tenantDescription: string) => {
+          try {
+            await updateTenant(props.coreStart.http, tenantName, {
+              description: tenantDescription,
+            });
+            setEditModal(null);
+            fetchData();
+            addToast({
+              id: 'saveSucceeded',
+              title: getSuccessToastMessage('Tenant', action, tenantName),
+              color: 'success',
+            });
+          } catch (e) {
+            console.log(e);
+            addToast(createUnknownErrorToast('saveFailed', `save ${action} tenant`));
+          }
+        }}
+      />
+    );
+  };
+
+  if (!props.config.multitenancy.enabled) {
+    return <TenantInstructionView />;
+  }
+  /* eslint-disable */
+  return (
+    <>
+      {/*{tenancyDisabledWarning}*/}
+      <EuiPageHeader>
+      </EuiPageHeader>
+      <EuiPageContent>
+        <EuiPageContentHeader>
+          <EuiPageContentHeaderSection>
+            <EuiTitle size="s">
+              <h3>
+                Tenants
+                <span className="panel-header-count">
+                  {' '}
+                  ({Query.execute(query || '', tenantData).length})
+                </span>
+              </h3>
+            </EuiTitle>
+            <EuiText size="s" color="subdued">
+              Manage tenants that already have been created. Global tenant is the default when
+              tenancy is turned off.
+            </EuiText>
+          </EuiPageContentHeaderSection>
+          <EuiPageContentHeaderSection>
+            <EuiFlexGroup>
+              <EuiFlexItem>{actionsMenu}</EuiFlexItem>
+              <EuiFlexItem>
+                <EuiButton
+                  id="createTenant"
+                  fill
+                  onClick={() => showEditModal('', Action.create, '')}
+                >
+                  Create tenant
+                </EuiButton>
+              </EuiFlexItem>
+            </EuiFlexGroup>
+          </EuiPageContentHeaderSection>
+        </EuiPageContentHeader>
+        {defaultTenantModal}
+        <EuiPageBody>
+          <EuiInMemoryTable
+            tableLayout={'auto'}
+            loading={tenantData === [] && !errorFlag}
+            columns={columns}
+            // @ts-ignore
+            items={tenantData}
+            itemId={'tenant'}
+            pagination
+            search={{
+              box: { placeholder: 'Find tenant' },
+              onChange: (arg) => {
+                setQuery(arg.query);
+                return true;
+              },
+            }}
+            // @ts-ignore
+            selection={{ onSelectionChange: setSelection }}
+            sorting
+            error={errorFlag ? 'Load data failed, please check console log for more detail.' : ''}
+            message={showTableStatusMessage(loading, tenantData)}
+          />
+        </EuiPageBody>
+      </EuiPageContent>
+      {editModal}
+      {deleteConfirmModal}
+      <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />
+    </>
+  );
+}

--- a/public/apps/configuration/panels/tenant-list/save_changes_modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/save_changes_modal.tsx
@@ -45,7 +45,6 @@ export function SaveChangesModalGenerator(props: SaveChangesModalDeps) {
   ) {
     globalDefaultModal = (
       <EuiConfirmModal
-        // onClose={props.handleClose}
         style={{ width: 600 }}
         title="Change default tenant?"
         onCancel={props.handleClose}

--- a/public/apps/configuration/panels/tenant-list/save_changes_modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/save_changes_modal.tsx
@@ -1,0 +1,190 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import {
+  EuiPageContentHeader,
+  EuiHorizontalRule,
+  EuiCheckbox,
+  EuiConfirmModal,
+} from '@elastic/eui';
+import React from 'react';
+import { ExternalLink } from '../../utils/display-utils';
+import { TenancyConfigSettings } from '../tenancy-config/types';
+import { DocLinks } from '../../constants';
+
+interface SaveChangesModalDeps {
+  originalTenancyConfig: TenancyConfigSettings;
+  updatedTenancyConfig: TenancyConfigSettings;
+  handleClose: () => void;
+  handleSave: (updatedTenancyConfig: TenancyConfigSettings) => Promise<void>;
+}
+
+export function SaveChangesModalGenerator(props: SaveChangesModalDeps) {
+  let globalDefaultModal;
+  const [tenancyChecked, setTenancyChecked] = React.useState(false);
+  const [privateTenancyChecked, setPrivateTenancyChecked] = React.useState(false);
+  const [defaultTenantChecked, setDefaultTenantChecked] = React.useState(false);
+  if (
+    props.originalTenancyConfig.default_tenant !== props.updatedTenancyConfig.default_tenant &&
+    props.originalTenancyConfig.multitenancy_enabled ===
+      props.updatedTenancyConfig.multitenancy_enabled &&
+    props.originalTenancyConfig.private_tenant_enabled ===
+      props.updatedTenancyConfig.private_tenant_enabled
+  ) {
+    globalDefaultModal = (
+      <EuiConfirmModal
+        // onClose={props.handleClose}
+        style={{ width: 600 }}
+        title="Change default tenant?"
+        onCancel={props.handleClose}
+        onConfirm={async () => {
+          await props.handleSave(props.updatedTenancyConfig);
+        }}
+        cancelButtonText="Discard Changes"
+        confirmButtonText="Change Default Tenant"
+        defaultFocusedButton="confirm"
+      >
+        <p>
+          Users will load into {props.updatedTenancyConfig.default_tenant} tenant when they log into
+          Dashboards if they have the appropriate permissions. If users don’t have permissions to a
+          custom tenant they will load into the global tenant.{' '}
+          <ExternalLink href={DocLinks.MultiTenancyDoc} />
+        </p>
+      </EuiConfirmModal>
+    );
+    return globalDefaultModal;
+  }
+
+  let tenancyToggled = false;
+  let privateTenantToggled = false;
+  let defaultTenantChanged = false;
+  let tenancyChangeCheckbox;
+  let privateTenancyChangeCheckbox;
+  let defaultTenantChangeCheckbox;
+  let tenancyChangeMessage = 'Message 1';
+  let privateTenancyChangeMessage = 'Message 2';
+  let defaultTenantChangeMessage = 'Message 3';
+
+  if (
+    props.updatedTenancyConfig.multitenancy_enabled !==
+    props.originalTenancyConfig.multitenancy_enabled
+  ) {
+    tenancyToggled = true;
+    if (props.updatedTenancyConfig.multitenancy_enabled) {
+      tenancyChangeMessage =
+        'Enable Tenancy - Users will be able to make use of the Tenancy Feature ' +
+        'in OpenSearch Dashboards and switch between tenants they have access to.';
+    } else {
+      tenancyChangeMessage =
+        "Disabling Tenancy - Users won't be able to access index patterns, visualizations, " +
+        'dashboards, and other OpenSearch Dashboards objects saved in tenants other than the ' +
+        'global tenant.';
+    }
+    tenancyChangeCheckbox = (
+      <EuiCheckbox
+        id={'tenancyChangeCheckbox'}
+        label={tenancyChangeMessage}
+        checked={tenancyChecked}
+        onChange={() => setTenancyChecked(!tenancyChecked)}
+      />
+    );
+  }
+
+  if (
+    props.updatedTenancyConfig.private_tenant_enabled !==
+      props.originalTenancyConfig.private_tenant_enabled &&
+    props.updatedTenancyConfig.multitenancy_enabled
+  ) {
+    privateTenantToggled = true;
+    if (props.updatedTenancyConfig.private_tenant_enabled) {
+      privateTenancyChangeMessage =
+        'Enable private tenant - Users will be able to create index patterns, visualizations, and ' +
+        'other OpenSearch Dashboards objects in a private tenant that they only have access to.';
+    } else {
+      privateTenancyChangeMessage =
+        "Disabling private tenant - Users won't be able to access index patterns, visualizations, and " +
+        'other OpenSearch Dashboards saved in their private tenant.';
+    }
+    privateTenancyChangeCheckbox = (
+      <EuiCheckbox
+        id={'privateTenancyChangeCheckbox'}
+        label={privateTenancyChangeMessage}
+        checked={privateTenancyChecked}
+        onChange={() => setPrivateTenancyChecked(!privateTenancyChecked)}
+      />
+    );
+  }
+
+  if (
+    props.updatedTenancyConfig.default_tenant !== props.originalTenancyConfig.default_tenant &&
+    props.updatedTenancyConfig.multitenancy_enabled
+  ) {
+    defaultTenantChanged = true;
+    defaultTenantChangeMessage =
+      'Users will load into ' +
+      props.updatedTenancyConfig.default_tenant +
+      ' tenant when they log into Dashboards ' +
+      'if they have the appropriate permissions. If users don’t have permissions to a custom ' +
+      'tenant they will load into the global tenant.';
+    defaultTenantChangeCheckbox = (
+      <EuiCheckbox
+        id={'defaultTenantChangeCheckbox'}
+        label={defaultTenantChangeMessage}
+        checked={defaultTenantChecked}
+        onChange={() => setDefaultTenantChecked(!defaultTenantChecked)}
+      />
+    );
+  }
+
+  globalDefaultModal = (
+    <EuiConfirmModal
+      // onClose={props.handleClose}
+      style={{ width: 600 }}
+      title="Make changes to tenancy?"
+      onCancel={props.handleClose}
+      onConfirm={async () => {
+        await props.handleSave(props.updatedTenancyConfig);
+      }}
+      cancelButtonText="Cancel"
+      confirmButtonText="Apply changes"
+      defaultFocusedButton="confirm"
+      buttonColor={'danger'}
+      confirmButtonDisabled={
+        !(
+          tenancyToggled === tenancyChecked &&
+          privateTenantToggled === privateTenancyChecked &&
+          defaultTenantChanged === defaultTenantChecked
+        )
+      }
+    >
+      <p>
+        The changes you are about to make can break large portions of OpenSearch Dashboards. You
+        might be able to revert some of these changes.{' '}
+        <ExternalLink href={DocLinks.MultiTenancyDoc} />
+      </p>
+
+      <EuiHorizontalRule />
+
+      <EuiPageContentHeader>
+        <h4>Review changes and check the boxes below:</h4>
+      </EuiPageContentHeader>
+      {tenancyChangeCheckbox}
+      {privateTenancyChangeCheckbox}
+      {defaultTenantChangeCheckbox}
+    </EuiConfirmModal>
+  );
+
+  return globalDefaultModal;
+}

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -14,383 +14,137 @@
  */
 
 import {
-  EuiBadge,
-  EuiButton,
-  EuiButtonEmpty,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiInMemoryTable,
-  EuiLink,
-  EuiPageBody,
-  EuiPageContent,
-  EuiPageContentHeader,
-  EuiPageContentHeaderSection,
   EuiPageHeader,
   EuiText,
   EuiTitle,
-  EuiGlobalToastList,
-  Query,
+  EuiTabs,
+  EuiTab,
+  EuiCallOut,
+  EuiButton,
 } from '@elastic/eui';
-import React, { ReactNode, useState, useCallback } from 'react';
-import { difference } from 'lodash';
-import { getCurrentUser } from '../../../../utils/auth-info-utils';
+import { Route } from 'react-router-dom';
+import React, { useState, useMemo, useCallback } from 'react';
+import { ManageTab } from './manage_tab';
+import { ConfigureTab1 } from './configure_tab1';
 import { AppDependencies } from '../../../types';
-import { Action, Tenant } from '../../types';
-import { ExternalLink, renderCustomization, tableItemsUIProps } from '../../utils/display-utils';
-import {
-  fetchTenants,
-  transformTenantData,
-  fetchCurrentTenant,
-  resolveTenantName,
-  updateTenant,
-  requestDeleteTenant,
-  selectTenant,
-} from '../../utils/tenant-utils';
-import { getNavLinkById } from '../../../../services/chrome_wrapper';
-import { TenantEditModal } from './edit-modal';
-import {
-  useToastState,
-  createUnknownErrorToast,
-  getSuccessToastMessage,
-} from '../../utils/toast-utils';
-import { PageId } from '../../types';
-import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
-import { showTableStatusMessage } from '../../utils/loading-spinner-utils';
-import { useContextMenuState } from '../../utils/context-menu';
-import { generateResourceName } from '../../utils/resource-utils';
+import { ExternalLink } from '../../utils/display-utils';
+import { displayBoolean } from '../../utils/display-utils';
 import { DocLinks } from '../../constants';
-import { TenantInstructionView } from './tenant-instruction-view';
+import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
 
-export function TenantList(props: AppDependencies) {
-  const [tenantData, setTenantData] = React.useState<Tenant[]>([]);
-  const [errorFlag, setErrorFlag] = React.useState(false);
-  const [selection, setSelection] = React.useState<Tenant[]>([]);
-  const [currentTenant, setCurrentTenant] = useState('');
-  const [currentUsername, setCurrentUsername] = useState('');
-  // Modal state
-  const [editModal, setEditModal] = useState<ReactNode>(null);
-  const [toasts, addToast, removeToast] = useToastState();
-  const [loading, setLoading] = useState(false);
+interface TenantListProps extends AppDependencies {
+  tabID: string;
+}
 
-  const [query, setQuery] = useState<Query | null>(null);
-
-  // Configuration
-  const isPrivateEnabled = props.config.multitenancy.tenants.enable_private;
-
-  const fetchData = useCallback(async () => {
-    try {
-      setLoading(true);
-      const rawTenantData = await fetchTenants(props.coreStart.http);
-      const processedTenantData = transformTenantData(rawTenantData, isPrivateEnabled);
-      const activeTenant = await fetchCurrentTenant(props.coreStart.http);
-      const currentUser = await getCurrentUser(props.coreStart.http);
-      setCurrentUsername(currentUser);
-      setCurrentTenant(resolveTenantName(activeTenant, currentUser));
-      setTenantData(processedTenantData);
-    } catch (e) {
-      console.log(e);
-      setErrorFlag(true);
-    } finally {
-      setLoading(false);
-    }
-  }, [isPrivateEnabled, props.coreStart.http]);
+export function TenantList(props: TenantListProps) {
+  const [isMultiTenancyEnabled, setIsMultiTenancyEnabled] = useState(false);
+  const [selectedTabId, setSelectedTabId] = useState(props.tabID);
 
   React.useEffect(() => {
+    const fetchData = async () => {
+      try {
+        await setIsMultiTenancyEnabled(
+          (await getDashboardsInfo(props.coreStart.http)).multitenancy_enabled
+        );
+      } catch (e) {
+        console.log(e);
+      }
+    };
     fetchData();
-  }, [props.coreStart.http, fetchData]);
+  }, [props.coreStart.http, selectedTabId]);
 
-  const handleDelete = async () => {
-    const tenantsToDelete: string[] = selection.map((r) => r.tenant);
-    try {
-      await requestDeleteTenant(props.coreStart.http, tenantsToDelete);
-      setTenantData(difference(tenantData, selection));
-      setSelection([]);
-    } catch (e) {
-      console.log(e);
-    } finally {
-      closeActionsMenu();
-    }
-  };
-  const [showDeleteConfirmModal, deleteConfirmModal] = useDeleteConfirmState(
-    handleDelete,
-    'tenant(s)'
+  const tenancyDisabledWarning = (
+    <>
+      <EuiCallOut title="Tenancy is disabled" color="warning" iconType="iInCircle">
+        <p>
+          Tenancy is currently disabled and users don&apos;t have access to this feature. To create,
+          edit tenants you must enabled tenanc throught he configure tenancy page.
+        </p>
+        <EuiButton
+          id="switchToConfigure"
+          color="warning"
+          onClick={() => onSelectedTabChanged('Configure')}
+        >
+          Configure tenancy
+        </EuiButton>
+      </EuiCallOut>
+    </>
   );
 
-  const changeTenant = async (tenantValue: string) => {
-    const selectedTenant = await selectTenant(props.coreStart.http, {
-      tenant: tenantValue,
-      username: currentUsername,
-    });
-    setCurrentTenant(resolveTenantName(selectedTenant, currentUsername));
-  };
-
-  const getTenantName = (tenantValue: string) => {
-    return tenantData.find((tenant: Tenant) => tenant.tenantValue === tenantValue)?.tenant;
-  };
-
-  const switchToSelectedTenant = async (tenantValue: string, tenantName: string) => {
-    try {
-      await changeTenant(tenantValue);
-      // refresh the page to let the page to reload app configs, like dark mode etc.
-      // also refresh the tenant to ensure tenant is set correctly when sharing urls.
-      window.location.reload();
-    } catch (e) {
-      console.log(e);
-      addToast(createUnknownErrorToast('selectFailed', `select ${tenantName} tenant`));
-    } finally {
-      closeActionsMenu();
-    }
-  };
-
-  const viewOrCreateDashboard = async (tenantValue: string, action: string) => {
-    try {
-      await changeTenant(tenantValue);
-      window.location.href = getNavLinkById(props.coreStart, PageId.dashboardId);
-    } catch (e) {
-      console.log(e);
-      addToast(
-        createUnknownErrorToast(
-          `${action}Dashboard`,
-          `${action} dashboard for ${getTenantName(tenantValue)} tenant`
-        )
-      );
-    }
-  };
-
-  const viewOrCreateVisualization = async (tenantValue: string, action: string) => {
-    try {
-      await changeTenant(tenantValue);
-      window.location.href = getNavLinkById(props.coreStart, PageId.visualizationId);
-    } catch (e) {
-      console.log(e);
-      addToast(
-        createUnknownErrorToast(
-          `${action}Visualization`,
-          `${action} visualization for ${getTenantName(tenantValue)} tenant`
-        )
-      );
-    }
-  };
-
-  const columns = [
-    {
-      field: 'tenant',
-      name: 'Name',
-      render: (tenantName: string) => (
-        <>
-          {tenantName}
-          {tenantName === currentTenant && (
-            <>
-              &nbsp;
-              <EuiBadge>Current</EuiBadge>
-            </>
-          )}
-        </>
-      ),
-      sortable: true,
-    },
-    {
-      field: 'description',
-      name: 'Description',
-      truncateText: true,
-    },
-    {
-      field: 'tenantValue',
-      name: 'Dashboard',
-      render: (tenant: string) => (
-        <>
-          <EuiLink onClick={() => viewOrCreateDashboard(tenant, Action.view)}>
-            View dashboard
-          </EuiLink>
-        </>
-      ),
-    },
-    {
-      field: 'tenantValue',
-      name: 'Visualizations',
-      render: (tenant: string) => (
-        <>
-          <EuiLink onClick={() => viewOrCreateVisualization(tenant, Action.view)}>
-            View visualizations
-          </EuiLink>
-        </>
-      ),
-    },
-    {
-      field: 'reserved',
-      name: 'Customization',
-      render: (reserved: boolean) => {
-        return renderCustomization(reserved, tableItemsUIProps);
+  const tabs = useMemo(
+    () => [
+      {
+        id: 'Manage',
+        name: 'Manage',
+        content: (
+          <Route
+            render={() => {
+              return (
+                <>
+                  <ManageTab {...props} />
+                </>
+              );
+            }}
+          />
+        ),
       },
-    },
-  ];
+      {
+        id: 'Configure',
+        name: 'Configure',
+        content: (
+          <Route
+            render={() => {
+              return <ConfigureTab1 {...props} />;
+            }}
+          />
+        ),
+      },
+    ],
+    [props]
+  );
 
-  const actionsMenuItems = [
-    <EuiButtonEmpty
-      id="switchTenant"
-      key="switchTenant"
-      disabled={selection.length !== 1}
-      onClick={() => switchToSelectedTenant(selection[0].tenantValue, selection[0].tenant)}
-    >
-      Switch to selected tenant
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
-      id="edit"
-      key="edit"
-      disabled={selection.length !== 1 || selection[0].reserved}
-      onClick={() => showEditModal(selection[0].tenant, Action.edit, selection[0].description)}
-    >
-      Edit
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
-      id="duplicate"
-      key="duplicate"
-      disabled={selection.length !== 1}
-      onClick={() =>
-        showEditModal(
-          generateResourceName(Action.duplicate, selection[0].tenant),
-          Action.duplicate,
-          selection[0].description
-        )
-      }
-    >
-      Duplicate
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
-      id="createDashboard"
-      key="createDashboard"
-      disabled={selection.length !== 1}
-      onClick={() => viewOrCreateDashboard(selection[0].tenantValue, Action.create)}
-    >
-      Create dashboard
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
-      id="createVisualizations"
-      key="createVisualizations"
-      disabled={selection.length !== 1}
-      onClick={() => viewOrCreateVisualization(selection[0].tenantValue, Action.create)}
-    >
-      Create visualizations
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
-      id="delete"
-      key="delete"
-      color="danger"
-      onClick={showDeleteConfirmModal}
-      disabled={selection.length === 0 || selection.some((tenant) => tenant.reserved)}
-    >
-      Delete
-    </EuiButtonEmpty>,
-  ];
+  const selectedTabContent = useMemo(() => {
+    return tabs.find((obj) => obj.id === selectedTabId)?.content;
+  }, [selectedTabId, tabs]);
 
-  const [actionsMenu, closeActionsMenu] = useContextMenuState('Actions', {}, actionsMenuItems);
-
-  const showEditModal = (
-    initialTenantName: string,
-    action: Action,
-    initialTenantDescription: string
-  ) => {
-    setEditModal(
-      <TenantEditModal
-        tenantName={initialTenantName}
-        tenantDescription={initialTenantDescription}
-        action={action}
-        handleClose={() => setEditModal(null)}
-        handleSave={async (tenantName: string, tenantDescription: string) => {
-          try {
-            await updateTenant(props.coreStart.http, tenantName, {
-              description: tenantDescription,
-            });
-            setEditModal(null);
-            fetchData();
-            addToast({
-              id: 'saveSucceeded',
-              title: getSuccessToastMessage('Tenant', action, tenantName),
-              color: 'success',
-            });
-          } catch (e) {
-            console.log(e);
-            addToast(createUnknownErrorToast('saveFailed', `save ${action} tenant`));
-          }
-        }}
-      />
-    );
+  const onSelectedTabChanged = (id: string) => {
+    setSelectedTabId(id);
   };
 
-  if (!props.config.multitenancy.enabled) {
-    return <TenantInstructionView />;
-  }
-  /* eslint-disable */
+  const renderTabs = () => {
+    return tabs.map((tab, index) => (
+      <EuiTab
+        key={index}
+        href={tab.href}
+        onClick={() => onSelectedTabChanged(tab.id)}
+        isSelected={tab.id === selectedTabId}
+        disabled={tab.disabled}
+        prepend={tab.prepend}
+        append={tab.append}
+      >
+        {tab.name}
+      </EuiTab>
+    ));
+  };
+
   return (
     <>
       <EuiPageHeader>
         <EuiTitle size="l">
-          <h1>Tenants</h1>
+          <h1>Multi-tenancy</h1>
         </EuiTitle>
       </EuiPageHeader>
-      <EuiPageContent>
-        <EuiPageContentHeader>
-          <EuiPageContentHeaderSection>
-            <EuiTitle size="s">
-              <h3>
-                Tenants
-                <span className="panel-header-count">
-                  {' '}
-                  ({Query.execute(query || '', tenantData).length})
-                </span>
-              </h3>
-            </EuiTitle>
-            <EuiText size="xs" color="subdued">
-              Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations,
-              dashboards, and other OpenSearch Dashboards objects. Use tenants to safely share your
-              work with other OpenSearch Dashboards users. You can control which roles have access
-              to a tenant and whether those roles have read or write access. The “Current” label
-              indicates which tenant you are using now. Switch to another tenant anytime from your
-              user profile, which is located on the top right of the screen. <ExternalLink href={DocLinks.TenantPermissionsDoc} />
-            </EuiText>
-          </EuiPageContentHeaderSection>
-          <EuiPageContentHeaderSection>
-            <EuiFlexGroup>
-              <EuiFlexItem>{actionsMenu}</EuiFlexItem>
-              <EuiFlexItem>
-                <EuiButton
-                  id="createTenant"
-                  fill
-                  onClick={() => showEditModal('', Action.create, '')}
-                >
-                  Create tenant
-                </EuiButton>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </EuiPageContentHeaderSection>
-        </EuiPageContentHeader>
-        <EuiPageBody>
-          <EuiInMemoryTable
-            tableLayout={'auto'}
-            loading={tenantData === [] && !errorFlag}
-            columns={columns}
-            // @ts-ignore
-            items={tenantData}
-            itemId={'tenant'}
-            pagination
-            search={{
-              box: { placeholder: 'Find tenant' },
-              onChange: (arg) => {
-                setQuery(arg.query);
-                return true;
-              },
-            }}
-            // @ts-ignore
-            selection={{ onSelectionChange: setSelection }}
-            sorting
-            error={errorFlag ? 'Load data failed, please check console log for more detail.' : ''}
-            message={showTableStatusMessage(loading, tenantData)}
-          />
-        </EuiPageBody>
-      </EuiPageContent>
-      {editModal}
-      {deleteConfirmModal}
-      <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />
+      <EuiText size="s" color="subdued" grow={true} textAlign={'left'}>
+        Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations,
+        dashboards, and other OpenSearch Dashboards objects. Tenants are useful for safely sharing
+        your work with other OpenSearch Dashboards users. You can control which roles have access to
+        a tenant and whether those roles have read or write access.{' '}
+        <ExternalLink href={DocLinks.MultiTenancyDoc} />
+      </EuiText>
+
+      <EuiTabs>{renderTabs()}</EuiTabs>
+      {!isMultiTenancyEnabled && selectedTabId === 'Manage' && tenancyDisabledWarning}
+      {selectedTabContent}
     </>
   );
 }

--- a/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
+++ b/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
@@ -2,15 +2,7 @@
 
 exports[`Tenant list Action menu click Duplicate click 1`] = `
 <Fragment>
-  <EuiPageHeader>
-    <EuiTitle
-      size="l"
-    >
-      <h1>
-        Tenants
-      </h1>
-    </EuiTitle>
-  </EuiPageHeader>
+  <EuiPageHeader />
   <EuiPageContent>
     <EuiPageContentHeader>
       <EuiPageContentHeaderSection>
@@ -31,12 +23,9 @@ exports[`Tenant list Action menu click Duplicate click 1`] = `
         </EuiTitle>
         <EuiText
           color="subdued"
-          size="xs"
+          size="s"
         >
-          Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations, dashboards, and other OpenSearch Dashboards objects. Use tenants to safely share your work with other OpenSearch Dashboards users. You can control which roles have access to a tenant and whether those roles have read or write access. The “Current” label indicates which tenant you are using now. Switch to another tenant anytime from your user profile, which is located on the top right of the screen. 
-          <ExternalLink
-            href="https://opensearch.org/docs/latest/security-plugin/multi-tenancy/multi-tenancy-config"
-          />
+          Manage tenants that already have been created. Global tenant is the default when tenancy is turned off.
         </EuiText>
       </EuiPageContentHeaderSection>
       <EuiPageContentHeaderSection>
@@ -83,6 +72,14 @@ exports[`Tenant list Action menu click Duplicate click 1`] = `
               Create visualizations
             </EuiButtonEmpty>
             <EuiButtonEmpty
+              disabled={true}
+              id="set as Global Default"
+              key="Set as Global Default key"
+              onClick={[Function]}
+            >
+              Set as Default Tenant
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
               color="danger"
               disabled={false}
               id="delete"
@@ -113,6 +110,11 @@ exports[`Tenant list Action menu click Duplicate click 1`] = `
               "name": "Name",
               "render": [Function],
               "sortable": true,
+            },
+            Object {
+              "field": "tenant",
+              "name": "Status",
+              "render": [Function],
             },
             Object {
               "field": "description",
@@ -188,15 +190,7 @@ exports[`Tenant list Action menu click Duplicate click 1`] = `
 
 exports[`Tenant list Action menu click Edit click 1`] = `
 <Fragment>
-  <EuiPageHeader>
-    <EuiTitle
-      size="l"
-    >
-      <h1>
-        Tenants
-      </h1>
-    </EuiTitle>
-  </EuiPageHeader>
+  <EuiPageHeader />
   <EuiPageContent>
     <EuiPageContentHeader>
       <EuiPageContentHeaderSection>
@@ -217,12 +211,9 @@ exports[`Tenant list Action menu click Edit click 1`] = `
         </EuiTitle>
         <EuiText
           color="subdued"
-          size="xs"
+          size="s"
         >
-          Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations, dashboards, and other OpenSearch Dashboards objects. Use tenants to safely share your work with other OpenSearch Dashboards users. You can control which roles have access to a tenant and whether those roles have read or write access. The “Current” label indicates which tenant you are using now. Switch to another tenant anytime from your user profile, which is located on the top right of the screen. 
-          <ExternalLink
-            href="https://opensearch.org/docs/latest/security-plugin/multi-tenancy/multi-tenancy-config"
-          />
+          Manage tenants that already have been created. Global tenant is the default when tenancy is turned off.
         </EuiText>
       </EuiPageContentHeaderSection>
       <EuiPageContentHeaderSection>
@@ -269,6 +260,14 @@ exports[`Tenant list Action menu click Edit click 1`] = `
               Create visualizations
             </EuiButtonEmpty>
             <EuiButtonEmpty
+              disabled={true}
+              id="set as Global Default"
+              key="Set as Global Default key"
+              onClick={[Function]}
+            >
+              Set as Default Tenant
+            </EuiButtonEmpty>
+            <EuiButtonEmpty
               color="danger"
               disabled={false}
               id="delete"
@@ -299,6 +298,11 @@ exports[`Tenant list Action menu click Edit click 1`] = `
               "name": "Name",
               "render": [Function],
               "sortable": true,
+            },
+            Object {
+              "field": "tenant",
+              "name": "Status",
+              "render": [Function],
             },
             Object {
               "field": "description",

--- a/public/apps/configuration/panels/tenant-list/test/tenant-list.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/test/tenant-list.test.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { TenantList } from '../tenant-list';
+import { ManageTab } from '../manage_tab';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { EuiInMemoryTable } from '@elastic/eui';
@@ -21,6 +21,7 @@ import { useDeleteConfirmState } from '../../../utils/delete-confirm-modal-utils
 import { Tenant } from '../../../types';
 import { TenantEditModal } from '../edit-modal';
 import { TenantInstructionView } from '../tenant-instruction-view';
+import { getDashboardsInfo } from '../../../../../utils/dashboards-info-utils';
 
 jest.mock('../../../utils/tenant-utils');
 jest.mock('../../../../../utils/auth-info-utils');
@@ -37,6 +38,19 @@ jest.mock('../../../utils/toast-utils', () => ({
   getSuccessToastMessage: jest.fn(),
   createUnknownErrorToast: jest.fn(),
 }));
+
+jest.mock('../../../../../utils/dashboards-info-utils', () => ({
+  getDashboardsInfo: jest.fn().mockImplementation(() => {
+    return mockDashboardsInfo;
+  }),
+}));
+
+const mockDashboardsInfo = {
+  multitenancy_enabled: true,
+  private_tenant_enabled: true,
+  default_tenant: '',
+};
+
 // eslint-disable-next-line
 const mockTenantUtils = require('../../../utils/tenant-utils');
 // eslint-disable-next-line
@@ -46,6 +60,11 @@ describe('Tenant list', () => {
   const setState = jest.fn();
   const mockCoreStart = {
     http: 1,
+    chrome: {
+      setBreadcrumbs() {
+        return 1;
+      },
+    },
   };
   const config = {
     multitenancy: {
@@ -61,6 +80,10 @@ describe('Tenant list', () => {
   });
 
   it('Render empty', () => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
+
     const mockTenantListingData = [
       {
         tenant: 'tenant_1',
@@ -73,7 +96,7 @@ describe('Tenant list', () => {
     mockTenantUtils.transformTenantData = jest.fn().mockReturnValue(mockTenantListingData);
 
     const component = shallow(
-      <TenantList
+      <ManageTab
         coreStart={mockCoreStart as any}
         navigation={{} as any}
         params={{} as any}
@@ -85,6 +108,13 @@ describe('Tenant list', () => {
   });
 
   it('renders when multitenancy is disabled in the opensearch_dashboards.yml', () => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return {
+        multitenancy_enabled: false,
+        private_tenant_enabled: true,
+        default_tenant: '',
+      };
+    });
     const config1 = {
       multitenancy: {
         enabled: false,
@@ -94,7 +124,7 @@ describe('Tenant list', () => {
       },
     };
     const component = shallow(
-      <TenantList
+      <ManageTab
         coreStart={mockCoreStart as any}
         navigation={{} as any}
         params={{} as any}
@@ -113,8 +143,8 @@ describe('Tenant list', () => {
     });
 
     shallow(
-      <TenantList
-        coreStart={{} as any}
+      <ManageTab
+        coreStart={mockCoreStart as any}
         navigation={{} as any}
         params={{} as any}
         config={config as any}
@@ -143,7 +173,7 @@ describe('Tenant list', () => {
     mockTenantUtils.transformTenantData = jest.fn().mockReturnValue(mockTenantListingData);
 
     shallow(
-      <TenantList
+      <ManageTab
         coreStart={mockCoreStart as any}
         navigation={{} as any}
         params={{} as any}
@@ -163,7 +193,7 @@ describe('Tenant list', () => {
 
   it('delete tenant', (done) => {
     shallow(
-      <TenantList
+      <ManageTab
         coreStart={mockCoreStart as any}
         navigation={{} as any}
         params={{} as any}
@@ -188,7 +218,7 @@ describe('Tenant list', () => {
     const loggingFunc = jest.fn();
     jest.spyOn(console, 'log').mockImplementationOnce(loggingFunc);
     shallow(
-      <TenantList
+      <ManageTab
         coreStart={mockCoreStart as any}
         navigation={{} as any}
         params={{} as any}
@@ -207,7 +237,7 @@ describe('Tenant list', () => {
 
   it('submit tenant', () => {
     const component = shallow(
-      <TenantList
+      <ManageTab
         coreStart={mockCoreStart as any}
         navigation={{} as any}
         params={{} as any}
@@ -229,7 +259,7 @@ describe('Tenant list', () => {
       throw error;
     });
     const component = shallow(
-      <TenantList
+      <ManageTab
         coreStart={mockCoreStart as any}
         navigation={{} as any}
         params={{} as any}
@@ -267,7 +297,7 @@ describe('Tenant list', () => {
     it('edit and delete should be disabled when selected tenant is reserved', () => {
       jest.spyOn(React, 'useState').mockImplementation(() => [[sampleReservedTenant], jest.fn()]);
       const component = shallow(
-        <TenantList
+        <ManageTab
           coreStart={mockCoreStart as any}
           navigation={{} as any}
           params={{} as any}
@@ -283,7 +313,7 @@ describe('Tenant list', () => {
         .spyOn(React, 'useState')
         .mockImplementation(() => [[sampleReservedTenant, sampleCustomTenant1], jest.fn()]);
       const component = shallow(
-        <TenantList
+        <ManageTab
           coreStart={mockCoreStart as any}
           navigation={{} as any}
           params={{} as any}
@@ -303,7 +333,7 @@ describe('Tenant list', () => {
         .spyOn(React, 'useState')
         .mockImplementation(() => [[sampleCustomTenant1, sampleCustomTenant2], jest.fn()]);
       const component = shallow(
-        <TenantList
+        <ManageTab
           coreStart={mockCoreStart as any}
           navigation={{} as any}
           params={{} as any}
@@ -332,7 +362,7 @@ describe('Tenant list', () => {
     beforeEach(() => {
       jest.spyOn(React, 'useState').mockImplementation(() => [[sampleCustomTenant1], jest.fn()]);
       component = shallow(
-        <TenantList
+        <ManageTab
           coreStart={mockCoreStart as any}
           navigation={{} as any}
           params={{} as any}

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -197,6 +197,51 @@ exports[`Get started (landing page) renders when backend configuration is disabl
         </EuiButton>
       </EuiText>
     </EuiPanel>
+    <EuiSpacer
+      size="l"
+    />
+    <EuiPanel
+      paddingSize="l"
+    >
+      <EuiTitle
+        size="s"
+      >
+        <h3>
+          Optional: Multi-tenancy
+        </h3>
+      </EuiTitle>
+      <EuiText
+        color="subdued"
+        size="s"
+      >
+        <p>
+          By default tenancy is activated in Dashboards. Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations, dashboards, and other OpenSearch Dashboards objects.
+        </p>
+        <EuiFlexGroup
+          gutterSize="s"
+        >
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiButton
+              fill={true}
+              onClick={[Function]}
+            >
+              Manage Multi-tenancy
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiButton
+              onClick={[Function]}
+            >
+              Configure Multi-tenancy
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiText>
+    </EuiPanel>
   </div>
 </Fragment>
 `;
@@ -476,6 +521,51 @@ exports[`Get started (landing page) renders when backend configuration is enable
         >
           Purge cache
         </EuiButton>
+      </EuiText>
+    </EuiPanel>
+    <EuiSpacer
+      size="l"
+    />
+    <EuiPanel
+      paddingSize="l"
+    >
+      <EuiTitle
+        size="s"
+      >
+        <h3>
+          Optional: Multi-tenancy
+        </h3>
+      </EuiTitle>
+      <EuiText
+        color="subdued"
+        size="s"
+      >
+        <p>
+          By default tenancy is activated in Dashboards. Tenants in OpenSearch Dashboards are spaces for saving index patterns, visualizations, dashboards, and other OpenSearch Dashboards objects.
+        </p>
+        <EuiFlexGroup
+          gutterSize="s"
+        >
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiButton
+              fill={true}
+              onClick={[Function]}
+            >
+              Manage Multi-tenancy
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem
+            grow={false}
+          >
+            <EuiButton
+              onClick={[Function]}
+            >
+              Configure Multi-tenancy
+            </EuiButton>
+          </EuiFlexItem>
+        </EuiFlexGroup>
       </EuiText>
     </EuiPanel>
   </div>

--- a/public/apps/configuration/types.ts
+++ b/public/apps/configuration/types.ts
@@ -24,6 +24,8 @@ export enum ResourceType {
   users = 'users',
   permissions = 'permissions',
   tenants = 'tenants',
+  tenantsManageTab = 'tenantsManageTab',
+  tenantsConfigureTab = 'tenantsConfigureTab',
   auth = 'auth',
   auditLogging = 'auditLogging',
 }
@@ -33,6 +35,8 @@ export enum Action {
   create = 'create',
   edit = 'edit',
   duplicate = 'duplicate',
+  manage = 'manage',
+  configure = 'configure',
 }
 
 export enum SubAction {

--- a/public/apps/configuration/utils/request-utils.ts
+++ b/public/apps/configuration/utils/request-utils.ts
@@ -30,6 +30,10 @@ export async function httpPost<T>(http: HttpStart, url: string, body?: object): 
   return await request<T>(http.post, url, body);
 }
 
+export async function httpPut<T>(http: HttpStart, url: string, body?: object): Promise<T> {
+  return await request<T>(http.put, url, body);
+}
+
 export async function httpDelete<T>(http: HttpStart, url: string): Promise<T> {
   return await request<T>(http.delete, url);
 }

--- a/public/apps/configuration/utils/tenancy-config_util.tsx
+++ b/public/apps/configuration/utils/tenancy-config_util.tsx
@@ -1,0 +1,28 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { HttpStart } from 'opensearch-dashboards/public';
+import { API_ENDPOINT_TENANCY_CONFIGS } from '../constants';
+import { httpGet, httpPut, httpPost } from './request-utils';
+import { TenancyConfigSettings } from '../panels/tenancy-config/types';
+
+export async function updateTenancyConfig(http: HttpStart, updateObject: TenancyConfigSettings) {
+  return await httpPost(http, API_ENDPOINT_TENANCY_CONFIGS, updateObject);
+}
+
+export async function getTenancyConfig(http: HttpStart): Promise<TenancyConfigSettings> {
+  const rawConfiguration = await httpGet<any>(http, API_ENDPOINT_TENANCY_CONFIGS);
+  return rawConfiguration;
+}

--- a/public/apps/configuration/utils/test/tenant-utils.test.tsx
+++ b/public/apps/configuration/utils/test/tenant-utils.test.tsx
@@ -82,25 +82,23 @@ describe('Tenant list utils', () => {
     };
 
     it('transform global tenant', () => {
-      const result = transformTenantData({ global_tenant: globalTenant }, false);
-      expect(result.length).toBe(1);
+      const result = transformTenantData({ global_tenant: globalTenant });
+      expect(result.length).toBe(2);
       expect(result[0]).toEqual(expectedGlobalTenantListing);
     });
 
     it('transform private tenant', () => {
-      const result = transformTenantData({}, true);
+      const result = transformTenantData({});
       expect(result.length).toBe(1);
       expect(result[0]).toEqual(expectedPrivateTenantListing);
     });
 
     it('transform global and custom tenant', () => {
-      const result = transformTenantData(
-        { global_tenant: globalTenant, dummy: sampleTenant1 },
-        false
-      );
-      expect(result.length).toBe(2);
+      const result = transformTenantData({ global_tenant: globalTenant, dummy: sampleTenant1 });
+      expect(result.length).toBe(3);
       expect(result[0]).toEqual(expectedGlobalTenantListing);
-      expect(result[1]).toMatchObject(expectedTenantListing);
+      expect(result[1]).toMatchObject(expectedPrivateTenantListing);
+      expect(result[2]).toMatchObject(expectedTenantListing);
     });
 
     it('transform global, private and custom tenant', () => {

--- a/public/apps/configuration/utils/test/toast-utils.test.tsx
+++ b/public/apps/configuration/utils/test/toast-utils.test.tsx
@@ -89,6 +89,7 @@ describe('Toast utils', () => {
       const result = createUnknownErrorToast('dummy', 'dummy_action');
       const expectedUnknownErrorToast: Toast = {
         id: 'dummy',
+        iconType: 'alert',
         color: 'danger',
         title: 'Failed to dummy_action',
         text:

--- a/public/apps/configuration/utils/toast-utils.tsx
+++ b/public/apps/configuration/utils/toast-utils.tsx
@@ -20,6 +20,17 @@ export function createErrorToast(id: string, title: string, text: string): Toast
   return {
     id,
     color: 'danger',
+    iconType: 'alert',
+    title,
+    text,
+  };
+}
+
+export function createSuccessToast(id: string, title: string, text: string): Toast {
+  return {
+    id,
+    color: 'success',
+    iconType: 'check',
     title,
     text,
   };
@@ -31,6 +42,14 @@ export function createUnknownErrorToast(id: string, failedAction: string): Toast
     `Failed to ${failedAction}`,
     `Failed to ${failedAction}. You may refresh the page to retry or see browser console for more information.`
   );
+}
+
+export function createTenancyErrorToast(id: string, title: string, Message: string): Toast {
+  return createErrorToast(id, title, Message);
+}
+
+export function createTenancySuccessToast(id: string, Title: string, Message: string): Toast {
+  return createSuccessToast(id, Title, Message);
 }
 
 export function useToastState(): [Toast[], (toAdd: Toast) => void, (toDelete: Toast) => void] {

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -47,6 +47,7 @@ import {
 import { addTenantToShareURL } from './services/shared-link';
 import { interceptError } from './utils/logout-utils';
 import { tenantColumn, getNamespacesToRegister } from './apps/configuration/utils/tenant-utils';
+import { getDashboardsInfoSafe } from './utils/dashboards-info-utils';
 
 async function hasApiPermission(core: CoreSetup): Promise<boolean | undefined> {
   try {
@@ -88,6 +89,7 @@ export class SecurityPlugin
     const config = this.initializerContext.config.get<ClientConfigType>();
 
     const accountInfo = (await fetchAccountInfoSafe(core.http))?.data;
+    const multitenancyEnabled = (await getDashboardsInfoSafe(core.http))?.multitenancy_enabled;
     const isReadonly = accountInfo?.roles.some((role) =>
       (config.readonly_mode?.roles || DEFAULT_READONLY_ROLES).includes(role)
     );
@@ -153,7 +155,7 @@ export class SecurityPlugin
       })
     );
 
-    if (config.multitenancy.enabled && config.multitenancy.enable_aggregation_view) {
+    if (multitenancyEnabled && config.multitenancy.enable_aggregation_view) {
       deps.savedObjectsManagement.columns.register(
         (tenantColumn as unknown) as SavedObjectsManagementColumn<string>
       );

--- a/public/types.ts
+++ b/public/types.ts
@@ -40,6 +40,12 @@ export interface AuthInfo {
   };
 }
 
+export interface DashboardsInfo {
+  multitenancy_enabled?: boolean;
+  private_tenant_enabled?: boolean;
+  default_tenant: string;
+}
+
 export interface ClientConfigType {
   readonly_mode: {
     roles: string[];

--- a/public/utils/dashboards-info-utils.tsx
+++ b/public/utils/dashboards-info-utils.tsx
@@ -1,0 +1,29 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { HttpStart } from 'opensearch-dashboards/public';
+import { API_ENDPOINT_DASHBOARDSINFO } from '../../common';
+import { httpGet, httpGetWithIgnores } from '../apps/configuration/utils/request-utils';
+import { DashboardsInfo } from '../types';
+import { AccountInfo } from '../apps/account/types';
+import { API_ENDPOINT_ACCOUNT_INFO } from '../apps/account/constants';
+
+export async function getDashboardsInfo(http: HttpStart) {
+  return await httpGet<DashboardsInfo>(http, API_ENDPOINT_DASHBOARDSINFO);
+}
+
+export async function getDashboardsInfoSafe(http: HttpStart): Promise<DashboardsInfo | undefined> {
+  return httpGetWithIgnores<DashboardsInfo>(http, API_ENDPOINT_DASHBOARDSINFO, [401]);
+}

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -246,15 +246,19 @@ export abstract class AuthenticationType implements IAuthenticationType {
       }
     }
 
-    const selectedTenant = resolveTenant(
+    const dashboardsInfo = await this.securityClient.dashboardsinfo(request, authHeader);
+
+    return resolveTenant({
       request,
-      authInfo.user_name,
-      authInfo.roles,
-      authInfo.tenants,
-      this.config,
-      cookie
-    );
-    return selectedTenant;
+      username: authInfo.user_name,
+      roles: authInfo.roles,
+      availabeTenants: authInfo.tenants,
+      config: this.config,
+      cookie,
+      multitenancyEnabled: dashboardsInfo.multitenancy_enabled,
+      privateTenantEnabled: dashboardsInfo.private_tenant_enabled,
+      defaultTenant: dashboardsInfo.default_tenant,
+    });
   }
 
   isPageRequest(request: OpenSearchDashboardsRequest) {

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -117,15 +117,19 @@ export class BasicAuthRoutes {
           expiryTime: Date.now() + this.config.session.ttl,
         };
 
-        if (this.config.multitenancy?.enabled) {
-          const selectTenant = resolveTenant(
+        if (user.multitenancy_enabled) {
+          const selectTenant = resolveTenant({
             request,
-            user.username,
-            user.roles,
-            user.tenants,
-            this.config,
-            sessionStorage
-          );
+            username: user.username,
+            roles: user.roles,
+            availabeTenants: user.tenants,
+            config: this.config,
+            cookie: sessionStorage,
+            multitenancyEnabled: user.multitenancy_enabled,
+            privateTenantEnabled: user.private_tenant_enabled,
+            defaultTenant: user.default_tenant,
+          });
+          // const selectTenant = user.default_tenant;
           sessionStorage.tenant = selectTenant;
         }
         this.sessionStorageFactory.asScoped(request).set(sessionStorage);
@@ -203,15 +207,18 @@ export class BasicAuthRoutes {
             expiryTime: Date.now() + this.config.session.ttl,
           };
 
-          if (this.config.multitenancy?.enabled) {
-            const selectTenant = resolveTenant(
+          if (user.multitenancy_enabled) {
+            const selectTenant = resolveTenant({
               request,
-              user.username,
-              user.roles,
-              user.tenants,
-              this.config,
-              sessionStorage
-            );
+              username: user.username,
+              roles: user.roles,
+              availabeTenants: user.tenants,
+              config: this.config,
+              cookie: sessionStorage,
+              multitenancyEnabled: user.multitenancy_enabled,
+              privateTenantEnabled: user.private_tenant_enabled,
+              defaultTenant: user.default_tenant,
+            });
             sessionStorage.tenant = selectTenant;
           }
           this.sessionStorageFactory.asScoped(request).set(sessionStorage);

--- a/server/auth/user.ts
+++ b/server/auth/user.ts
@@ -21,4 +21,7 @@ export interface User {
   selectedTenant?: string;
   credentials?: any;
   proxyCredentials?: any;
+  multitenancy_enabled?: boolean;
+  private_tenant_enabled?: boolean;
+  default_tenant?: string;
 }

--- a/server/backend/opensearch_security_plugin.ts
+++ b/server/backend/opensearch_security_plugin.ts
@@ -30,6 +30,12 @@ export default function (Client: any, config: any, components: any) {
     },
   });
 
+  Client.prototype.opensearch_security.prototype.dashboardsinfo = ca({
+    url: {
+      fmt: '/_plugins/_security/dashboardsinfo',
+    },
+  });
+
   /**
    * Gets tenant info and opensearch-dashboards server info.
    *
@@ -68,6 +74,14 @@ export default function (Client: any, config: any, components: any) {
     needBody: true,
     url: {
       fmt: '/_plugins/_security/api/authtoken',
+    },
+  });
+
+  Client.prototype.opensearch_security.prototype.tenancy_configs = ca({
+    method: 'PUT',
+    needBody: true,
+    url: {
+      fmt: '/_plugins/_security/api/tenancy/config',
     },
   });
 }

--- a/server/multitenancy/routes.ts
+++ b/server/multitenancy/routes.ts
@@ -115,6 +115,37 @@ export function setupMultitenantRoutes(
     }
   );
 
+  router.put(
+    {
+      path: '/api/v1/configuration/tenancy/config',
+      validate: {
+        body: schema.object({
+          multitenancy_enabled: schema.boolean(),
+          private_tenant_enabled: schema.boolean(),
+          default_tenant: schema.string(),
+        }),
+      },
+    },
+    async (context, request, response) => {
+      try {
+        const esResponse = await securityClient.putMultitenancyConfigurations(
+          request,
+          request.body
+        );
+        return response.ok({
+          body: esResponse,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+      } catch (error) {
+        return response.internalError({
+          body: error.message,
+        });
+      }
+    }
+  );
+
   router.post(
     {
       // FIXME: Seems this is not being used, confirm and delete if not used anymore

--- a/server/multitenancy/test/tenant_resolver.test.ts
+++ b/server/multitenancy/test/tenant_resolver.test.ts
@@ -23,6 +23,7 @@ describe("Resolve tenants when multitenancy is enabled and both 'Global' and 'Pr
       config.preferredTenants,
       config.availableTenants,
       config.globalTenantEnabled,
+      config.multitenancy_enabled,
       config.privateTenantEnabled
     );
   }
@@ -34,6 +35,7 @@ describe("Resolve tenants when multitenancy is enabled and both 'Global' and 'Pr
       preferredTenants: undefined,
       availableTenants: { global_tenant: true, admin_tenant: true, test_tenant: true, admin: true },
       globalTenantEnabled: false,
+      multitenancy_enabled: true,
       privateTenantEnabled: false,
     };
 
@@ -48,10 +50,26 @@ describe("Resolve tenants when multitenancy is enabled and both 'Global' and 'Pr
       preferredTenants: undefined,
       availableTenants: { global_tenant: true, testuser: true },
       globalTenantEnabled: false,
+      multitenancy_enabled: true,
       privateTenantEnabled: false,
     };
 
     const nonadminResult = resolveWithConfig(nonadminConfig);
     expect(nonadminResult).toEqual('global_tenant');
+  });
+
+  it('Resolve tenant with multitenancy disabled and global tenant enabled', () => {
+    const adminConfig = {
+      username: 'admin',
+      requestedTenant: undefined,
+      preferredTenants: undefined,
+      availableTenants: { global_tenant: true, testuser: true },
+      globalTenantEnabled: true,
+      multitenancy_enabled: false,
+      privateTenantEnabled: false,
+    };
+
+    const adminResult = resolveWithConfig(adminConfig);
+    expect(adminResult).toEqual('');
   });
 });

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -543,6 +543,30 @@ export function defineRoutes(router: IRouter) {
     }
   );
 
+  router.get(
+    {
+      path: `${API_PREFIX}/auth/dashboardsinfo`,
+      validate: false,
+    },
+    async (
+      context,
+      request,
+      response
+    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
+      const client = context.security_plugin.esClient.asScoped(request);
+      let esResp;
+      try {
+        esResp = await client.callAsCurrentUser('opensearch_security.dashboardsinfo');
+
+        return response.ok({
+          body: esResp,
+        });
+      } catch (error) {
+        return errorResponse(response, error);
+      }
+    }
+  );
+
   /**
    * Gets audit log configuration。
    *

--- a/test/jest_integration/saml_auth.test.ts
+++ b/test/jest_integration/saml_auth.test.ts
@@ -284,87 +284,87 @@ describe('start OpenSearch Dashboards server', () => {
     await driver.quit();
   });
 
-  it('Tenancy persisted after Logout in SAML', async () => {
-    const driver = getDriver(browser, options).build();
-
-    await driver.get('http://localhost:5601/app/opensearch_dashboards_overview#/');
-
-    await driver.findElement(By.xpath(signInBtnXPath)).click();
-
-    await driver.wait(until.elementsLocated(By.xpath(pageTitleXPath)), 10000);
-
-    await driver.wait(
-      until.elementsLocated(By.xpath('//button[@aria-label="Closes this modal window"]')),
-      10000
-    );
-
-    // Select Global Tenant Radio Button
-    const radio = await driver.findElement(By.xpath('//input[@id="global"]'));
-    await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
-    await driver.executeScript('arguments[0].click();', radio);
-
-    await driver.wait(until.elementIsSelected(radio));
-
-    await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
-
-    await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
-
-    await driver.findElement(By.xpath(userIconBtnXPath)).click();
-
-    await driver.findElement(By.xpath('//*[@data-test-subj="log-out-1"]')).click();
-
-    // RELOGIN AND CHECK TENANT
-
-    await driver.wait(until.elementsLocated(By.xpath(signInBtnXPath)), 10000);
-
-    await driver.findElement(By.xpath(signInBtnXPath)).click();
-
-    await driver.wait(until.elementsLocated(By.xpath(skipWelcomeBtnXPath)), 10000);
-
-    await driver.findElement(By.xpath(skipWelcomeBtnXPath)).click();
-
-    await driver.findElement(By.xpath(userIconBtnXPath)).click();
-
-    await driver.wait(until.elementsLocated(By.xpath(tenantNameLabelXPath)), 10000);
-
-    const tenantName = await driver.findElement(By.xpath(tenantNameLabelXPath)).getText();
-    const localStorageItem = await driver.executeScript(
-      `return window.localStorage.getItem("opendistro::security::tenant::saved")`
-    );
-
-    // Retry previous steps one more time if the webdriver doens't reload as expected
-    if (tenantName === 'Private' && localStorageItem === '""') {
-      await driver.wait(until.elementsLocated(By.xpath(tenantSwitchBtnXPath)), 10000);
-      await driver.findElement(By.xpath(tenantSwitchBtnXPath)).click();
-
-      await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
-      await driver.executeScript('arguments[0].click();', radio);
-      await driver.wait(until.elementIsSelected(radio));
-
-      await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
-
-      await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
-      await driver.findElement(By.xpath(userIconBtnXPath)).click();
-      await driver.findElement(By.xpath('//*[@data-test-subj="log-out-1"]')).click();
-
-      await driver.wait(until.elementsLocated(By.xpath(signInBtnXPath)), 10000);
-      await driver.findElement(By.xpath(signInBtnXPath)).click();
-
-      await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
-      await driver.findElement(By.xpath(userIconBtnXPath)).click();
-      await driver.wait(until.elementsLocated(By.xpath(tenantNameLabelXPath)), 10000);
-
-      const newtenantName = await driver.findElement(By.xpath(tenantNameLabelXPath)).getText();
-      expect(newtenantName).toEqual('Global');
-    } else {
-      expect(localStorageItem).toEqual('""');
-      expect(tenantName).toEqual('Global');
-    }
-    await driver.manage().deleteAllCookies();
-    await driver.quit();
-
-    expect(localStorageItem).toEqual('""');
-  });
+  // it('Tenancy persisted after Logout in SAML', async () => {
+  //   const driver = getDriver(browser, options).build();
+  //
+  //   await driver.get('http://localhost:5601/app/opensearch_dashboards_overview#/');
+  //
+  //   await driver.findElement(By.xpath(signInBtnXPath)).click();
+  //
+  //   await driver.wait(until.elementsLocated(By.xpath(pageTitleXPath)), 10000);
+  //
+  //   await driver.wait(
+  //     until.elementsLocated(By.xpath('//button[@aria-label="Closes this modal window"]')),
+  //     10000
+  //   );
+  //
+  //   // Select Global Tenant Radio Button
+  //   const radio = await driver.findElement(By.xpath('//input[@id="global"]'));
+  //   await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
+  //   await driver.executeScript('arguments[0].click();', radio);
+  //
+  //   await driver.wait(until.elementIsSelected(radio));
+  //
+  //   await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
+  //
+  //   await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
+  //
+  //   await driver.findElement(By.xpath(userIconBtnXPath)).click();
+  //
+  //   await driver.findElement(By.xpath('//*[@data-test-subj="log-out-1"]')).click();
+  //
+  //   // RELOGIN AND CHECK TENANT
+  //
+  //   await driver.wait(until.elementsLocated(By.xpath(signInBtnXPath)), 10000);
+  //
+  //   await driver.findElement(By.xpath(signInBtnXPath)).click();
+  //
+  //   await driver.wait(until.elementsLocated(By.xpath(skipWelcomeBtnXPath)), 10000);
+  //
+  //   await driver.findElement(By.xpath(skipWelcomeBtnXPath)).click();
+  //
+  //   await driver.findElement(By.xpath(userIconBtnXPath)).click();
+  //
+  //   await driver.wait(until.elementsLocated(By.xpath(tenantNameLabelXPath)), 10000);
+  //
+  //   const tenantName = await driver.findElement(By.xpath(tenantNameLabelXPath)).getText();
+  //   const localStorageItem = await driver.executeScript(
+  //     `return window.localStorage.getItem("opendistro::security::tenant::saved")`
+  //   );
+  //
+  //   // Retry previous steps one more time if the webdriver doens't reload as expected
+  //   if (tenantName === 'Private' && localStorageItem === '""') {
+  //     await driver.wait(until.elementsLocated(By.xpath(tenantSwitchBtnXPath)), 10000);
+  //     await driver.findElement(By.xpath(tenantSwitchBtnXPath)).click();
+  //
+  //     await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
+  //     await driver.executeScript('arguments[0].click();', radio);
+  //     await driver.wait(until.elementIsSelected(radio));
+  //
+  //     await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
+  //
+  //     await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
+  //     await driver.findElement(By.xpath(userIconBtnXPath)).click();
+  //     await driver.findElement(By.xpath('//*[@data-test-subj="log-out-1"]')).click();
+  //
+  //     await driver.wait(until.elementsLocated(By.xpath(signInBtnXPath)), 10000);
+  //     await driver.findElement(By.xpath(signInBtnXPath)).click();
+  //
+  //     await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
+  //     await driver.findElement(By.xpath(userIconBtnXPath)).click();
+  //     await driver.wait(until.elementsLocated(By.xpath(tenantNameLabelXPath)), 10000);
+  //
+  //     const newtenantName = await driver.findElement(By.xpath(tenantNameLabelXPath)).getText();
+  //     expect(newtenantName).toEqual('Global');
+  //   } else {
+  //     expect(localStorageItem).toEqual('""');
+  //     expect(tenantName).toEqual('Global');
+  //   }
+  //   await driver.manage().deleteAllCookies();
+  //   await driver.quit();
+  //
+  //   expect(localStorageItem).toEqual('""');
+  // });
 });
 
 function getDriver(browser: string, options: Options) {

--- a/test/jest_integration/saml_auth.test.ts
+++ b/test/jest_integration/saml_auth.test.ts
@@ -284,87 +284,87 @@ describe('start OpenSearch Dashboards server', () => {
     await driver.quit();
   });
 
-  // it('Tenancy persisted after Logout in SAML', async () => {
-  //   const driver = getDriver(browser, options).build();
-  //
-  //   await driver.get('http://localhost:5601/app/opensearch_dashboards_overview#/');
-  //
-  //   await driver.findElement(By.xpath(signInBtnXPath)).click();
-  //
-  //   await driver.wait(until.elementsLocated(By.xpath(pageTitleXPath)), 10000);
-  //
-  //   await driver.wait(
-  //     until.elementsLocated(By.xpath('//button[@aria-label="Closes this modal window"]')),
-  //     10000
-  //   );
-  //
-  //   // Select Global Tenant Radio Button
-  //   const radio = await driver.findElement(By.xpath('//input[@id="global"]'));
-  //   await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
-  //   await driver.executeScript('arguments[0].click();', radio);
-  //
-  //   await driver.wait(until.elementIsSelected(radio));
-  //
-  //   await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
-  //
-  //   await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
-  //
-  //   await driver.findElement(By.xpath(userIconBtnXPath)).click();
-  //
-  //   await driver.findElement(By.xpath('//*[@data-test-subj="log-out-1"]')).click();
-  //
-  //   // RELOGIN AND CHECK TENANT
-  //
-  //   await driver.wait(until.elementsLocated(By.xpath(signInBtnXPath)), 10000);
-  //
-  //   await driver.findElement(By.xpath(signInBtnXPath)).click();
-  //
-  //   await driver.wait(until.elementsLocated(By.xpath(skipWelcomeBtnXPath)), 10000);
-  //
-  //   await driver.findElement(By.xpath(skipWelcomeBtnXPath)).click();
-  //
-  //   await driver.findElement(By.xpath(userIconBtnXPath)).click();
-  //
-  //   await driver.wait(until.elementsLocated(By.xpath(tenantNameLabelXPath)), 10000);
-  //
-  //   const tenantName = await driver.findElement(By.xpath(tenantNameLabelXPath)).getText();
-  //   const localStorageItem = await driver.executeScript(
-  //     `return window.localStorage.getItem("opendistro::security::tenant::saved")`
-  //   );
-  //
-  //   // Retry previous steps one more time if the webdriver doens't reload as expected
-  //   if (tenantName === 'Private' && localStorageItem === '""') {
-  //     await driver.wait(until.elementsLocated(By.xpath(tenantSwitchBtnXPath)), 10000);
-  //     await driver.findElement(By.xpath(tenantSwitchBtnXPath)).click();
-  //
-  //     await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
-  //     await driver.executeScript('arguments[0].click();', radio);
-  //     await driver.wait(until.elementIsSelected(radio));
-  //
-  //     await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
-  //
-  //     await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
-  //     await driver.findElement(By.xpath(userIconBtnXPath)).click();
-  //     await driver.findElement(By.xpath('//*[@data-test-subj="log-out-1"]')).click();
-  //
-  //     await driver.wait(until.elementsLocated(By.xpath(signInBtnXPath)), 10000);
-  //     await driver.findElement(By.xpath(signInBtnXPath)).click();
-  //
-  //     await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
-  //     await driver.findElement(By.xpath(userIconBtnXPath)).click();
-  //     await driver.wait(until.elementsLocated(By.xpath(tenantNameLabelXPath)), 10000);
-  //
-  //     const newtenantName = await driver.findElement(By.xpath(tenantNameLabelXPath)).getText();
-  //     expect(newtenantName).toEqual('Global');
-  //   } else {
-  //     expect(localStorageItem).toEqual('""');
-  //     expect(tenantName).toEqual('Global');
-  //   }
-  //   await driver.manage().deleteAllCookies();
-  //   await driver.quit();
-  //
-  //   expect(localStorageItem).toEqual('""');
-  // });
+  it('Tenancy persisted after Logout in SAML', async () => {
+    const driver = getDriver(browser, options).build();
+
+    await driver.get('http://localhost:5601/app/opensearch_dashboards_overview#/');
+
+    await driver.findElement(By.xpath(signInBtnXPath)).click();
+
+    await driver.wait(until.elementsLocated(By.xpath(pageTitleXPath)), 10000);
+
+    await driver.wait(
+      until.elementsLocated(By.xpath('//button[@aria-label="Closes this modal window"]')),
+      10000
+    );
+
+    // Select Global Tenant Radio Button
+    const radio = await driver.findElement(By.xpath('//input[@id="global"]'));
+    await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
+    await driver.executeScript('arguments[0].click();', radio);
+
+    await driver.wait(until.elementIsSelected(radio));
+
+    await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
+
+    await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
+
+    await driver.findElement(By.xpath(userIconBtnXPath)).click();
+
+    await driver.findElement(By.xpath('//*[@data-test-subj="log-out-1"]')).click();
+
+    // RELOGIN AND CHECK TENANT
+
+    await driver.wait(until.elementsLocated(By.xpath(signInBtnXPath)), 10000);
+
+    await driver.findElement(By.xpath(signInBtnXPath)).click();
+
+    await driver.wait(until.elementsLocated(By.xpath(skipWelcomeBtnXPath)), 10000);
+
+    await driver.findElement(By.xpath(skipWelcomeBtnXPath)).click();
+
+    await driver.findElement(By.xpath(userIconBtnXPath)).click();
+
+    await driver.wait(until.elementsLocated(By.xpath(tenantNameLabelXPath)), 10000);
+
+    const tenantName = await driver.findElement(By.xpath(tenantNameLabelXPath)).getText();
+    const localStorageItem = await driver.executeScript(
+      `return window.localStorage.getItem("opendistro::security::tenant::saved")`
+    );
+
+    // Retry previous steps one more time if the webdriver doens't reload as expected
+    if (tenantName === 'Private' && localStorageItem === '""') {
+      await driver.wait(until.elementsLocated(By.xpath(tenantSwitchBtnXPath)), 10000);
+      await driver.findElement(By.xpath(tenantSwitchBtnXPath)).click();
+
+      await driver.executeScript('arguments[0].scrollIntoView(true);', radio);
+      await driver.executeScript('arguments[0].click();', radio);
+      await driver.wait(until.elementIsSelected(radio));
+
+      await driver.findElement(By.xpath('//button[@data-test-subj="confirm"]')).click();
+
+      await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
+      await driver.findElement(By.xpath(userIconBtnXPath)).click();
+      await driver.findElement(By.xpath('//*[@data-test-subj="log-out-1"]')).click();
+
+      await driver.wait(until.elementsLocated(By.xpath(signInBtnXPath)), 10000);
+      await driver.findElement(By.xpath(signInBtnXPath)).click();
+
+      await driver.wait(until.elementsLocated(By.xpath(userIconBtnXPath)), 10000);
+      await driver.findElement(By.xpath(userIconBtnXPath)).click();
+      await driver.wait(until.elementsLocated(By.xpath(tenantNameLabelXPath)), 10000);
+
+      const newtenantName = await driver.findElement(By.xpath(tenantNameLabelXPath)).getText();
+      expect(newtenantName).toEqual('Global');
+    } else {
+      expect(localStorageItem).toEqual('""');
+      expect(tenantName).toEqual('Global');
+    }
+    await driver.manage().deleteAllCookies();
+    await driver.quit();
+
+    expect(localStorageItem).toEqual('""');
+  });
 });
 
 function getDriver(browser: string, options: Options) {


### PR DESCRIPTION
### Description
* Category : Enhancement
* Why these changes are required?
These changes are required to dynamically enable/disable multi-tenancy, private tenant and set a default tenant.
* What is the old behavior before changes and new behavior after changes?
Earlier users had to change YAML files in each node and restart node to enable/disable multi-tenancy and private tenant. With our changes, users will be able to change these settings dynamically. We will also give admins the option to set a default tenant for all users for first time log in. This PR is for changes in Dashboards so that users can use Dashboards UI to change these settings. 
Related Security plugin PR: https://github.com/opensearch-project/security/pull/2607
More details can be found here:
https://github.com/opensearch-project/OpenSearch/issues/5853
https://github.com/opensearch-project/security-dashboards-plugin/issues/1302

### Issues Resolved
https://github.com/opensearch-project/security-dashboards-plugin/issues/1302

Is this a backport? If so, please add backport PR # and/or commits #
Nope

### Testing
We have done manual testing for all changes on our local server. We will also write Integ tests for these changes.

### Check List
- [  ] New functionality includes testing
- [] New functionality has been documented. : Will document in further commits.
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

**This is still a draft request. I am still working on some minor fixes and code style.**

