### PR TITLE
Bumps 1.3 to 1.3.15.0

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "securityDashboards",
-  "version": "1.3.14.0",
-  "opensearchDashboardsVersion": "1.3.14",
+  "version": "1.3.15.0",
+  "opensearchDashboardsVersion": "1.3.15",
   "configPath": [
     "opensearch_security"
   ],

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "opensearch-security-dashboards",
-  "version": "1.3.14.0",
+  "version": "1.3.15.0",
   "main": "target/plugins/opensearch_security_dashboards",
   "opensearchDashboards": {
-    "version": "1.3.14",
-    "templateVersion": "1.3.14"
+    "version": "1.3.15",
+    "templateVersion": "1.3.15"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/opensearch-project/security-dashboards-plugin",


### PR DESCRIPTION
1.3 on OpenSearch-Dashboards is bumped to 1.3.15. This PR updates the plugin version to match the core version.

### Category
Maintenance

### Check List
~- [ ] New functionality includes testing~
~- [ ] New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).