### PR TITLE
[BUG-1427] Newly created user defaults to same tenant as admin when using same browser window.

### DIFF
--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -70,8 +70,19 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
   );
   const [isMultiTenancyEnabled, setIsMultiTenancyEnabled] = useState(true);
 
-  const setCurrentTenant = (currentRawTenantName: string, currentUserName: string) => {
-    const resolvedTenantName = resolveTenantName(currentRawTenantName, currentUserName);
+  const setCurrentTenant = (
+    currentRawTenantName: string,
+    currentUserName: string,
+    tempTenantsList: string[]
+  ) => {
+    const isGlobalEnabled = props.config.multitenancy.tenants.enable_global;
+    const shouldDisableGlobal =
+      !isGlobalEnabled || !tempTenantsList.includes(GLOBAL_TENANT_KEY_NAME);
+    const resolvedTenantName = resolveTenantName(
+      currentRawTenantName,
+      currentUserName,
+      shouldDisableGlobal
+    );
 
     if (resolvedTenantName === RESOLVED_GLOBAL_TENANT) {
       setTenantSwitchRadioIdSelected(GLOBAL_TENANT_RADIO_ID);
@@ -91,8 +102,9 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         const dashboardsInfo = await getDashboardsInfo(props.coreStart.http);
         setIsMultiTenancyEnabled(dashboardsInfo.multitenancy_enabled);
         setIsPrivateEnabled(dashboardsInfo.private_tenant_enabled);
-        const tenantsInfo = accountInfo.data.tenants || {};
-        setTenants(keys(tenantsInfo));
+        const tenantsInfo = accountInfo.data.tenants || {}; // temp variable to pass current tenants list state to setCurrentTenant
+        const tempTenantsList = keys(tenantsInfo);
+        setTenants(tempTenantsList);
 
         const currentUserName = accountInfo.data.user_name;
         setUsername(currentUserName);
@@ -103,7 +115,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         } else {
           currentRawTenantName = accountInfo.data.user_requested_tenant;
         }
-        setCurrentTenant(currentRawTenantName || '', currentUserName);
+        setCurrentTenant(currentRawTenantName || '', currentUserName, tempTenantsList);
       } catch (e) {
         // TODO: switch to better error display.
         console.error(e);

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -122,11 +122,12 @@ export async function selectTenant(http: HttpStart, selectObject: TenantSelect):
 export const RESOLVED_GLOBAL_TENANT = 'Global';
 export const RESOLVED_PRIVATE_TENANT = 'Private';
 
-export function resolveTenantName(tenant: string, userName: string) {
-  if (!tenant || tenant === 'undefined') {
+export function resolveTenantName(tenant: string, userName: string, isGlobalDisabled: boolean) {
+  const probablyGlobal = !tenant || tenant === 'undefined';
+  if (probablyGlobal && !isGlobalDisabled) {
     return RESOLVED_GLOBAL_TENANT;
   }
-  if (tenant === userName || tenant === '__user__') {
+  if (probablyGlobal || tenant === userName || tenant === '__user__') {
     return RESOLVED_PRIVATE_TENANT;
   } else {
     return tenant;

--- a/public/apps/configuration/utils/test/tenant-utils.test.tsx
+++ b/public/apps/configuration/utils/test/tenant-utils.test.tsx
@@ -102,10 +102,7 @@ describe('Tenant list utils', () => {
     });
 
     it('transform global, private and custom tenant', () => {
-      const result = transformTenantData(
-        { global_tenant: globalTenant, dummy: sampleTenant1 },
-        true
-      );
+      const result = transformTenantData({ global_tenant: globalTenant, dummy: sampleTenant1 });
       expect(result.length).toBe(3);
       expect(result[0]).toEqual(expectedGlobalTenantListing);
       expect(result[1]).toEqual(expectedPrivateTenantListing);
@@ -114,32 +111,43 @@ describe('Tenant list utils', () => {
   });
 
   describe('Resolve tenant name', () => {
-    const tenantNames = ['', 'undefined', 'user1', '__user__', ' dummy'];
+    const tenantNames = ['', 'undefined', 'user1', '__user__', ' dummy', '', 'undefined'];
+    const isGlobalDisabled = [false, false, false, false, false, true, true];
     const userName = 'user1';
 
     it('resolve to global tenant when tenant name is empty', () => {
-      const result = resolveTenantName(tenantNames[0], userName);
+      const result = resolveTenantName(tenantNames[0], userName, isGlobalDisabled[0]);
       expect(result).toBe(RESOLVED_GLOBAL_TENANT);
     });
 
     it('resolve to global tenant when tenant name is undefined', () => {
-      const result = resolveTenantName(tenantNames[1], userName);
+      const result = resolveTenantName(tenantNames[1], userName, isGlobalDisabled[1]);
       expect(result).toBe(RESOLVED_GLOBAL_TENANT);
     });
 
     it('resolve to private tenant when tenant name is user name', () => {
-      const result = resolveTenantName(tenantNames[2], userName);
+      const result = resolveTenantName(tenantNames[2], userName, isGlobalDisabled[2]);
       expect(result).toBe(RESOLVED_PRIVATE_TENANT);
     });
 
     it('resolve to private tenant when tenant name is __user__', () => {
-      const result = resolveTenantName(tenantNames[3], userName);
+      const result = resolveTenantName(tenantNames[3], userName, isGlobalDisabled[3]);
       expect(result).toBe(RESOLVED_PRIVATE_TENANT);
     });
 
     it('resolve to actual tenant name when tenant name is custom', () => {
-      const result = resolveTenantName(tenantNames[4], userName);
+      const result = resolveTenantName(tenantNames[4], userName, isGlobalDisabled[4]);
       expect(result).toBe(tenantNames[4]);
+    });
+
+    it('resolve to private tenant when tenant name is empty and global is disabled', () => {
+      const result = resolveTenantName(tenantNames[5], userName, isGlobalDisabled[5]);
+      expect(result).toBe(RESOLVED_PRIVATE_TENANT);
+    });
+
+    it('resolve to private tenant when tenant name is undefined and global is disabled', () => {
+      const result = resolveTenantName(tenantNames[6], userName, isGlobalDisabled[6]);
+      expect(result).toBe(RESOLVED_PRIVATE_TENANT);
     });
   });
 


### PR DESCRIPTION
### Description
Fixes bug that defaults a new user to the Global tenant, even when they do not have permission for the Global tenant and this option is blocked out on the modal. To fix this, I added a new check to the resolveTenantName function, in which it checks of whether the Global tenant is available for this account through a new parameter to the function, in that case it skips over the Global tenant return and returns a Private tenant.


### Category
Bug fix

### Why these changes are required?
New users were having the Global tenant role even when they don't have the permissions to, which is a security risk.

### What is the old behavior before changes and new behavior after changes?
Old behavior: When you select global tenant on the admin account then switch to a new user, this global tenant is selected by default even when this option is not available since the new user doesn't have access to the Global tenant.
![Screenshot 2023-10-18 at 12 40 40 AM](https://github.com/opensearch-project/security-dashboards-plugin/assets/66924475/79b2e8a0-2089-4d0d-a411-2903522d9013)

New behavior: In this case, the default option automatically switches to the next accessible role, which is the Private tenant.
![Screenshot 2023-10-18 at 12 52 10 AM](https://github.com/opensearch-project/security-dashboards-plugin/assets/66924475/552391df-1e40-4a1f-bc72-e8a14245b36f)


### Issues Resolved
Fixed issue #1427 

### Testing
Manually tested to make sure nothing was broken. Additionally added new tests to tenant-utils.test.tsx to update function and test for cases where the global tenant is not enabled.

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).