### PR TITLE
Clear the contents of opensearch_dashboards prior to putting settings

### DIFF
--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Configure and Run OpenSearch Dashboards with Cypress Test Cases
         run: |
           cd ./OpenSearch-Dashboards
+          > ./config/opensearch_dashboards.yml  # Clear the file
           echo 'server.host: "0.0.0.0"' >> ./config/opensearch_dashboards.yml
           echo 'opensearch.hosts: ["https://localhost:9200"]' >> ./config/opensearch_dashboards.yml
           echo 'opensearch.ssl.verificationMode: none' >> ./config/opensearch_dashboards.yml

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Configure and Run OpenSearch Dashboards with Cypress Test Cases
         run: |
           cd ./OpenSearch-Dashboards
+          > ./config/opensearch_dashboards.yml  # Clear the file
           echo 'server.host: "0.0.0.0"' >> ./config/opensearch_dashboards.yml
           echo 'opensearch.hosts: ["https://localhost:9200"]' >> ./config/opensearch_dashboards.yml
           echo 'opensearch.ssl.verificationMode: none' >> ./config/opensearch_dashboards.yml


### PR DESCRIPTION
### Description
Figured out the issue was the removal of newline here: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5777/files#r1480507232. This caused the first line of server.host to be written into a comment, and thus leaving cypress not able to access OSD. 

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
Fix: #1779

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).