### PR TITLE
Force resolution of selenium-webdriver to 4.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "gulp-rename": "2.0.0",
     "jose": "^4.11.2",
     "saml-idp": "^1.2.1",
-    "selenium-webdriver": "^4.0.0-alpha.7",
     "selfsigned": "^2.0.1",
     "typescript": "4.0.2"
   },
@@ -36,5 +35,8 @@
     "@hapi/cryptiles": "5.0.0",
     "@hapi/wreck": "^17.1.0",
     "html-entities": "1.3.1"
+  },
+  "resolutions": {
+    "selenium-webdriver": "4.10.0"
   }
 }


### PR DESCRIPTION
### Description

Fixes an issue with the Integration Tests that were failing with selenium-webdriver 4.11.1. The tests had a bug on determining browser path that would result in it eventually failing with a message `InvalidArgumentError: binary is not a Firefox executable`. See details on linked issue. 

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Test fix

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1540

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).