### PR TITLE
Run `cypress-tests` and `cypress-tests-tenancy-disabled` on Chrome

### DIFF
--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -50,7 +50,7 @@ jobs:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugin-name: ${{ env.PLUGIN_NAME }}
           setup-script-name: setup
-          admin-password: admin
+          admin-password: myStrongPassword123!
 
       - name: Run Dashboard with Security Dashboards Plugin
         uses: ./.github/actions/install-dashboards

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -12,12 +12,12 @@ env:
   PLUGIN_NAME: opensearch-security
 
 jobs:
-  tests:
+  cypress-tests-multitenancy-disabled:
     name: Run Cypress Tests Multitenancy Disabled
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest , windows-latest ]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -74,4 +74,4 @@ jobs:
           git clone https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
           cd opensearch-dashboards-functional-test
           npm install cypress --save-dev
-          yarn cypress:run-with-security --browser firefox --spec "cypress/integration/plugins/security-dashboards-plugin/inaccessible_tenancy_features.js"
+          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/inaccessible_tenancy_features.js"

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -50,7 +50,7 @@ jobs:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugin-name: ${{ env.PLUGIN_NAME }}
           setup-script-name: setup
-          admin-password: admin
+          admin-password: myStrongPassword123!
 
       - name: Run Dashboard with Security Dashboards Plugin
         uses: ./.github/actions/install-dashboards

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:       

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -76,6 +76,6 @@ jobs:
           git clone https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
           cd opensearch-dashboards-functional-test
           npm install cypress --save-dev
-          yarn cypress:run-with-security-and-aggregation-view --browser firefox --spec "cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js"
-          yarn cypress:run-with-security --browser firefox --spec "cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js"
-          yarn cypress:run-with-security --browser firefox --spec "cypress/integration/plugins/security-dashboards-plugin/default_tenant.js"
+          yarn cypress:run-with-security-and-aggregation-view --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js"
+          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js"
+          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/default_tenant.js"

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -12,12 +12,12 @@ env:
   PLUGIN_NAME: opensearch-security
 
 jobs:
-  tests:
+  cypress-tests:
     name: Run Cypress tests
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest , windows-latest ]
+        os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:       


### PR DESCRIPTION
### Description

Fixes an error seen on cypress tests runs like [this](https://github.com/cwperks/security-dashboards-plugin/actions/runs/7426340976/job/20209864738):

```
...
Still waiting to connect to Firefox, retrying in 1 second (attempt 58/62)
Still waiting to connect to Firefox, retrying in 1 second (attempt 59/62)
Still waiting to connect to Firefox, retrying in 1 second (attempt 60/62)
Still waiting to connect to Firefox, retrying in 1 second (attempt 61/62)
Still waiting to connect to Firefox, retrying in 1 second (attempt 62/62)
Cypress failed to make a connection to Firefox.

This usually indicates there was a problem opening the Firefox browser.

Error: could not find CRI target
    at lazyAssLogic (/home/runner/.cache/Cypress/9.5.4/Cypress/resources/app/node_modules/lazy-ass/index.js:110:14)
    at lazyAss (/home/runner/.cache/Cypress/9.5.4/Cypress/resources/app/node_modules/lazy-ass/index.js:115:28)
    at findStartPage (/home/runner/.cache/Cypress/9.5.4/Cypress/resources/app/packages/server/lib/browsers/protocol.js:56:28)
    at runMicrotasks (<anonymous>:null:null)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

by switching these workflows to run with Chrome instead.

Also renames these jobs since `tests` is used in multiple workflows and these should ideally be unique.

### Category

Test fix

### Issues Resolved

- https://github.com/opensearch-project/security-dashboards-plugin/issues/1599

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).