### PR TITLE
Add workspace and multi tenancy check

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -10,7 +10,8 @@
     "savedObjectsManagement"
   ],
   "optionalPlugins": [
-    "managementOverview"
+    "managementOverview",
+    "workspace"
   ],
   "server": true,
   "ui": true

--- a/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
+++ b/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
@@ -98,6 +98,14 @@ export function ConfigureTab1(props: AppDependencies) {
         handleSave={async (updatedConfiguration1: TenancyConfigSettings) => {
           try {
             console.log('Calling API');
+            if (
+              updatedConfiguration1.multitenancy_enabled &&
+              props.coreStart.application.capabilities.workspaces.enabled
+            ) {
+              throw new Error(
+                'Multi-tenancy is not allowed to enable as workspace is enabled, you can disable workspace and retry.'
+              );
+            }
             await updateTenancyConfiguration(props.coreStart.http, updatedConfiguration1);
             setSaveChangesModal(null);
             setChangeInMultiTenancyOption(0);
@@ -349,6 +357,7 @@ export function ConfigureTab1(props: AppDependencies) {
                 label={'Enabled'}
                 checked={updatedConfiguration.multitenancy_enabled}
                 onChange={() => onSwitchChangeTenancyEnabled()}
+                disabled={props.coreStart.application.capabilities.workspaces.enabled}
               />
             </EuiDescribedFormGroup>
           </EuiPageContentHeaderSection>

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -15,6 +15,7 @@
 
 import { first } from 'rxjs/operators';
 import { Observable } from 'rxjs';
+import { CriticalError } from '../../../src/core/server/errors';
 import {
   PluginInitializerContext,
   CoreSetup,
@@ -148,10 +149,10 @@ export class SecurityPlugin
     );
 
     if (workspace && config.multitenancy?.enabled && dashboardsInfo.multitenancy_enabled) {
-      this.logger.error(
-        'Both workspace and multi-tenancy features are enabled, only one of them can be enabled at the same time.'
-      );
-      process.exit(1);
+      const message =
+        'Both workspace and multi-tenancy features are enabled, only one of them can be enabled at the same time.';
+      this.logger.error(message);
+      throw new CriticalError(message, 'InvalidConfig', 64);
     }
 
     // set up multi-tenant routes

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -73,7 +73,8 @@ interface SecurityPluginSetupDeps {
   workspace: WorkspacePluginSetup;
 }
 
-export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPluginStart, SecurityPluginSetupDeps> {
+export class SecurityPlugin
+  implements Plugin<SecurityPluginSetup, SecurityPluginStart, SecurityPluginSetupDeps> {
   private readonly logger: Logger;
   // FIXME: keep an reference of admin client so that it can be used in start(), better to figureout a
   //        decent way to get adminClient in start. (maybe using getStartServices() from setup?)

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -142,14 +142,20 @@ export class SecurityPlugin
     defineRoutes(router);
     defineAuthTypeRoutes(router, config);
 
+    // multitenancyinfo is application level
+    const dashboardsInfo = await esClient.callAsInternalUser(
+      'opensearch_security.multitenancyinfo'
+    );
+
+    if (workspace && config.multitenancy?.enabled && dashboardsInfo.multitenancy_enabled) {
+      this.logger.error(
+        'Both workspace and multi-tenancy features are enabled, only one of them can be enabled at the same time.'
+      );
+      process.exit(1);
+    }
+
     // set up multi-tenant routes
     if (config.multitenancy?.enabled) {
-      if (workspace) {
-        this.logger.error(
-          'Both workspace and multi-tenancy features are enabled, only one of them can be enabled at the same time.'
-        );
-        process.exit(1);
-      }
       setupMultitenantRoutes(router, securitySessionStorageFactory, this.securityClient);
     }
 

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -144,7 +144,9 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
     // set up multi-tenant routes
     if (config.multitenancy?.enabled) {
       if (workspace) {
-        this.logger.error("Both workspace and multi-tenancy features are turned on, only one of them could turned on at same time.");
+        this.logger.error(
+          'Both workspace and multi-tenancy features are enabled, only one of them could enabled at same time.'
+        );
         process.exit(1);
       }
       setupMultitenantRoutes(router, securitySessionStorageFactory, this.securityClient);

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -145,7 +145,7 @@ export class SecurityPlugin implements Plugin<SecurityPluginSetup, SecurityPlugi
     if (config.multitenancy?.enabled) {
       if (workspace) {
         this.logger.error(
-          'Both workspace and multi-tenancy features are enabled, only one of them could enabled at same time.'
+          'Both workspace and multi-tenancy features are enabled, only one of them can be enabled at the same time.'
         );
         process.exit(1);
       }


### PR DESCRIPTION
### Description

Add check for both workspace and multi tenancy turn on case. If they are both on, an error message will print on console and whole OSD process will exit.


**Enable both workspace and multi tenancy**

Run the command to start OSD
`yarn start --workspace.enabled=true  --opensearch_security.multitenancy.enabled=true` and dynamic multi-tenancy flag is `true`

The output 
```
server    log   [07:12:26.988] [error][plugins][securityDashboards] Both workspace and multi-tenancy features are enabled, only one of them could enabled at same time.
server crashed  with status code 1
```
**Enable multi tenancy only**

Run the command to start OSD
`yarn start --no-base-path --opensearch_security.multitenancy.enabled=true`

Output
```
server    log   [07:14:28.546] [info][listening] Server running at http://0.0.0.0:5601
server    log   [07:14:28.612] [info][server][OpenSearchDashboards][http] http server running at http://0.0.0.0:5601
```


**Enable workspace only**

Run the command to start OSD
`yarn start --no-base-path --workspace.enabled=true  --opensearch_security.multitenancy.enabled=false`

Output
```
server    log   [07:21:27.487] [info][plugins-system] Starting [40] plugins: [usageCollection,opensearchDashboardsUsageCollection,opensearchDashboardsLegacy,mapsLegacy,share,opensearchUiShared,legacyExport,embeddable,expressions,data,home,apmOss,savedObjects,workspace,dashboard,visualizations,visTypeVega,visTypeTimeline,visTypeTable,visTypeMarkdown,visBuilder,visAugmenter,tileMap,regionMap,inputControlVis,visualize,management,indexPatternManagement,advancedSettings,console,dataExplorer,charts,visTypeTimeseries,visTypeVislib,visTypeTagcloud,visTypeMetric,discover,savedObjectsManagement,securityDashboards,bfetch]
server    log   [07:21:27.700] [info][listening] Server running at http://0.0.0.0:5601
server    log   [07:21:27.755] [info][server][OpenSearchDashboards][http] http server running at http://0.0.0.0:5601
```

**When workspace enabled**

Multi-tenancy check is disabled that will not all cx turn on multi-tenancy dynamiclly.

![image](https://github.com/opensearch-project/security-dashboards-plugin/assets/113890546/4bd0a4d3-286e-46b7-9457-32a7a603687b)



### Category

New feature

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
opensearch-project/OpenSearch-Dashboards#1819 

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).