### PR TITLE
Add block to extract OSD version 2.x from package.json

### DIFF
--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -64,7 +64,6 @@ jobs:
         run: |
           echo "::set-output name=osd-version::$(jq -r '.opensearchDashboards.version | split(".") | .[:2] | join(".")' package.json)"
           echo "::set-output name=osd-x-version::$(jq -r '.opensearchDashboards.version | split(".") | .[0]' package.json).x"
-        working-directory: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
         shell: bash
 
       - id: branch-switch-if-possible

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -59,6 +59,13 @@ jobs:
           filter: |
             cypress
             test
+      
+      - id: osd-version
+        run: |
+          echo "::set-output name=osd-version::$(jq -r '.opensearchDashboards.version | split(".") | .[:2] | join(".")' package.json)"
+          echo "::set-output name=osd-x-version::$(jq -r '.opensearchDashboards.version | split(".") | .[0]' package.json).x"
+        working-directory: ${{ steps.determine-plugin-directory.outputs.plugin-directory }}
+        shell: bash
 
       - id: branch-switch-if-possible
         continue-on-error: true # Defaults onto main if the branch switch doesn't work


### PR DESCRIPTION
### Description
The original PR was missing a block that extracted the version. It still worked since 3.0.0 doesn't need to be switched but 2.x does.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).