### PR TITLE
Add the tenant into the short URL once the short URL is resolved (#1462)

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -31,6 +31,13 @@ export const ERROR_MISSING_ROLE_PATH = '/missing-role';
 
 export const MAX_INTEGER = 2147483647;
 
+export const GLOBAL_TENANT_SYMBOL = '';
+export const PRIVATE_TENANT_SYMBOL = '__user__';
+export const DEFAULT_TENANT = 'default';
+export const GLOBAL_TENANT_RENDERING_TEXT = 'Global';
+export const PRIVATE_TENANT_RENDERING_TEXT = 'Private';
+export const globalTenantName = 'global_tenant';
+
 export enum AuthType {
   BASIC = 'basicauth',
   OPEN_ID = 'openid',
@@ -47,4 +54,8 @@ export enum AuthType {
 export function isValidResourceName(resourceName: string): boolean {
   // see: https://javascript.info/regexp-unicode
   return !/[\p{C}%]/u.test(resourceName) && resourceName.length > 0;
+}
+
+export function isGlobalTenant(selectedTenant: string | null) {
+  return selectedTenant !== null && selectedTenant === GLOBAL_TENANT_SYMBOL;
 }

--- a/server/multitenancy/tenant_resolver.test.ts
+++ b/server/multitenancy/tenant_resolver.test.ts
@@ -1,0 +1,88 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { httpServerMock } from '../../../../src/core/server/mocks';
+import { OpenSearchDashboardsRequest } from '../../../../src/core/server';
+import { addTenantParameterToResolvedShortLink } from './tenant_resolver';
+import { Request, ResponseObject } from '@hapi/hapi';
+
+describe('Preserve the tenant parameter in short urls', () => {
+  it(`adds the tenant as a query parameter for goto short links`, async () => {
+    const resolvedUrl = '/url/resolved';
+    const rawRequest = httpServerMock.createRawRequest({
+      url: {
+        pathname: '/goto/123',
+      },
+      headers: {
+        securitytenant: 'dummy_tenant',
+      },
+      response: {
+        headers: {
+          location: resolvedUrl,
+        },
+      },
+    }) as Request;
+
+    const osRequest = OpenSearchDashboardsRequest.from(rawRequest);
+    addTenantParameterToResolvedShortLink(osRequest);
+
+    expect((rawRequest.response as ResponseObject).headers.location).toEqual(
+      resolvedUrl + '?security_tenant=dummy_tenant'
+    );
+  });
+
+  it(`ignores links not starting with /goto`, async () => {
+    const resolvedUrl = '/url/resolved';
+    const rawRequest = httpServerMock.createRawRequest({
+      url: {
+        pathname: '/dontgoto/123',
+      },
+      headers: {
+        securitytenant: 'dummy_tenant',
+      },
+      response: {
+        headers: {
+          location: resolvedUrl,
+        },
+      },
+    }) as Request;
+
+    const osRequest = OpenSearchDashboardsRequest.from(rawRequest);
+    addTenantParameterToResolvedShortLink(osRequest);
+
+    expect((rawRequest.response as ResponseObject).headers.location).toEqual(resolvedUrl);
+  });
+
+  it(`checks that a redirect location is present before applying the query parameter`, async () => {
+    const rawRequest = httpServerMock.createRawRequest({
+      url: {
+        pathname: '/goto/123',
+      },
+      headers: {
+        securitytenant: 'dummy_tenant',
+      },
+      response: {
+        headers: {
+          someotherheader: 'abc',
+        },
+      },
+    }) as Request;
+
+    const osRequest = OpenSearchDashboardsRequest.from(rawRequest);
+    addTenantParameterToResolvedShortLink(osRequest);
+
+    expect((rawRequest.response as ResponseObject).headers.location).toBeFalsy();
+  });
+});

--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -14,12 +14,14 @@
  */
 
 import { isEmpty, findKey, cloneDeep } from 'lodash';
-import { OpenSearchDashboardsRequest } from '../../../../src/core/server';
+import { OpenSearchDashboardsRequest } from 'opensearch-dashboards/server';
+import { ResponseObject } from '@hapi/hapi';
 import { SecuritySessionCookie } from '../session/security_cookie';
 import { SecurityPluginConfigType } from '..';
-
-const PRIVATE_TENANT_SYMBOL: string = '__user__';
-const GLOBAL_TENANT_SYMBOL: string = '';
+import { GLOBAL_TENANT_SYMBOL, PRIVATE_TENANT_SYMBOL, globalTenantName } from '../../common';
+import { modifyUrl } from '../../../../packages/osd-std';
+import { ensureRawRequest } from '../../../../src/core/server/http/router';
+import { GOTO_PREFIX } from '../../../../src/plugins/share/common/short_url_routes';
 
 export const PRIVATE_TENANTS: string[] = [PRIVATE_TENANT_SYMBOL, 'private'];
 export const GLOBAL_TENANTS: string[] = ['global', GLOBAL_TENANT_SYMBOL];
@@ -169,4 +171,30 @@ function resolve(
  */
 export function isValidTenant(tenant: string | undefined | null): boolean {
   return tenant !== undefined && tenant !== null;
+}
+
+/**
+ * If multitenancy is enabled & the URL entered starts with /goto,
+ * We will modify the rawResponse to add a new parameter to the URL, the security_tenant (or value for tenant when in multitenancy)
+ * With the security_tenant added, the resolved short URL now contains the security_tenant information (so the short URL retains the tenant information).
+ **/
+
+export function addTenantParameterToResolvedShortLink(request: OpenSearchDashboardsRequest) {
+  if (request.url.pathname.startsWith(`${GOTO_PREFIX}/`)) {
+    const rawRequest = ensureRawRequest(request);
+    const rawResponse = rawRequest.response as ResponseObject;
+
+    // Make sure the request really should redirect
+    if (rawResponse.headers.location) {
+      const modifiedUrl = modifyUrl(rawResponse.headers.location as string, (parts) => {
+        if (parts.query.security_tenant === undefined) {
+          parts.query.security_tenant = request.headers.securitytenant as string;
+        }
+        // Mutating the headers toolkit.next({headers: ...}) logs a warning about headers being overwritten
+      });
+      rawResponse.headers.location = modifiedUrl;
+    }
+  }
+
+  return request;
 }


### PR DESCRIPTION
### Description
Manually backports https://github.com/opensearch-project/security-dashboards-plugin/commit/e9f95763a16f5e42247830ff6083af6ef7014e9b from https://github.com/opensearch-project/security-dashboards-plugin/pull/1462.

### Category
Bug fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).