### PR TITLE
Remove txt file option and pass in OPENSEARCH_INITIAL_ADMIN_PASSWORD env variable

### DIFF
--- a/.github/workflows/cypress-test-oidc-e2e.yml
+++ b/.github/workflows/cypress-test-oidc-e2e.yml
@@ -21,6 +21,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
+    env:
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: admin
 
     steps:
       - name: Set up JDK
@@ -156,13 +158,6 @@ jobs:
           EOT
           echo "THIS IS THE SECURITY CONFIG FILE: "
           cat config.yml
-
-      # TODO: REMOVE THIS ONCE ADMIN JAVA TOOL SUPPORT IT
-      - name: Write password to opensearch_initial_admin_password.txt
-        if: ${{ runner.os == 'Linux'}}
-        run:
-          echo admin >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/opensearch_initial_admin_password.txt
-        shell: bash
 
       # Run any configuration scripts
       - name: Run Setup Script for Linux

--- a/.github/workflows/cypress-test-saml-e2e.yml
+++ b/.github/workflows/cypress-test-saml-e2e.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
+    env:
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: admin
 
     steps:
       - name: Set up JDK
@@ -55,13 +57,6 @@ jobs:
         run: |
           tar -xzf opensearch-*.tar.gz
           rm -f opensearch-*.tar.gz
-        shell: bash
-
-      # TODO: REMOVE THIS ONCE ADMIN JAVA TOOL SUPPORT IT
-      - name: Write password to opensearch_initial_admin_password.txt
-        if: ${{ runner.os == 'Linux'}}
-        run:
-          echo admin >> ./opensearch-${{ env.OPENSEARCH_VERSION }}-SNAPSHOT/config/opensearch_initial_admin_password.txt
         shell: bash
 
       # Install the security plugin


### PR DESCRIPTION
### Description
Recent changes in security backend disallows passing in the initial admin password via a txt file since it is insecure. This removes that step and sets the environment variable to successfully spin up the cluster.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).