### PR TITLE
[2.x] Pass in env variable and -t flag to set "admin" as the initial admin password

### DIFF
--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -40,7 +40,7 @@ runs:
       if: ${{ runner.os == 'Windows' }}
       run: |
         New-Item .\setup.bat -type file
-        Set-Content .\setup.bat -Value "powershell.exe -noexit -command `".\opensearch-${{ inputs.opensearch-version}}-SNAPSHOT\plugins\${{ inputs.plugin-name }}\tools\install_demo_configuration.bat -y -i -c`""
+        Set-Content .\setup.bat -Value "powershell.exe -noexit -command `".\opensearch-${{ inputs.opensearch-version}}-SNAPSHOT\plugins\${{ inputs.plugin-name }}\tools\install_demo_configuration.bat -y -i -c -t`""
         Add-Content -Path .\setup.bat -Value "echo plugins.security.unsupported.restapi.allow_securityconfig_modification: true >> .\opensearch-${{ inputs.opensearch-version}}-SNAPSHOT\config\opensearch.yml"
         Add-Content -Path .\setup.bat -Value "echo cluster.routing.allocation.disk.threshold_enabled: false >> .\opensearch-${{ inputs.opensearch-version}}-SNAPSHOT\config\opensearch.yml"
         Get-Content .\setup.bat

--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -30,7 +30,7 @@ runs:
       run: |
         cat > setup.sh <<'EOF'
         chmod +x  ./opensearch-${{ inputs.opensearch-version}}-SNAPSHOT/plugins/${{ inputs.plugin-name }}/tools/install_demo_configuration.sh 
-        /bin/bash -c "yes | ./opensearch-${{ inputs.opensearch-version}}-SNAPSHOT/plugins/${{ inputs.plugin-name }}/tools/install_demo_configuration.sh"
+        /bin/bash -c "yes | ./opensearch-${{ inputs.opensearch-version}}-SNAPSHOT/plugins/${{ inputs.plugin-name }}/tools/install_demo_configuration.sh -t"
         echo "plugins.security.unsupported.restapi.allow_securityconfig_modification: true" >> ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/config/opensearch.yml
         echo "cluster.routing.allocation.disk.threshold_enabled: false" >> ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/config/opensearch.yml
         EOF

--- a/.github/workflows/cypress-test-oidc-e2e.yml
+++ b/.github/workflows/cypress-test-oidc-e2e.yml
@@ -21,6 +21,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
+    env:
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: admin
 
     steps:
       - name: Set up JDK

--- a/.github/workflows/cypress-test-saml-e2e.yml
+++ b/.github/workflows/cypress-test-saml-e2e.yml
@@ -17,6 +17,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
+    env:
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: admin
 
     steps:
       - name: Set up JDK

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -15,6 +15,8 @@ jobs:
       matrix:
         os: [ ubuntu-latest , windows-latest ]
     runs-on: ${{ matrix.os }}
+    env:
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: admin
 
     steps:
       - name: Checkout Branch


### PR DESCRIPTION
### Description
Consumes changes in 2.x line of security backend plugin that requires admin password to be set via an environment variable. Also changes the CI to run in "test" mode to accept the weak admin password "admin".

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).