### PR TITLE
[2.x] Explicitly pass `basePath: false` in jwt_auth.test.ts

### DIFF
--- a/test/jest_integration/jwt_auth.test.ts
+++ b/test/jest_integration/jwt_auth.test.ts
@@ -76,6 +76,7 @@ describe('start OpenSearch Dashboards server', () => {
         // to make ignoreVersionMismatch setting work
         // can be removed when we have corresponding ES version
         dev: true,
+        basePath: false
       }
     );
 

--- a/test/jest_integration/jwt_auth.test.ts
+++ b/test/jest_integration/jwt_auth.test.ts
@@ -76,7 +76,7 @@ describe('start OpenSearch Dashboards server', () => {
         // to make ignoreVersionMismatch setting work
         // can be removed when we have corresponding ES version
         dev: true,
-        basePath: false
+        basePath: false,
       }
     );
 


### PR DESCRIPTION
### Description

This PR explicitly sets `basePath` to false in jwt_auth.test.ts to ensure that the test does not run with a basePath

Fixes CI errors seen in: https://github.com/opensearch-project/security-dashboards-plugin/pull/1550

I'm am looking more into `osdTestServer.getRootWithSettings` to see why the default is not being picked up: https://github.com/opensearch-project/OpenSearch-Dashboards/blob/9253a372004ae108afad01cdc41d36a9ceccd1ff/src/core/test_helpers/osd_server.ts#L75-L104

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Test fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).