### PR TITLE
Update or remove instances of hardcoded colors

### DIFF
--- a/public/apps/configuration/_index.scss
+++ b/public/apps/configuration/_index.scss
@@ -14,7 +14,7 @@
  */
 
 .panel-header-count {
-  color: #687078;
+  color: $euiTextSubduedColor;
   font-weight: normal;
 }
 

--- a/public/apps/configuration/panels/audit-logging/_index.scss
+++ b/public/apps/configuration/panels/audit-logging/_index.scss
@@ -5,7 +5,3 @@
 .form-row {
   max-width: 800px;
 }
-
-pre code {
-  color: #666;
-}


### PR DESCRIPTION
### Description

There are 2 instances in this repo of hardcoded colors:

```
public/apps/configuration/_index.scss
 17:3  ✖  Using the value "#687078" is not allowed. All colors should be inherited from the OUI theme, not hard-coded. Either remove the custom color rule or use OUI SASS variables instead. (no_restricted_values)  @osd/stylelint/no_restricted_values

public/apps/configuration/panels/audit-logging/_index.scss
 10:3  ✖  Using the value "#666" is not allowed. All colors should be inherited from the OUI theme, not hard-coded. Either remove the custom color rule or use OUI SASS variables instead. (no_restricted_values)  @osd/stylelint/no_restricted_values
```

This PR either updates or removes the instance of the hardcoded color to comply with https://github.com/opensearch-project/security-dashboards-plugin/issues/1471

### Category

Maintenance

### Issues Resolved

https://github.com/opensearch-project/security-dashboards-plugin/issues/1471

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).