### PR TITLE
Add indices:data/read/search/template/render to cluster permissions dropdown

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -240,6 +240,7 @@ export const CLUSTER_PERMISSIONS: string[] = [
   'indices:data/read/msearch/template',
   'indices:data/read/mtv',
   'indices:data/read/mtv*',
+  'indices:data/read/search/template/render',
   'indices:data/write/reindex',
 ];
 


### PR DESCRIPTION
### Description

Adds the cluster permission to render a search template in the cluster permissions dropdown. 

Render search template was made into a separate transport action in core in this [PR](https://github.com/opensearch-project/OpenSearch/pull/11170)

### Category

Maintenance

### Issues Resolved

Related: https://github.com/opensearch-project/security/issues/3672

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).