### PR TITLE
Fixes mutlti-tenancy popup toggle due to hard-coded default state

### DIFF
--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -49,7 +49,11 @@ export function AccountNavButton(props: {
   const [modal, setModal] = React.useState<React.ReactNode>(null);
   const horizontalRule = <EuiHorizontalRule margin="xs" />;
   const username = props.username;
-  const [isMultiTenancyEnabled, setIsMultiTenancyEnabled] = React.useState<boolean>(true);
+  const propsMultiTenancyToggle = props.config.multitenancy.enabled;
+  const [isMultiTenancyEnabled, setIsMultiTenancyEnabled] = React.useState<boolean>(
+    propsMultiTenancyToggle || false
+  );
+  const shouldDisplaySwitchTenantsPanel = isMultiTenancyEnabled && propsMultiTenancyToggle;
 
   const showTenantSwitchPanel = useCallback(
     () =>
@@ -72,9 +76,11 @@ export function AccountNavButton(props: {
   React.useEffect(() => {
     const fetchData = async () => {
       try {
-        setIsMultiTenancyEnabled(
-          (await getDashboardsInfo(props.coreStart.http)).multitenancy_enabled
+        // defaults to true if for some reason the multitenancy_enabled flag is undefined. This should ideally never happen.
+        const { multitenancy_enabled: isEnabled = true } = await getDashboardsInfo(
+          props.coreStart.http
         );
+        setIsMultiTenancyEnabled(isEnabled);
       } catch (e) {
         // TODO: switch to better error display.
         console.error(e);
@@ -128,7 +134,7 @@ export function AccountNavButton(props: {
       >
         View roles and identities
       </EuiButtonEmpty>
-      {isMultiTenancyEnabled && (
+      {shouldDisplaySwitchTenantsPanel && (
         <>
           {horizontalRule}
           <EuiButtonEmpty data-test-subj="switch-tenants" size="xs" onClick={showTenantSwitchPanel}>


### PR DESCRIPTION
### Category
Bug fix

### Why these changes are required?
To fix the incorrect popup display for switching tenants.

### What is the old behavior before changes and new behavior after changes?
After this change the switch tenants panel and popup won't be shown if multi-tenancy is disabled.

### Issues Resolved
Resolves #1412 

### Testing
Manual testing

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).