### PR TITLE
Bumps 1.x to 1.4.0.0

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "securityDashboards",
-  "version": "1.3.14.0",
-  "opensearchDashboardsVersion": "1.3.14",
+  "version": "1.4.0.0",
+  "opensearchDashboardsVersion": "1.4.0.0",
   "configPath": [
     "opensearch_security"
   ],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "opensearch-security-dashboards",
-  "version": "1.3.14.0",
+  "version": "1.4.0.0",
   "main": "target/plugins/opensearch_security_dashboards",
   "opensearchDashboards": {
-    "version": "1.3.14",
-    "templateVersion": "1.3.14"
+    "version": "1.4.0",
+    "templateVersion": "1.4.0"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/security-dashboards-plugin",


### PR DESCRIPTION
### Description
1.x on OpenSearch-Dashboards is at 1.4.0. This PR bumps version on 1.x to be in sync with dashboards.

### Category
Maintenance


### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).