### PR TITLE
Use password message from /dashboardsinfo

### DIFF
--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -67,7 +67,6 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
           (await getDashboardsInfo(props.coreStart.http)).password_validation_error_message
         );
       } catch (e) {
-        // TODO: switch to better error display.
         console.error(e);
       }
     };

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -32,6 +32,7 @@ import { logout, updateNewPassword } from './utils';
 import { PASSWORD_INSTRUCTION } from '../apps-constants';
 import { constructErrorMessageAndLog } from '../error-utils';
 import { validateCurrentPassword } from '../../utils/login-utils';
+import { getDashboardsInfo } from '../../utils/dashboards-info-utils';
 
 interface PasswordResetPanelProps {
   coreStart: CoreStart;
@@ -56,6 +57,23 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
   );
 
   const [errorCallOut, setErrorCallOut] = React.useState<string>('');
+
+  const [passwordHelpText, setPasswordHelpText] = React.useState<string>(PASSWORD_INSTRUCTION);
+
+  React.useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setPasswordHelpText(
+          (await getDashboardsInfo(props.coreStart.http)).password_validation_error_message
+        );
+      } catch (e) {
+        // TODO: switch to better error display.
+        console.error(e);
+      }
+    };
+
+    fetchData();
+  }, [props.coreStart.http]);
 
   const handleReset = async () => {
     const http = props.coreStart.http;
@@ -107,7 +125,7 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
 
           <FormRow
             headerText="New password"
-            helpText={PASSWORD_INSTRUCTION}
+            helpText={passwordHelpText}
             isInvalid={isNewPasswordInvalid}
           >
             <EuiFieldPassword

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -163,7 +163,11 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
             setNameState={setUserName}
             setIsFormValid={setIsFormValid}
           />
-          <PasswordEditPanel coreStart={props.coreStart} updatePassword={setPassword} updateIsInvalid={setIsPasswordInvalid} />
+          <PasswordEditPanel
+            coreStart={props.coreStart}
+            updatePassword={setPassword}
+            updateIsInvalid={setIsPasswordInvalid}
+          />
         </EuiForm>
       </PanelWithHeader>
       <EuiSpacer size="m" />

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -163,7 +163,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
             setNameState={setUserName}
             setIsFormValid={setIsFormValid}
           />
-          <PasswordEditPanel updatePassword={setPassword} updateIsInvalid={setIsPasswordInvalid} />
+          <PasswordEditPanel coreStart={props.coreStart} updatePassword={setPassword} updateIsInvalid={setIsPasswordInvalid} />
         </EuiForm>
       </PanelWithHeader>
       <EuiSpacer size="m" />

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -14,17 +14,37 @@
  */
 
 import React from 'react';
+import { CoreStart } from 'opensearch-dashboards/public';
 import { EuiFieldText, EuiIcon } from '@elastic/eui';
 import { FormRow } from './form-row';
 import { PASSWORD_INSTRUCTION } from '../../apps-constants';
+import { getDashboardsInfo } from '../../../utils/dashboards-info-utils';
 
 export function PasswordEditPanel(props: {
+  coreStart: CoreStart;
   updatePassword: (p: string) => void;
   updateIsInvalid: (v: boolean) => void;
 }) {
   const [password, setPassword] = React.useState<string>('');
   const [repeatPassword, setRepeatPassword] = React.useState<string>('');
   const [isRepeatPasswordInvalid, setIsRepeatPasswordInvalid] = React.useState<boolean>(false);
+  const [passwordHelpText, setPasswordHelpText] = React.useState<string>(PASSWORD_INSTRUCTION);
+
+  React.useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setPasswordHelpText(
+          (await getDashboardsInfo(props.coreStart.http)).password_validation_error_message
+        );
+        console.log(passwordHelpText);
+      } catch (e) {
+        // TODO: switch to better error display.
+        console.error(e);
+      }
+    };
+
+    fetchData();
+  }, [props.coreStart.http]);
 
   React.useEffect(() => {
     props.updatePassword(password);
@@ -43,7 +63,7 @@ export function PasswordEditPanel(props: {
 
   return (
     <>
-      <FormRow headerText="Password" helpText={PASSWORD_INSTRUCTION}>
+      <FormRow data-test-subj="password-form-row" headerText="Password" helpText={passwordHelpText}>
         <EuiFieldText
           data-test-subj="password"
           prepend={<EuiIcon type="lock" />}

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -62,7 +62,7 @@ export function PasswordEditPanel(props: {
 
   return (
     <>
-      <FormRow data-test-subj="password-form-row" headerText="Password" helpText={passwordHelpText}>
+      <FormRow headerText="Password" helpText={passwordHelpText}>
         <EuiFieldText
           data-test-subj="password"
           prepend={<EuiIcon type="lock" />}

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -36,7 +36,6 @@ export function PasswordEditPanel(props: {
         setPasswordHelpText(
           (await getDashboardsInfo(props.coreStart.http)).password_validation_error_message
         );
-        console.log(passwordHelpText);
       } catch (e) {
         // TODO: switch to better error display.
         console.error(e);

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -37,7 +37,6 @@ export function PasswordEditPanel(props: {
           (await getDashboardsInfo(props.coreStart.http)).password_validation_error_message
         );
       } catch (e) {
-        // TODO: switch to better error display.
         console.error(e);
       }
     };

--- a/public/apps/configuration/utils/test/password-edit-panel.test.tsx
+++ b/public/apps/configuration/utils/test/password-edit-panel.test.tsx
@@ -53,9 +53,6 @@ describe('Password edit panel', () => {
   });
 
   it('renders', (done) => {
-    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
-      return mockDashboardsInfo;
-    });
     mount(
       <PasswordEditPanel
         coreStart={mockCoreStart as any}

--- a/public/apps/configuration/utils/test/password-edit-panel.test.tsx
+++ b/public/apps/configuration/utils/test/password-edit-panel.test.tsx
@@ -46,16 +46,6 @@ describe('Password edit panel', () => {
   beforeEach(() => {
     useEffect.mockImplementationOnce((f) => f());
     useState.mockImplementation((initialValue) => [initialValue, setState]);
-    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
-      return mockDashboardsInfo;
-    });
-    component = shallow(
-      <PasswordEditPanel
-        coreStart={mockCoreStart as any}
-        updatePassword={updatePassword}
-        updateIsInvalid={updateIsInvalid}
-      />
-    );
   });
 
   afterEach(() => {
@@ -66,7 +56,7 @@ describe('Password edit panel', () => {
     (getDashboardsInfo as jest.Mock).mockImplementation(() => {
       return mockDashboardsInfo;
     });
-    const wrapper = mount(
+    mount(
       <PasswordEditPanel
         coreStart={mockCoreStart as any}
         updatePassword={updatePassword}
@@ -74,7 +64,6 @@ describe('Password edit panel', () => {
       />
     );
     process.nextTick(() => {
-      wrapper.update();
       expect(updatePassword).toHaveBeenCalledTimes(1);
       expect(updateIsInvalid).toHaveBeenCalledTimes(1);
       expect(setState).toBeCalledWith(mockDashboardsInfo.password_validation_error_message);
@@ -83,6 +72,13 @@ describe('Password edit panel', () => {
   });
 
   it('password field update', () => {
+    component = shallow(
+      <PasswordEditPanel
+        coreStart={mockCoreStart as any}
+        updatePassword={updatePassword}
+        updateIsInvalid={updateIsInvalid}
+      />
+    );
     const event = {
       target: { value: 'dummy' },
     } as React.ChangeEvent<HTMLInputElement>;
@@ -91,6 +87,13 @@ describe('Password edit panel', () => {
   });
 
   it('repeat password field update', () => {
+    component = shallow(
+      <PasswordEditPanel
+        coreStart={mockCoreStart as any}
+        updatePassword={updatePassword}
+        updateIsInvalid={updateIsInvalid}
+      />
+    );
     const event = {
       target: { value: 'dummy' },
     } as React.ChangeEvent<HTMLInputElement>;

--- a/public/apps/configuration/utils/test/password-edit-panel.test.tsx
+++ b/public/apps/configuration/utils/test/password-edit-panel.test.tsx
@@ -22,7 +22,8 @@ const mockDashboardsInfo = {
   multitenancy_enabled: true,
   private_tenant_enabled: true,
   default_tenant: '',
-  password_validation_error_message: 'Password must be minimum 5 characters long and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character.'
+  password_validation_error_message:
+    'Password must be minimum 5 characters long and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character.',
 };
 
 jest.mock('../../../../utils/dashboards-info-utils', () => ({
@@ -49,7 +50,11 @@ describe('Password edit panel', () => {
       return mockDashboardsInfo;
     });
     component = shallow(
-      <PasswordEditPanel coreStart={mockCoreStart as any} updatePassword={updatePassword} updateIsInvalid={updateIsInvalid} />
+      <PasswordEditPanel
+        coreStart={mockCoreStart as any}
+        updatePassword={updatePassword}
+        updateIsInvalid={updateIsInvalid}
+      />
     );
   });
 
@@ -62,7 +67,11 @@ describe('Password edit panel', () => {
       return mockDashboardsInfo;
     });
     const wrapper = mount(
-      <PasswordEditPanel coreStart={mockCoreStart as any} updatePassword={updatePassword} updateIsInvalid={updateIsInvalid} />
+      <PasswordEditPanel
+        coreStart={mockCoreStart as any}
+        updatePassword={updatePassword}
+        updateIsInvalid={updateIsInvalid}
+      />
     );
     process.nextTick(() => {
       wrapper.update();

--- a/public/apps/configuration/utils/test/password-edit-panel.test.tsx
+++ b/public/apps/configuration/utils/test/password-edit-panel.test.tsx
@@ -13,9 +13,23 @@
  *   permissions and limitations under the License.
  */
 
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { PasswordEditPanel } from '../password-edit-panel';
+import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
+
+const mockDashboardsInfo = {
+  multitenancy_enabled: true,
+  private_tenant_enabled: true,
+  default_tenant: '',
+  password_validation_error_message: 'Password must be minimum 5 characters long and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character.'
+};
+
+jest.mock('../../../../utils/dashboards-info-utils', () => ({
+  getDashboardsInfo: jest.fn().mockImplementation(() => {
+    return mockDashboardsInfo;
+  }),
+}));
 
 describe('Password edit panel', () => {
   let component;
@@ -24,18 +38,39 @@ describe('Password edit panel', () => {
   const updateIsInvalid = jest.fn();
   const useState = jest.spyOn(React, 'useState');
   const useEffect = jest.spyOn(React, 'useEffect');
+  const mockCoreStart = {
+    http: 1,
+  };
 
   beforeEach(() => {
     useEffect.mockImplementationOnce((f) => f());
     useState.mockImplementation((initialValue) => [initialValue, setState]);
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
     component = shallow(
-      <PasswordEditPanel updatePassword={updatePassword} updateIsInvalid={updateIsInvalid} />
+      <PasswordEditPanel coreStart={mockCoreStart as any} updatePassword={updatePassword} updateIsInvalid={updateIsInvalid} />
     );
   });
 
-  it('renders', () => {
-    expect(updatePassword).toHaveBeenCalledTimes(1);
-    expect(updateIsInvalid).toHaveBeenCalledTimes(1);
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders', (done) => {
+    (getDashboardsInfo as jest.Mock).mockImplementation(() => {
+      return mockDashboardsInfo;
+    });
+    const wrapper = mount(
+      <PasswordEditPanel coreStart={mockCoreStart as any} updatePassword={updatePassword} updateIsInvalid={updateIsInvalid} />
+    );
+    process.nextTick(() => {
+      wrapper.update();
+      expect(updatePassword).toHaveBeenCalledTimes(1);
+      expect(updateIsInvalid).toHaveBeenCalledTimes(1);
+      expect(setState).toBeCalledWith(mockDashboardsInfo.password_validation_error_message);
+      done();
+    });
   });
 
   it('password field update', () => {

--- a/public/types.ts
+++ b/public/types.ts
@@ -46,6 +46,7 @@ export interface DashboardsInfo {
   multitenancy_enabled?: boolean;
   private_tenant_enabled?: boolean;
   default_tenant: string;
+  password_validation_error_message: string;
 }
 
 export interface ClientConfigType {


### PR DESCRIPTION
### Description

Companion Security PR: https://github.com/opensearch-project/security/pull/2949

This PR uses the message from `/_plugins/_security/dashboardsinfo` to get the password message from the backend if its configured in `opensearch.yml`. If the setting is not set, the backend will return the default.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Bug fix

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1501

### Testing

Jest tests and manual dashboard testing of both password reset and password edit

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).