### PR TITLE
Moves eslint to devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,12 +33,12 @@
     "jose": "^4.11.2",
     "saml-idp": "^1.2.1",
     "selfsigned": "^2.0.1",
-    "typescript": "4.0.2"
+    "typescript": "4.0.2",
+    "eslint-plugin-cypress": "^2.8.1"
   },
   "dependencies": {
     "@hapi/cryptiles": "5.0.0",
     "@hapi/wreck": "^17.1.0",
-    "eslint-plugin-cypress": "^2.8.1",
     "html-entities": "1.3.1"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2222,7 +2222,7 @@ glob-all@^3.2.1:
     glob "^7.2.3"
     yargs "^15.3.1"
 
-glob-parent@5.1.2, glob-parent@^3.1.0, glob-parent@~5.1.2:
+glob-parent@^3.1.0, glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==


### PR DESCRIPTION
### Description
Moves eslint-plugin-cypress to a devDependency since it is only used in formatting cypress files. Runs yarn to update the lock file, but this didn't change anything. 

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
#1745 

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).