### PR TITLE
Adding @derek-ho as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
 | Stephen Crawford | [scrawfor99](https://github.com/scrawfor99)           | Amazon      |
+| Derek Ho         | [derek-ho](https://github.com/derek-ho)               | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
### Description

@derek-ho has been an avid contributor to the security-dashboards-plugin repo since June '23 with 12 Pull Requests merged into main to date. Derek regularly engages on Pull Requests by giving other contributors valuable feedback, helps to maintain all release branches with critical bug fixes and ensuring dependencies are free of known security vulnerabilities, and contributes new features to the security-dashboards-plugin. Some of @derek-ho's notable contributions include:

- https://github.com/opensearch-project/security-dashboards-plugin/pull/1482 - Fix to show only pertinent actions and action groups when looking at cluster_permissions or index_permissions dropdowns.
- https://github.com/opensearch-project/security-dashboards-plugin/pull/1636 - Fix for custom action groups to be visible in dropdowns
- https://github.com/opensearch-project/security-dashboards-plugin/pull/1739 - Creating a new workflow to run the installation of the security-dashboards-plugin with yarn build which helps to detect instances where imports may succeed when starting a development server, but fail with a production build
- Identifying and fixing the distribution build failures related to security-dashboards-plugin

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).