### PR TITLE
Removes tiny.amazon.com links

### DIFF
--- a/server/multitenancy/tenant_index.ts
+++ b/server/multitenancy/tenant_index.ts
@@ -88,7 +88,6 @@ export async function migrateTenantIndices(
   }
 
   // follows the same approach in opensearch_dashboards_migrator.ts to initiate DocumentMigrator here
-  // see: https://tiny.amazon.com/foi0x1wt/githelaskibablobe4c1srccore
   const documentMigrator = new DocumentMigrator({
     opensearchDashboardsVersion,
     typeRegistry,
@@ -103,7 +102,6 @@ export async function migrateTenantIndices(
     });
 
     // follows the same aporach in opensearch_dashboards_mirator.ts to construct IndexMigrator
-    // see: https://tiny.amazon.com/9cdcchz5/githelaskibablobe4c1srccore
     //
     // FIXME: hard code batchSize, pollInterval, and scrollDuration for now
     //        they are used to fetched from `migration.xxx` config, which is not accessible from new playform


### PR DESCRIPTION
### Description
Removes tiny.amazon.com links that are internal.

### Category
Maintenance


### Testing
N/A

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).