### PR TITLE
Update instances of admin:admin in documentation and fix file location

### DIFF
--- a/.github/workflows/cypress-test-oidc-e2e.yml
+++ b/.github/workflows/cypress-test-oidc-e2e.yml
@@ -158,10 +158,10 @@ jobs:
           cat config.yml
 
       # TODO: REMOVE THIS ONCE ADMIN JAVA TOOL SUPPORT IT
-      - name: Write password to initialAdminPassword location
+      - name: Write password to opensearch_initial_admin_password.txt
         if: ${{ runner.os == 'Linux'}}
         run:
-          echo admin >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/initialAdminPassword.txt
+          echo admin >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/opensearch_initial_admin_password.txt
         shell: bash
 
       # Run any configuration scripts

--- a/.github/workflows/cypress-test-saml-e2e.yml
+++ b/.github/workflows/cypress-test-saml-e2e.yml
@@ -58,10 +58,10 @@ jobs:
         shell: bash
 
       # TODO: REMOVE THIS ONCE ADMIN JAVA TOOL SUPPORT IT
-      - name: Write password to initialAdminPassword location
+      - name: Write password to opensearch_initial_admin_password.txt
         if: ${{ runner.os == 'Linux'}}
         run:
-          echo admin >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/initialAdminPassword.txt
+          echo admin >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/opensearch_initial_admin_password.txt
         shell: bash
 
       # Install the security plugin

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -35,7 +35,7 @@ For the sake of this guide, let's assume the latest version on main for OpenSear
 Ensure that an OpenSearch cluster with the security plugin installed is running locally. If you followed the steps from [the developer guide of the Security Plugin](https://github.com/opensearch-project/security/blob/main/DEVELOPER_GUIDE.md), then you can verify this by running:
 
 ```
-curl -XGET https://admin:admin@localhost:9200/ --insecure
+curl -XGET https://admin:<admin password>@localhost:9200/ --insecure
 ```
 
 ## Install OpenSearch-Dashboards with Security Dashboards Plugin


### PR DESCRIPTION
### Description
Fixes documentation assuming admin password is admin. Also updates the integration tests to work with the new location of the initial admin password.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).