### PR TITLE
Update cypress tests to set OPENSEARCH_INITIAL_ADMIN_PASSWORD env variable

### DIFF
--- a/.github/workflows/cypress-test-oidc-e2e.yml
+++ b/.github/workflows/cypress-test-oidc-e2e.yml
@@ -21,6 +21,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
+    env:
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: admin
 
     steps:
       - name: Set up JDK
@@ -156,13 +158,6 @@ jobs:
           EOT
           echo "THIS IS THE SECURITY CONFIG FILE: "
           cat config.yml
-
-      # TODO: REMOVE THIS ONCE ADMIN JAVA TOOL SUPPORT IT
-      - name: SET OPENSEARCH_INITIAL_ADMIN_PASSWORD env variable
-        if: ${{ runner.os == 'Linux'}}
-        run:
-          export OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
-        shell: bash
 
       # Run any configuration scripts
       - name: Run Setup Script for Linux

--- a/.github/workflows/cypress-test-oidc-e2e.yml
+++ b/.github/workflows/cypress-test-oidc-e2e.yml
@@ -158,10 +158,10 @@ jobs:
           cat config.yml
 
       # TODO: REMOVE THIS ONCE ADMIN JAVA TOOL SUPPORT IT
-      - name: Write password to opensearch_initial_admin_password.txt
+      - name: SET OPENSEARCH_INITIAL_ADMIN_PASSWORD env variable
         if: ${{ runner.os == 'Linux'}}
         run:
-          echo admin >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/opensearch_initial_admin_password.txt
+          export OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
         shell: bash
 
       # Run any configuration scripts

--- a/.github/workflows/cypress-test-saml-e2e.yml
+++ b/.github/workflows/cypress-test-saml-e2e.yml
@@ -58,10 +58,10 @@ jobs:
         shell: bash
 
       # TODO: REMOVE THIS ONCE ADMIN JAVA TOOL SUPPORT IT
-      - name: Write password to opensearch_initial_admin_password.txt
+      - name: Set OPENSEARCH_INITIAL_ADMIN_PASSWORD env variable
         if: ${{ runner.os == 'Linux'}}
         run:
-          echo admin >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/opensearch_initial_admin_password.txt
+          export OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
         shell: bash
 
       # Install the security plugin

--- a/.github/workflows/cypress-test-saml-e2e.yml
+++ b/.github/workflows/cypress-test-saml-e2e.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
+    env:
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: admin
 
     steps:
       - name: Set up JDK
@@ -55,13 +57,6 @@ jobs:
         run: |
           tar -xzf opensearch-*.tar.gz
           rm -f opensearch-*.tar.gz
-        shell: bash
-
-      # TODO: REMOVE THIS ONCE ADMIN JAVA TOOL SUPPORT IT
-      - name: Set OPENSEARCH_INITIAL_ADMIN_PASSWORD env variable
-        if: ${{ runner.os == 'Linux'}}
-        run:
-          export OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin
         shell: bash
 
       # Install the security plugin


### PR DESCRIPTION
### Description

Updates the SAML and OIDC Cypress tests to set OPENSEARCH_INITIAL_ADMIN_PASSWORD env variable.

### Category

Test fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).