### PR TITLE
[Main] Forward port version logic change in install binary workflow

### DIFF
--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -60,6 +60,12 @@ jobs:
             cypress
             test
 
+      - id: osd-version
+        run: |
+          echo "::set-output name=osd-version::$(jq -r '.opensearchDashboards.version | split(".") | .[:2] | join(".")' package.json)"
+          echo "::set-output name=osd-x-version::$(jq -r '.opensearchDashboards.version | split(".") | .[0]' package.json).x"
+        shell: bash
+        
       - id: branch-switch-if-possible
         continue-on-error: true # Defaults onto main if the branch switch doesn't work
         if: ${{ steps.osd-version.outputs.osd-version }}


### PR DESCRIPTION
### Description
I had previously missed extracting and setting the version in the install binary workflow. This resulted in failures on the 2.x line since it was still trying to install the plugin zip into 3.0.0 OSD. That was since fixed, and this PR forward ports the change. It's not strictly necessary, but for consistency so the files are the same.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).