### PR TITLE
Fix bug where custom permission groups are missing

### DIFF
--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -175,7 +175,7 @@ export function RoleEdit(props: RoleEditDeps) {
     {
       label: 'Other permission groups',
       options: actionGroups
-        .filter((actionGroup) => (actionGroup[1].type !== 'index' &&  actionGroup[1].type !== 'cluster'))
+        .filter((actionGroup) => actionGroup[1].type === undefined)
         .map((actionGroup) => actionGroup[0])
         .map(stringToComboBoxOption),
     },
@@ -196,7 +196,7 @@ export function RoleEdit(props: RoleEditDeps) {
     {
       label: 'Other permission groups',
       options: actionGroups
-        .filter((actionGroup) => (actionGroup[1].type !== 'index' &&  actionGroup[1].type !== 'cluster'))
+        .filter((actionGroup) => actionGroup[1].type === undefined)
         .map((actionGroup) => actionGroup[0])
         .map(stringToComboBoxOption),
     },

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -166,9 +166,16 @@ export function RoleEdit(props: RoleEditDeps) {
 
   const clusterWisePermissionOptions = [
     {
-      label: 'Permission groups',
+      label: 'Cluster permission groups',
       options: actionGroups
         .filter((actionGroup) => actionGroup[1].type === 'cluster')
+        .map((actionGroup) => actionGroup[0])
+        .map(stringToComboBoxOption),
+    },
+    {
+      label: 'Other permission groups',
+      options: actionGroups
+        .filter((actionGroup) => (actionGroup[1].type !== 'index' &&  actionGroup[1].type !== 'cluster'))
         .map((actionGroup) => actionGroup[0])
         .map(stringToComboBoxOption),
     },
@@ -180,9 +187,16 @@ export function RoleEdit(props: RoleEditDeps) {
 
   const indexWisePermissionOptions = [
     {
-      label: 'Permission groups',
+      label: 'Index permission groups',
       options: actionGroups
         .filter((actionGroup) => actionGroup[1].type === 'index')
+        .map((actionGroup) => actionGroup[0])
+        .map(stringToComboBoxOption),
+    },
+    {
+      label: 'Other permission groups',
+      options: actionGroups
+        .filter((actionGroup) => (actionGroup[1].type !== 'index' &&  actionGroup[1].type !== 'cluster'))
         .map((actionGroup) => actionGroup[0])
         .map(stringToComboBoxOption),
     },

--- a/public/apps/configuration/panels/role-edit/test/role-edit-filtering.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/role-edit-filtering.test.tsx
@@ -16,7 +16,6 @@
 import React from 'react';
 import { ClusterPermissionPanel } from '../cluster-permission-panel';
 import { RoleEdit } from '../role-edit';
-import { ActionGroupItem } from '../../../types';
 import { fetchActionGroups } from '../../../utils/action-groups-utils';
 
 import { render, waitFor } from '@testing-library/react';
@@ -67,6 +66,14 @@ describe('Role edit filtering', () => {
       description: 'Manage pipelines',
       static: true,
     },
+    custom: {
+      reserved: false,
+      hidden: false,
+      allowed_actions: ['cluster:admin/ingest/pipeline/*'],
+      type: undefined,
+      description: 'Custom group',
+      static: true,
+    },
   });
 
   it('basic cluster permission panel rendering', async () => {
@@ -98,10 +105,18 @@ describe('Role edit filtering', () => {
     // Cluster Permission Panel props is filtered to action groups with type cluster, and only the cluster permission constants
     expect(props.optionUniverse).toEqual([
       {
-        label: 'Permission groups',
+        label: 'Cluster permission groups',
         options: [
           {
             label: 'cluster_manage_pipelines',
+          },
+        ],
+      },
+      {
+        label: 'Other permission groups',
+        options: [
+          {
+            label: 'custom',
           },
         ],
       },
@@ -143,10 +158,18 @@ describe('Role edit filtering', () => {
     // Index Permission Panel props is filtered to action groups with type index, and only the index permission constants
     expect(props.optionUniverse).toEqual([
       {
-        label: 'Permission groups',
+        label: 'Index permission groups',
         options: [
           {
             label: 'data_access',
+          },
+        ],
+      },
+      {
+        label: 'Other permission groups',
+        options: [
+          {
+            label: 'custom',
           },
         ],
       },


### PR DESCRIPTION
### Description
Fix custom/kibana/all permission groups missing from dropdown. This was because I had assumed there were only "cluster" and "index" type groups, whereas there are also custom, kibana, and all types for permission groups. This has slight duplication since the custom types will show up in both cluster and index dropdowns, but this fixes the bug.

More details here: https://github.com/opensearch-project/security-dashboards-plugin/pull/1636#issuecomment-1789606810


### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
FIX: https://github.com/opensearch-project/security-dashboards-plugin/issues/1597
### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).