### PR TITLE
Add loose flag to OSD bootstrap

### DIFF
--- a/.github/actions/install-dashboards/action.yml
+++ b/.github/actions/install-dashboards/action.yml
@@ -82,4 +82,4 @@ runs:
       with:
         timeout_minutes: 20
         max_attempts: 2
-        command: yarn --cwd OpenSearch-Dashboards osd bootstrap --oss --single-version=loose
+        command: yarn --cwd OpenSearch-Dashboards osd bootstrap --oss --single-version=loose # loose is passed in to ignore version conflicts on cypress version used in OSD and this repo

--- a/.github/actions/install-dashboards/action.yml
+++ b/.github/actions/install-dashboards/action.yml
@@ -82,4 +82,4 @@ runs:
       with:
         timeout_minutes: 20
         max_attempts: 2
-        command: yarn --cwd OpenSearch-Dashboards osd bootstrap --oss
+        command: yarn --cwd OpenSearch-Dashboards osd bootstrap --oss --single-version=loose

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -92,7 +92,7 @@ jobs:
           npm i -g yarn@${{ steps.tool-versions.outputs.yarn_version }}
           yarn cache clean
           yarn add sha.js
-          yarn osd bootstrap
+          yarn osd bootstrap --single-version=loose
           scripts/use_node scripts/build
         working-directory: OpenSearch-Dashboards
         shell: bash
@@ -103,7 +103,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yarn osd bootstrap
+          yarn osd bootstrap --single-version=loose
         working-directory: OpenSearch-Dashboards
         shell: bash
 

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -85,6 +85,7 @@ jobs:
           node-version: ${{ steps.tool-versions.outputs.node_version }}
           registry-url: 'https://registry.npmjs.org'
 
+      # loose is passed in to ignore version conflicts on cypress version used in OSD and this repo
       - name: Setup Opensearch Dashboards
         run: |
           npm uninstall -g yarn
@@ -92,7 +93,7 @@ jobs:
           npm i -g yarn@${{ steps.tool-versions.outputs.yarn_version }}
           yarn cache clean
           yarn add sha.js
-          yarn osd bootstrap --single-version=loose
+          yarn osd bootstrap --single-version=loose 
           scripts/use_node scripts/build
         working-directory: OpenSearch-Dashboards
         shell: bash
@@ -101,6 +102,7 @@ jobs:
         with:
           path: OpenSearch-Dashboards/plugins/security-dashboards-plugin
 
+      # loose is passed in to ignore version conflicts on cypress version used in OSD and this repo
       - name: Install dependencies
         run: |
           yarn osd bootstrap --single-version=loose


### PR DESCRIPTION
### Description
Coming from: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5675, this PR adds the flag to have loose single-version dependencies. Ideally this should not be enforced for devDependencies, but should unblock the build. 

### Category
CI fix.

### Why these changes are required?
OSD core added a dependency to cypress 9.5.4 (mismatching with the version in this repo) here: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5725/files#r1494915750, leading to error at bootstrap.

### What is the old behavior before changes and new behavior after changes?
Old behavior is that the bootstrap process would fail. OSD core added a dependency to cypress 9.5.4 in this PR: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5725/files#r1494915750. Since we need cypress 13 in order to run our test suites (including cross-origin support), bootstrapping the plugin with OSD fails since there is a version mismatch. With this new flag, this inconsistency is ignored and the CI is green.

### Issues Resolved
Related to: https://github.com/opensearch-project/security-dashboards-plugin/issues/1786. However that issue is coming from autocuts. We need opensearch-build repo to take in this change to close the autocut. 

### Testing
Testing done via Github Actions

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).