### PR TITLE
Revert Adding @derek-ho as a maintainer (opensearch-project#1758)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,7 +13,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
 | Stephen Crawford | [scrawfor99](https://github.com/scrawfor99)           | Amazon      |
-| Derek Ho         | [derek-ho](https://github.com/derek-ho)               | Amazon      |
 
 ## Emeritus
 


### PR DESCRIPTION
This PR is made to revert PR #1758 which added @derek-ho as a maintainer.

While I continue to believe that Derek would be a great maintainer of the project, I was overeager when merging the pull request. The Security and Security Dashboards repositories follow a 1-week "bake" period practice where all nominations for maintainership must wait 1 week before being merged. I was too quick to merge the pull request so unfortunately must revert it.

This is definitely embarrassing on my part but I wanted to correct my mistake. 