### PR TITLE
Skip flaky SAML test as it awaits a fix

### DIFF
--- a/test/jest_integration/saml_auth.test.ts
+++ b/test/jest_integration/saml_auth.test.ts
@@ -284,7 +284,7 @@ describe('start OpenSearch Dashboards server', () => {
     await driver.quit();
   });
 
-  it('Tenancy persisted after Logout in SAML', async () => {
+  it.skip('Tenancy persisted after Logout in SAML', async () => {
     const driver = getDriver(browser, options).build();
 
     await driver.get('http://localhost:5601/app/opensearch_dashboards_overview#/');


### PR DESCRIPTION
### Description

Adds `.skip` to the SAML Test: `Tenancy persisted after Logout in SAML`. The test passes after many tries, but has a high failure rate which is making it hard to merge PRs in time. All selenium tests are going to be migrated to the opensearch-dashboards-functional-test repo as soon as the Cypress 12 upgrade is complete so that cross-origin testing is supported which is required for SAML testing.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).