### PR TITLE
Add eslint rule to forbid imports from path containing packages/ from root dir of OSD

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,18 @@ module.exports = {
   extends: ['@elastic/eslint-config-kibana', 'plugin:@elastic/eui/recommended'],
   rules: {
     // "@osd/eslint/require-license-header": "off"
+    '@osd/eslint/no-restricted-paths': [
+      'error',
+      {
+        basePath: __dirname,
+        zones: [
+          {
+            target: ['(public|server)/**/*'],
+            from: ['../../packages/**/*','packages/**/*']
+          },
+        ]
+      }
+    ]
   },
   overrides: [
     {

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,6 +1,8 @@
 files:
   include:
     - 'public/**/*.s+(a|c)ss'
+plugins:
+  - eslint-plugin-import
 rules:
   quotes:
     - 2
@@ -68,3 +70,8 @@ rules:
   no-warn: 0
   # Transition all is useful in certain situations and there's no recent info to suggest slowdown
   no-transition-all: 0
+  import/no-restricted-paths:
+    - error
+    - target: '/packages/'
+      message: 'Imports with "packages" in the path are forbidden.'
+

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,8 +1,6 @@
 files:
   include:
     - 'public/**/*.s+(a|c)ss'
-plugins:
-  - eslint-plugin-import
 rules:
   quotes:
     - 2
@@ -70,8 +68,3 @@ rules:
   no-warn: 0
   # Transition all is useful in certain situations and there's no recent info to suggest slowdown
   no-transition-all: 0
-  import/no-restricted-paths:
-    - error
-    - target: '/packages/'
-      message: 'Imports with "packages" in the path are forbidden.'
-

--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -16,10 +16,10 @@
 import { isEmpty, findKey, cloneDeep } from 'lodash';
 import { OpenSearchDashboardsRequest } from 'opensearch-dashboards/server';
 import { ResponseObject } from '@hapi/hapi';
+import { modifyUrl } from '@osd/std';
 import { SecuritySessionCookie } from '../session/security_cookie';
 import { SecurityPluginConfigType } from '..';
 import { GLOBAL_TENANT_SYMBOL, PRIVATE_TENANT_SYMBOL, globalTenantName } from '../../common';
-import { modifyUrl } from '../../../../packages/osd-std';
 import { ensureRawRequest } from '../../../../src/core/server/http/router';
 import { GOTO_PREFIX } from '../../../../src/plugins/share/common/short_url_routes';
 

--- a/server/saved_objects/saved_objects_wrapper.ts
+++ b/server/saved_objects/saved_objects_wrapper.ts
@@ -34,7 +34,6 @@ import {
   SavedObjectsUpdateOptions,
   SavedObjectsUpdateResponse,
 } from 'opensearch-dashboards/server';
-import { Config } from 'packages/osd-config/target';
 import { SecurityPluginConfigType } from '..';
 import { OpenSearchDashboardsAuthState } from '../auth/types/authentication_type';
 import {


### PR DESCRIPTION
### Description

Opening a Draft PR with a new eslint rule forbidding imports from `./packages` directory of OpenSearch dashboards which is only used for development. I added the rule directly into security-dashboards-plugin to show it working, but it would probably be best to place this directly in OSD. I have not been able to get this working with a rule in OSD core and not quite sure how dashboards plugins inherit rules from the OSD core.

I see the following rule in OSD core which looks like it should have caught the bad import: https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/.eslintrc.js#L295-L319

### Category

Bug fix

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1487

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).