### PR TITLE
Fixes anonymous auth flow to work with SAML

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -34,6 +34,8 @@ export const OPENID_AUTH_LOGIN_WITH_FRAGMENT = '/auth/openid/captureUrlFragment'
 export const SAML_AUTH_LOGIN = '/auth/saml/login';
 export const SAML_AUTH_LOGIN_WITH_FRAGMENT = '/auth/saml/captureUrlFragment';
 export const ANONYMOUS_AUTH_LOGIN = '/auth/anonymous';
+export const ANONYMOUS_AUTH_HEADER =
+  'Basic b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM6b3BlbmRpc3Ryb19zZWN1cnV0eV9hbm9ueW1vdXM=';
 
 export const OPENID_AUTH_LOGOUT = '/auth/openid/logout';
 export const SAML_AUTH_LOGOUT = '/auth/saml/logout';

--- a/common/index.ts
+++ b/common/index.ts
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { randomString } from "@hapi/cryptiles";
+import { randomString } from '@hapi/cryptiles';
 
 export const PLUGIN_ID = 'opensearchDashboardsSecurity';
 export const PLUGIN_NAME = 'security-dashboards-plugin';
@@ -39,7 +39,7 @@ export const ANONYMOUS_AUTH_LOGIN = '/auth/anonymous';
 const ANONYMOUS_AUTH_USER: string = 'opendistro_security_anonymous';
 const RANDOM_PASS: string = randomString(12);
 const ANONYMOUS_USER_PASS: string = `${ANONYMOUS_AUTH_USER}:${RANDOM_PASS}`;
-export const ANONYMOUS_AUTH_HEADER = `Basic ${Buffer.from(ANONYMOUS_USER_PASS).toString('base64')}`
+export const ANONYMOUS_AUTH_HEADER = `Basic ${Buffer.from(ANONYMOUS_USER_PASS).toString('base64')}`;
 
 export const OPENID_AUTH_LOGOUT = '/auth/openid/logout';
 export const SAML_AUTH_LOGOUT = '/auth/saml/logout';

--- a/common/index.ts
+++ b/common/index.ts
@@ -13,6 +13,8 @@
  *   permissions and limitations under the License.
  */
 
+import { randomString } from "@hapi/cryptiles";
+
 export const PLUGIN_ID = 'opensearchDashboardsSecurity';
 export const PLUGIN_NAME = 'security-dashboards-plugin';
 
@@ -34,8 +36,10 @@ export const OPENID_AUTH_LOGIN_WITH_FRAGMENT = '/auth/openid/captureUrlFragment'
 export const SAML_AUTH_LOGIN = '/auth/saml/login';
 export const SAML_AUTH_LOGIN_WITH_FRAGMENT = '/auth/saml/captureUrlFragment';
 export const ANONYMOUS_AUTH_LOGIN = '/auth/anonymous';
-export const ANONYMOUS_AUTH_HEADER =
-  'Basic b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM6b3BlbmRpc3Ryb19zZWN1cnV0eV9hbm9ueW1vdXM=';
+const ANONYMOUS_AUTH_USER: string = 'opendistro_security_anonymous';
+const RANDOM_PASS: string = randomString(12);
+const ANONYMOUS_USER_PASS: string = `${ANONYMOUS_AUTH_USER}:${RANDOM_PASS}`;
+export const ANONYMOUS_AUTH_HEADER = `Basic ${Buffer.from(ANONYMOUS_USER_PASS).toString('base64')}`
 
 export const OPENID_AUTH_LOGOUT = '/auth/openid/logout';
 export const SAML_AUTH_LOGOUT = '/auth/saml/logout';

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -212,14 +212,14 @@ export function LoginPage(props: LoginPageDeps) {
             </EuiFormRow>
           );
 
-          if (authOpts.length > 0) {
-            if (props.config.auth.anonymous_auth_enabled) {
-              const anonymousConfig = props.config.ui[AuthType.ANONYMOUS].login;
-              formBody.push(
-                renderLoginButton(AuthType.ANONYMOUS, ANONYMOUS_AUTH_LOGIN, anonymousConfig)
-              );
-            }
+          if (props.config.auth.anonymous_auth_enabled) {
+            const anonymousConfig = props.config.ui[AuthType.ANONYMOUS].login;
+            formBody.push(
+              renderLoginButton(AuthType.ANONYMOUS, ANONYMOUS_AUTH_LOGIN, anonymousConfig)
+            );
+          }
 
+          if (authOpts.length > 1) {
             formBody.push(<EuiSpacer size="xs" />);
             formBody.push(<EuiHorizontalRule size="full" margin="xl" />);
             formBody.push(<EuiSpacer size="xs" />);

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -212,7 +212,7 @@ export function LoginPage(props: LoginPageDeps) {
             </EuiFormRow>
           );
 
-          if (authOpts.length > 1) {
+          if (authOpts.length > 0) {
             if (props.config.auth.anonymous_auth_enabled) {
               const anonymousConfig = props.config.ui[AuthType.ANONYMOUS].login;
               formBody.push(

--- a/public/apps/login/test/__snapshots__/login-page.test.tsx.snap
+++ b/public/apps/login/test/__snapshots__/login-page.test.tsx.snap
@@ -153,6 +153,419 @@ exports[`Login page renders renders with config value for multiauth 1`] = `
 </EuiListGroup>
 `;
 
+exports[`Login page renders renders with config value for multiauth with anonymous auth enabled 1`] = `
+<EuiListGroup
+  className="login-wrapper"
+>
+  <EuiImage
+    alt=""
+    size="fullWidth"
+    url="http://localhost:5601/images/test.png"
+  />
+  <EuiSpacer
+    size="s"
+  />
+  <EuiText
+    size="m"
+    textAlign="center"
+  >
+    Title1
+  </EuiText>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiText
+    size="s"
+    textAlign="center"
+  >
+    SubTitle1
+  </EuiText>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiForm
+    component="form"
+  >
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiFieldText
+        aria-label="username_input"
+        data-test-subj="user-name"
+        isInvalid={false}
+        onChange={[Function]}
+        placeholder="Username"
+        prepend={
+          <EuiIcon
+            type="user"
+          />
+        }
+        value=""
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      isInvalid={false}
+      labelType="label"
+    >
+      <EuiFieldText
+        aria-label="password_input"
+        data-test-subj="password"
+        isInvalid={false}
+        onChange={[Function]}
+        placeholder="Password"
+        prepend={
+          <EuiIcon
+            type="lock"
+          />
+        }
+        type="password"
+        value=""
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiButton
+        aria-label="basicauth_login_button"
+        className="test-btn-style"
+        data-test-subj="submit"
+        fill={true}
+        onClick={[Function]}
+        size="s"
+        type="submit"
+      >
+        Log in
+      </EuiButton>
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiButton
+        aria-label="anonymous_login_button"
+        className="test-btn-style"
+        data-test-subj="submit"
+        href="/app/opensearch-dashboards/auth/anonymous"
+        iconType="http://localhost:5601/images/test.png"
+        size="s"
+        type="prime"
+      />
+    </EuiFormRow>
+    <EuiSpacer
+      size="xs"
+    />
+    <EuiHorizontalRule
+      margin="xl"
+      size="full"
+    />
+    <EuiSpacer
+      size="xs"
+    />
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiButton
+        aria-label="openid_login_button"
+        className="test-btn-style"
+        data-test-subj="submit"
+        href="/app/opensearch-dashboards/auth/openid/captureUrlFragment?nextUrl=%2F"
+        iconType="http://localhost:5601/images/test.png"
+        size="s"
+        type="prime"
+      >
+        Button1
+      </EuiButton>
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiButton
+        aria-label="saml_login_button"
+        className="test-btn-style"
+        data-test-subj="submit"
+        href="/app/opensearch-dashboards/auth/saml/captureUrlFragment?nextUrl=%2F"
+        iconType="http://localhost:5601/images/test.png"
+        size="s"
+        type="prime"
+      >
+        Button2
+      </EuiButton>
+    </EuiFormRow>
+  </EuiForm>
+</EuiListGroup>
+`;
+
+exports[`Login page renders renders with config value with anonymous auth enabled: string 1`] = `
+<EuiListGroup
+  className="login-wrapper"
+>
+  <EuiImage
+    alt=""
+    size="fullWidth"
+    url="http://localhost:5601/images/test.png"
+  />
+  <EuiSpacer
+    size="s"
+  />
+  <EuiText
+    size="m"
+    textAlign="center"
+  >
+    Title1
+  </EuiText>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiText
+    size="s"
+    textAlign="center"
+  >
+    SubTitle1
+  </EuiText>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiForm
+    component="form"
+  >
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiFieldText
+        aria-label="username_input"
+        data-test-subj="user-name"
+        isInvalid={false}
+        onChange={[Function]}
+        placeholder="Username"
+        prepend={
+          <EuiIcon
+            type="user"
+          />
+        }
+        value=""
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      isInvalid={false}
+      labelType="label"
+    >
+      <EuiFieldText
+        aria-label="password_input"
+        data-test-subj="password"
+        isInvalid={false}
+        onChange={[Function]}
+        placeholder="Password"
+        prepend={
+          <EuiIcon
+            type="lock"
+          />
+        }
+        type="password"
+        value=""
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiButton
+        aria-label="basicauth_login_button"
+        className="test-btn-style"
+        data-test-subj="submit"
+        fill={true}
+        onClick={[Function]}
+        size="s"
+        type="submit"
+      >
+        Log in
+      </EuiButton>
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiButton
+        aria-label="anonymous_login_button"
+        className="test-btn-style"
+        data-test-subj="submit"
+        href="/app/opensearch-dashboards/auth/anonymous"
+        iconType="http://localhost:5601/images/test.png"
+        size="s"
+        type="prime"
+      />
+    </EuiFormRow>
+  </EuiForm>
+</EuiListGroup>
+`;
+
+exports[`Login page renders renders with config value with anonymous auth enabled: string array 1`] = `
+<EuiListGroup
+  className="login-wrapper"
+>
+  <EuiImage
+    alt=""
+    size="fullWidth"
+    url="http://localhost:5601/images/test.png"
+  />
+  <EuiSpacer
+    size="s"
+  />
+  <EuiText
+    size="m"
+    textAlign="center"
+  >
+    Title1
+  </EuiText>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiText
+    size="s"
+    textAlign="center"
+  >
+    SubTitle1
+  </EuiText>
+  <EuiSpacer
+    size="s"
+  />
+  <EuiForm
+    component="form"
+  >
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiFieldText
+        aria-label="username_input"
+        data-test-subj="user-name"
+        isInvalid={false}
+        onChange={[Function]}
+        placeholder="Username"
+        prepend={
+          <EuiIcon
+            type="user"
+          />
+        }
+        value=""
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      isInvalid={false}
+      labelType="label"
+    >
+      <EuiFieldText
+        aria-label="password_input"
+        data-test-subj="password"
+        isInvalid={false}
+        onChange={[Function]}
+        placeholder="Password"
+        prepend={
+          <EuiIcon
+            type="lock"
+          />
+        }
+        type="password"
+        value=""
+      />
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiButton
+        aria-label="basicauth_login_button"
+        className="test-btn-style"
+        data-test-subj="submit"
+        fill={true}
+        onClick={[Function]}
+        size="s"
+        type="submit"
+      >
+        Log in
+      </EuiButton>
+    </EuiFormRow>
+    <EuiFormRow
+      describedByIds={Array []}
+      display="row"
+      fullWidth={false}
+      hasChildLabel={true}
+      hasEmptyLabelSpace={false}
+      labelType="label"
+    >
+      <EuiButton
+        aria-label="anonymous_login_button"
+        className="test-btn-style"
+        data-test-subj="submit"
+        href="/app/opensearch-dashboards/auth/anonymous"
+        iconType="http://localhost:5601/images/test.png"
+        size="s"
+        type="prime"
+      />
+    </EuiFormRow>
+  </EuiForm>
+</EuiListGroup>
+`;
+
 exports[`Login page renders renders with config value: string 1`] = `
 <EuiListGroup
   className="login-wrapper"

--- a/public/apps/login/test/login-page.test.tsx
+++ b/public/apps/login/test/login-page.test.tsx
@@ -36,6 +36,15 @@ const configUI = {
       buttonstyle: 'test-btn-style',
     },
   },
+  anonymous: {
+    login: {
+      title: 'Anony1',
+      subtitle: 'AnonySub1',
+      showbrandimage: true,
+      brandimage: 'http://localhost:5601/images/test.png',
+      buttonstyle: 'test-btn-style',
+    },
+  },
   openid: {
     login: {
       buttonname: 'Button1',
@@ -112,6 +121,21 @@ describe('Login page', () => {
       expect(component).toMatchSnapshot();
     });
 
+    it('renders with config value with anonymous auth enabled: string array', () => {
+      const config: ClientConfigType = {
+        ui: configUI,
+        auth: {
+          type: [AuthType.BASIC],
+          logout_url: API_AUTH_LOGOUT,
+          anonymous_auth_enabled: true,
+        },
+      };
+      const component = shallow(
+        <LoginPage http={mockHttpStart as any} chrome={chrome} config={config as any} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
     it('renders with config value: string', () => {
       const config: ClientConfigType = {
         ui: configUI,
@@ -126,12 +150,42 @@ describe('Login page', () => {
       expect(component).toMatchSnapshot();
     });
 
+    it('renders with config value with anonymous auth enabled: string', () => {
+      const config: ClientConfigType = {
+        ui: configUI,
+        auth: {
+          type: AuthType.BASIC,
+          logout_url: API_AUTH_LOGOUT,
+          anonymous_auth_enabled: true,
+        },
+      };
+      const component = shallow(
+        <LoginPage http={mockHttpStart as any} chrome={chrome} config={config as any} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
     it('renders with config value for multiauth', () => {
       const config: ClientConfigType = {
         ui: configUI,
         auth: {
           type: [AuthType.BASIC, 'openid', AuthType.SAML],
           logout_url: API_AUTH_LOGOUT,
+        },
+      };
+      const component = shallow(
+        <LoginPage http={mockHttpStart as any} chrome={chrome} config={config as any} />
+      );
+      expect(component).toMatchSnapshot();
+    });
+
+    it('renders with config value for multiauth with anonymous auth enabled', () => {
+      const config: ClientConfigType = {
+        ui: configUI,
+        auth: {
+          type: [AuthType.BASIC, 'openid', AuthType.SAML],
+          logout_url: API_AUTH_LOGOUT,
+          anonymous_auth_enabled: true,
         },
       };
       const component = shallow(

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -115,7 +115,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
     let authInfo: any | undefined;
 
     if (this.config.auth.anonymous_auth_enabled) {
-      const anonymousAuthHeaders = { _auth_request_type_: 'anonymous' };
+      const anonymousAuthHeaders = { _auth_request_type_: 'anonymous', authorization: 'Basic b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM6b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM=' };
       Object.assign(authHeaders, anonymousAuthHeaders);
     }
 
@@ -159,10 +159,6 @@ export abstract class AuthenticationType implements IAuthenticationType {
         if (request.url.pathname && request.url.pathname.startsWith('/bundles/')) {
           return toolkit.notHandled();
         }
-        console.log('Request is unauthorized');
-        console.log(request.url);
-        console.log(request.route);
-
         // send to auth workflow
         return this.handleUnauthedRequest(request, response, toolkit);
       }

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -115,7 +115,10 @@ export abstract class AuthenticationType implements IAuthenticationType {
     let authInfo: any | undefined;
 
     // Adds a basic auth credentials headers to requests originated as anonymous user
-    if (this.config.auth.anonymous_auth_enabled) {
+    if (
+      this.config.auth.anonymous_auth_enabled &&
+      !request.headers.hasOwnProperty('authorization')
+    ) {
       const anonymousAuthHeaders = { authorization: ANONYMOUS_AUTH_HEADER };
       Object.assign(authHeaders, anonymousAuthHeaders);
     }

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -113,6 +113,12 @@ export abstract class AuthenticationType implements IAuthenticationType {
     const authHeaders = {};
     let cookie: SecuritySessionCookie | null | undefined;
     let authInfo: any | undefined;
+
+    if (this.config.auth.anonymous_auth_enabled) {
+      const anonymousAuthHeaders = { _auth_request_type_: 'anonymous' };
+      Object.assign(authHeaders, anonymousAuthHeaders);
+    }
+
     // if this is an REST API call, suppose the request includes necessary auth header
     // see https://www.elastic.co/guide/en/opensearch-dashboards/master/using-api.html
     if (this.requestIncludesAuthInfo(request)) {
@@ -153,10 +159,14 @@ export abstract class AuthenticationType implements IAuthenticationType {
         if (request.url.pathname && request.url.pathname.startsWith('/bundles/')) {
           return toolkit.notHandled();
         }
+        console.log('Request is unauthorized');
+        console.log(request.url);
+        console.log(request.route);
 
         // send to auth workflow
         return this.handleUnauthedRequest(request, response, toolkit);
       }
+      console.log('we have a cookie: ' + JSON.stringify(cookie));
 
       // extend session expiration time
       if (this.config.session.keepalive) {
@@ -211,6 +221,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
     }
     if (!authInfo) {
       authInfo = await this.securityClient.authinfo(request, authHeaders);
+      console.log(authInfo);
     }
     authState.authInfo = authInfo;
 

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -31,7 +31,7 @@ import { SecuritySessionCookie } from '../../session/security_cookie';
 import { SecurityClient } from '../../backend/opensearch_security_client';
 import { resolveTenant, isValidTenant } from '../../multitenancy/tenant_resolver';
 import { UnauthenticatedError } from '../../errors';
-import { GLOBAL_TENANT_SYMBOL } from '../../../common';
+import { ANONYMOUS_AUTH_HEADER, GLOBAL_TENANT_SYMBOL } from '../../../common';
 
 export interface IAuthenticationType {
   type: string;
@@ -115,7 +115,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
     let authInfo: any | undefined;
 
     if (this.config.auth.anonymous_auth_enabled) {
-      const anonymousAuthHeaders = { _auth_request_type_: 'anonymous', authorization: 'Basic b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM6b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM=' };
+      const anonymousAuthHeaders = { authorization: ANONYMOUS_AUTH_HEADER };
       Object.assign(authHeaders, anonymousAuthHeaders);
     }
 
@@ -162,7 +162,6 @@ export abstract class AuthenticationType implements IAuthenticationType {
         // send to auth workflow
         return this.handleUnauthedRequest(request, response, toolkit);
       }
-      console.log('we have a cookie: ' + JSON.stringify(cookie));
 
       // extend session expiration time
       if (this.config.session.keepalive) {
@@ -217,7 +216,6 @@ export abstract class AuthenticationType implements IAuthenticationType {
     }
     if (!authInfo) {
       authInfo = await this.securityClient.authinfo(request, authHeaders);
-      console.log(authInfo);
     }
     authState.authInfo = authInfo;
 

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -114,6 +114,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
     let cookie: SecuritySessionCookie | null | undefined;
     let authInfo: any | undefined;
 
+    // Adds a basic auth credentials headers to requests originated as anonymous user
     if (this.config.auth.anonymous_auth_enabled) {
       const anonymousAuthHeaders = { authorization: ANONYMOUS_AUTH_HEADER };
       Object.assign(authHeaders, anonymousAuthHeaders);
@@ -159,6 +160,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
         if (request.url.pathname && request.url.pathname.startsWith('/bundles/')) {
           return toolkit.notHandled();
         }
+
         // send to auth workflow
         return this.handleUnauthedRequest(request, response, toolkit);
       }

--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -111,21 +111,13 @@ export class BasicAuthentication extends AuthenticationType {
         request,
         this.coreSetup.http.basePath.serverBasePath
       );
-      if (this.config.auth.anonymous_auth_enabled) {
-        const redirectLocation = `${this.coreSetup.http.basePath.serverBasePath}${ANONYMOUS_AUTH_LOGIN}?${nextUrlParam}`;
-        return response.redirected({
-          headers: {
-            location: `${redirectLocation}`,
-          },
-        });
-      } else {
-        const redirectLocation = `${this.coreSetup.http.basePath.serverBasePath}${LOGIN_PAGE_URI}?${nextUrlParam}`;
-        return response.redirected({
-          headers: {
-            location: `${redirectLocation}`,
-          },
-        });
-      }
+
+      const redirectLocation = `${this.coreSetup.http.basePath.serverBasePath}${LOGIN_PAGE_URI}?${nextUrlParam}`;
+      return response.redirected({
+        headers: {
+          location: `${redirectLocation}`,
+        },
+      });
     } else {
       return response.unauthorized({
         body: `Authentication required`,

--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -28,7 +28,7 @@ import { SecurityPluginConfigType } from '../../..';
 import { SecuritySessionCookie } from '../../../session/security_cookie';
 import { BasicAuthRoutes } from './routes';
 import { AuthenticationType } from '../authentication_type';
-import { LOGIN_PAGE_URI, ANONYMOUS_AUTH_LOGIN } from '../../../../common';
+import { LOGIN_PAGE_URI, ANONYMOUS_AUTH_HEADER } from '../../../../common';
 import { composeNextUrlQueryParam } from '../../../utils/next_url';
 import { AUTH_HEADER_NAME, AuthType, OPENDISTRO_SECURITY_ANONYMOUS } from '../../../../common';
 
@@ -130,7 +130,7 @@ export class BasicAuthentication extends AuthenticationType {
     request: OpenSearchDashboardsRequest
   ): any {
     if (this.config.auth.anonymous_auth_enabled && cookie.isAnonymousAuth) {
-      return {};
+      return { authorization: ANONYMOUS_AUTH_HEADER };
     }
     const headers: any = {};
     Object.assign(headers, { authorization: cookie.credentials?.authHeaderValue });

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -212,7 +212,6 @@ export class BasicAuthRoutes {
           };
 
           if (user.multitenancy_enabled) {
-            request.headers.authorization = ANONYMOUS_AUTH_HEADER;
             const selectTenant = resolveTenant({
               request,
               username: user.username,
@@ -231,7 +230,6 @@ export class BasicAuthRoutes {
           return response.redirected({
             headers: {
               location: `${redirectUrl}`,
-              authorization: ANONYMOUS_AUTH_HEADER,
             },
           });
         } else {

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -186,7 +186,9 @@ export class BasicAuthRoutes {
           }
           context.security_plugin.logger.info('The Redirect Path is ' + redirectUrl);
           try {
-            user = await this.securityClient.authenticateWithHeaders(request, {});
+            user = await this.securityClient.authenticateWithHeaders(request, {
+              _auth_request_type_: 'anonymous',
+            });
           } catch (error) {
             context.security_plugin.logger.error(
               `Failed authentication: ${error}. Redirecting to Login Page`
@@ -200,6 +202,8 @@ export class BasicAuthRoutes {
             });
           }
 
+          console.log('Anon user: ' + JSON.stringify(user));
+
           this.sessionStorageFactory.asScoped(request).clear();
           const sessionStorage: SecuritySessionCookie = {
             username: user.username,
@@ -209,6 +213,7 @@ export class BasicAuthRoutes {
           };
 
           if (user.multitenancy_enabled) {
+            request.headers._auth_request_type_ = 'anonymous';
             const selectTenant = resolveTenant({
               request,
               username: user.username,

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -186,8 +186,13 @@ export class BasicAuthRoutes {
           }
           context.security_plugin.logger.info('The Redirect Path is ' + redirectUrl);
           try {
+            // user = await this.securityClient.authenticateWithHeaders(request, {
+            //   _auth_request_type_: 'anonymous',
+            // });
+            // opendistro_security_anonymous:opendistro_security_anonymous
+            const authHeader = "b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM6b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM="; 
             user = await this.securityClient.authenticateWithHeaders(request, {
-              _auth_request_type_: 'anonymous',
+              authorization: `Basic ${authHeader}`,
             });
           } catch (error) {
             context.security_plugin.logger.error(
@@ -214,6 +219,7 @@ export class BasicAuthRoutes {
 
           if (user.multitenancy_enabled) {
             request.headers._auth_request_type_ = 'anonymous';
+            request.headers.authorization = 'Basic b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM6b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM=';
             const selectTenant = resolveTenant({
               request,
               username: user.username,
@@ -232,6 +238,8 @@ export class BasicAuthRoutes {
           return response.redirected({
             headers: {
               location: `${redirectUrl}`,
+              _auth_request_type_: "anonymous",
+              authorization: "Basic b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM6b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM="
             },
           });
         } else {

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -23,6 +23,7 @@ import { SecurityPluginConfigType } from '../../..';
 import { User } from '../../user';
 import { SecurityClient } from '../../../backend/opensearch_security_client';
 import {
+  ANONYMOUS_AUTH_HEADER,
   ANONYMOUS_AUTH_LOGIN,
   API_AUTH_LOGIN,
   API_AUTH_LOGOUT,
@@ -186,13 +187,8 @@ export class BasicAuthRoutes {
           }
           context.security_plugin.logger.info('The Redirect Path is ' + redirectUrl);
           try {
-            // user = await this.securityClient.authenticateWithHeaders(request, {
-            //   _auth_request_type_: 'anonymous',
-            // });
-            // opendistro_security_anonymous:opendistro_security_anonymous
-            const authHeader = "b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM6b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM="; 
             user = await this.securityClient.authenticateWithHeaders(request, {
-              authorization: `Basic ${authHeader}`,
+              authorization: ANONYMOUS_AUTH_HEADER,
             });
           } catch (error) {
             context.security_plugin.logger.error(
@@ -207,8 +203,6 @@ export class BasicAuthRoutes {
             });
           }
 
-          console.log('Anon user: ' + JSON.stringify(user));
-
           this.sessionStorageFactory.asScoped(request).clear();
           const sessionStorage: SecuritySessionCookie = {
             username: user.username,
@@ -218,8 +212,7 @@ export class BasicAuthRoutes {
           };
 
           if (user.multitenancy_enabled) {
-            request.headers._auth_request_type_ = 'anonymous';
-            request.headers.authorization = 'Basic b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM6b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM=';
+            request.headers.authorization = ANONYMOUS_AUTH_HEADER;
             const selectTenant = resolveTenant({
               request,
               username: user.username,
@@ -238,8 +231,7 @@ export class BasicAuthRoutes {
           return response.redirected({
             headers: {
               location: `${redirectUrl}`,
-              _auth_request_type_: "anonymous",
-              authorization: "Basic b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM6b3BlbmRpc3Ryb19zZWN1cml0eV9hbm9ueW1vdXM="
+              authorization: ANONYMOUS_AUTH_HEADER,
             },
           });
         } else {

--- a/server/auth/types/multiple/multi_auth.ts
+++ b/server/auth/types/multiple/multi_auth.ts
@@ -166,20 +166,13 @@ export class MultipleAuthentication extends AuthenticationType {
         this.coreSetup.http.basePath.serverBasePath
       );
 
-      if (this.config.auth.anonymous_auth_enabled) {
-        const redirectLocation = `${this.coreSetup.http.basePath.serverBasePath}${ANONYMOUS_AUTH_LOGIN}?${nextUrlParam}`;
-        return response.redirected({
-          headers: {
-            location: `${redirectLocation}`,
-          },
-        });
-      }
       return response.redirected({
         headers: {
           location: `${this.coreSetup.http.basePath.serverBasePath}${LOGIN_PAGE_URI}?${nextUrlParam}`,
         },
       });
     } else {
+      console.log('not a page request');
       return response.unauthorized();
     }
   }

--- a/server/auth/types/multiple/multi_auth.ts
+++ b/server/auth/types/multiple/multi_auth.ts
@@ -172,7 +172,6 @@ export class MultipleAuthentication extends AuthenticationType {
         },
       });
     } else {
-      console.log('not a page request');
       return response.unauthorized();
     }
   }

--- a/server/readonly/readonly_service.ts
+++ b/server/readonly/readonly_service.ts
@@ -24,6 +24,7 @@ import {
   isPrivateTenant,
   LOGIN_PAGE_URI,
   CUSTOM_ERROR_PAGE_URI,
+  ANONYMOUS_AUTH_HEADER,
 } from '../../common';
 import { SecurityClient } from '../backend/opensearch_security_client';
 import { IAuthenticationType, OpenSearchAuthInfo } from '../auth/types/authentication_type';

--- a/test/constant.ts
+++ b/test/constant.ts
@@ -13,13 +13,8 @@
  *   permissions and limitations under the License.
  */
 
-import { version, opensearchDashboards } from '../package.json';
-
 export const OPENSEARCH_DASHBOARDS_SERVER_USER: string = 'kibanaserver';
 export const OPENSEARCH_DASHBOARDS_SERVER_PASSWORD: string = 'kibanaserver';
-
-export const ELASTICSEARCH_VERSION: string = opensearchDashboards.version;
-export const SECURITY_ES_PLUGIN_VERSION: string = version;
 
 export const ADMIN_USER: string = 'admin';
 export const ADMIN_PASSWORD: string = 'admin';

--- a/test/jest_integration/basic_auth.test.ts
+++ b/test/jest_integration/basic_auth.test.ts
@@ -132,6 +132,20 @@ describe('start OpenSearch Dashboards server', () => {
     expect(response.status).toEqual(200);
   });
 
+  it('cannot access home page as anonymous user if no credentials are supplied', async () => {
+    const response = await osdTestServer.request
+      .get(root, '/app/home#/')
+      .unset(AUTHORIZATION_HEADER_NAME);
+    expect(response.status).toEqual(302);
+  });
+
+  it('can access home page as anonymous user', async () => {
+    const response = await osdTestServer.request
+      .get(root, '/app/home#/')
+      .set(AUTHORIZATION_HEADER_NAME, ANONYMOUS_AUTH_HEADER);
+    expect(response.status).toEqual(200);
+  });
+
   it('call authinfo API as admin', async () => {
     const testUserCredentials = Buffer.from(ADMIN_CREDENTIALS);
     const response = await osdTestServer.request
@@ -143,8 +157,15 @@ describe('start OpenSearch Dashboards server', () => {
   it('call authinfo API without credentials', async () => {
     const response = await osdTestServer.request
       .get(root, '/api/v1/auth/authinfo')
-      .unset('Authorization');
+      .unset(AUTHORIZATION_HEADER_NAME);
     expect(response.status).toEqual(401);
+  });
+
+  it('call authinfo API as anonymous user', async () => {
+    const response = await osdTestServer.request
+      .get(root, '/api/v1/auth/authinfo')
+      .set(AUTHORIZATION_HEADER_NAME, ANONYMOUS_AUTH_HEADER);
+    expect(response.status).toEqual(200);
   });
 
   it('call authinfo API with cookie', async () => {

--- a/test/jest_integration/basic_auth.test.ts
+++ b/test/jest_integration/basic_auth.test.ts
@@ -27,6 +27,7 @@ import {
 } from '../constant';
 import { getAuthCookie, extractAuthCookie } from '../helper/cookie';
 import wreck from '@hapi/wreck';
+import { ANONYMOUS_AUTH_HEADER } from '../../common';
 
 describe('start OpenSearch Dashboards server', () => {
   let root: Root;
@@ -226,16 +227,11 @@ describe('start OpenSearch Dashboards server', () => {
       .unset(AUTHORIZATION_HEADER_NAME);
 
     expect(response.status).toEqual(302);
-    expect(response.header.location).toEqual('/auth/anonymous?nextUrl=%2Fapp%2Fhome');
+    expect(response.header.location).toEqual('/app/login?nextUrl=%2Fapp%2Fhome');
 
     const response2 = await osdTestServer.request.get(root, response.header.location);
 
-    expect(response2.status).toEqual(302);
-    expect(response2.header.location).toEqual('/app/login?nextUrl=%2Fapp%2Fhome');
-
-    const response3 = await osdTestServer.request.get(root, response2.header.location);
-
-    expect(response3.status).toEqual(200);
+    expect(response2.status).toEqual(200);
   });
 
   it('redirect for home follows login for anonymous auth disabled', async () => {
@@ -264,14 +260,10 @@ describe('start OpenSearch Dashboards server', () => {
       .unset(AUTHORIZATION_HEADER_NAME);
 
     expect(response.status).toEqual(302);
+    expect(response.header.location).toEqual(expectedPath);
 
     const response2 = await osdTestServer.request.get(root, response.header.location);
 
-    expect(response2.status).toEqual(302);
-    expect(response2.header.location).toEqual(expectedPath);
-
-    const response3 = await osdTestServer.request.get(root, response2.header.location);
-
-    expect(response3.status).toEqual(200);
+    expect(response2.status).toEqual(200);
   });
 });


### PR DESCRIPTION
### Description
This PR fixes 2 things:
1. Anonymous login button would not show if only 1 auth option was supplied
2. Broken SAML auth flow when anonymous auth is enabled.


### Category
- Bug fix

### Why these changes are required?
- For SAML and anonymous auth options to function when both options are enabled

### What is the old behavior before changes and new behavior after changes?
- At present, SAML auth flow is broken since anonymous auth automatically assumes the Anonymous user when no auth credentials are found. See security plugin PR[1] for more details.

[1] - Companion PR: https://github.com/opensearch-project/security/pull/4097


### Issues Resolved
- Resolves https://github.com/opensearch-project/security-dashboards-plugin/issues/1731

### Testing
- Automated + Manual

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).