### PR TITLE
[2.x] Change the regex command in install dashboard GHA + Increment version to 2.10.0

### DIFF
--- a/.github/actions/install-dashboards/action.yml
+++ b/.github/actions/install-dashboards/action.yml
@@ -39,8 +39,8 @@ runs:
 
     - id: osd-version
       run: |
-        echo "::set-output name=osd-version::$(cat package.json | jq '.opensearchDashboards.version' | cut -c 2-4)"
-        echo "::set-output name=osd-x-version::$(cat package.json | jq '.opensearchDashboards.version' | cut -c 2-3)"
+        echo "::set-output name=osd-version::$(jq -r '.opensearchDashboards.version' package.json)"
+        echo "::set-output name=osd-x-version::$(jq -r '.opensearchDashboards.version | split(".") | .[:2] | join(".")' package.json)"
       working-directory: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
       shell: bash
 

--- a/.github/actions/install-dashboards/action.yml
+++ b/.github/actions/install-dashboards/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - id: osd-version
       run: |
-        echo "::set-output name=osd-version::$(jq -r '.opensearchDashboards.version' package.json)"
+        echo "::set-output name=osd-version::$(jq -r '.opensearchDashboards.version | split(".") | .[:2] | join(".")' package.json)"
         echo "::set-output name=osd-x-version::$(jq -r '.opensearchDashboards.version | split(".") | .[0]' package.json).x"
       working-directory: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
       shell: bash

--- a/.github/actions/install-dashboards/action.yml
+++ b/.github/actions/install-dashboards/action.yml
@@ -40,14 +40,14 @@ runs:
     - id: osd-version
       run: |
         echo "::set-output name=osd-version::$(jq -r '.opensearchDashboards.version' package.json)"
-        echo "::set-output name=osd-x-version::$(jq -r '.opensearchDashboards.version | split(".") | .[:2] | join(".")' package.json)"
+        echo "::set-output name=osd-x-version::$(jq -r '.opensearchDashboards.version | split(".") | .[0]' package.json).x"
       working-directory: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
       shell: bash
 
     - id: branch-switch-if-possible
       continue-on-error: true # Defaults onto main if the branch switch doesn't work
       if: ${{ steps.osd-version.outputs.osd-version }}
-      run: git checkout ${{ steps.osd-version.outputs.osd-version }} || git checkout ${{ steps.osd-version.outputs.osd-x-version }}x
+      run: git checkout ${{ steps.osd-version.outputs.osd-version }} || git checkout ${{ steps.osd-version.outputs.osd-x-version }}
       working-directory: ./OpenSearch-Dashboards
       shell: bash
 

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "securityDashboards",
-  "version": "2.9.0.0",
-  "opensearchDashboardsVersion": "2.9.0",
+  "version": "2.10.0.0",
+  "opensearchDashboardsVersion": "2.10.0",
   "configPath": [
     "opensearch_security"
   ],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "opensearch-security-dashboards",
-  "version": "2.9.0.0",
+  "version": "2.10.0.0",
   "main": "target/plugins/opensearch_security_dashboards",
   "opensearchDashboards": {
-    "version": "2.9.0",
-    "templateVersion": "2.9.0"
+    "version": "2.10.0",
+    "templateVersion": "2.10.0"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/security-dashboards-plugin",


### PR DESCRIPTION
### Description
Change the regex command in install dashboard GHA to handle generic format of version numbers. This PR also includes the  version bump to 2.10.0.

### Category
Bug fix

### Issues Resolved
* Relate https://github.com/opensearch-project/security-dashboards-plugin/pull/1526
* Resolve https://github.com/opensearch-project/security-dashboards-plugin/issues/1532

### Testing
Before:
<img width="1214" alt="Screenshot 2023-08-01 at 4 16 08 PM" src="https://github.com/opensearch-project/security-dashboards-plugin/assets/109499885/ae7000c6-0aa0-431a-824b-fe262e7fbce3">

After:
<img width="1264" alt="Screenshot 2023-08-01 at 4 17 34 PM" src="https://github.com/opensearch-project/security-dashboards-plugin/assets/109499885/1ad80e5c-c0c8-43d0-a615-b703c00bd422">

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).