### PR TITLE
Add step to install dependencies prior to building

### DIFF
--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -101,6 +101,12 @@ jobs:
         with:
           path: OpenSearch-Dashboards/plugins/security-dashboards-plugin
 
+      - name: Install dependencies
+        run: |
+          yarn osd bootstrap
+        working-directory: OpenSearch-Dashboards
+        shell: bash
+
       - name: Build Plugin Zip
         run: |
           yarn build


### PR DESCRIPTION
### Description
This PR adds a step to install the dependencies prior to building. This will fix the workflow of installing the binary when the dependent libraries are not installed yet, leading to false-positive failures of the install via binary workflow.

The reason why this was not caught before is that security dashboards plugin's current dependencies are only used in the `server` and `test` folders. In the build process, there is a step to run yarn to install dependencies, but the workflow is erroring out in the @osd/optimizer step when trying to add dependencies that live in the `public` folder. This is because the front end code needs to be bundled and thus when a dependency is not there it will error out. This should fix the build and install workflow for dependencies used in the frontend `public` folder.

We should not rely on some implementation detail of how OSD core runs `yarn build` and instead makes sure all necessary dependencies are available when we run that command.


```
yarn run v1.22.19
$ yarn plugin-helpers build && node build_tools/rename_zip.js
$ node ../../scripts/plugin_helpers build
 info deleting the build and target directories
 info running @osd/optimizer
 │ info initialized, 0 bundles cached
 │ info starting worker [1 bundle]
 │ succ 1 bundles compiled successfully after 11.6 sec
 info copying assets from `public/assets` to build
 info copying server source into the build and converting with babel
 info running yarn to install dependencies
 info compressing plugin into [securityDashboards-3.0.0.zip]
 info cleaning up compression temporary artifacts
```

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).