### PR TITLE
Add toast handling for purge cache action

### DIFF
--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -35,12 +35,7 @@ import { ResourceType } from '../../../../common';
 import { API_ENDPOINT_CACHE, DocLinks } from '../constants';
 import { ExternalLink, ExternalLinkButton } from '../utils/display-utils';
 import { httpDelete } from '../utils/request-utils';
-import {
-  createErrorToast,
-  createSuccessToast,
-  createUnknownErrorToast,
-  useToastState,
-} from '../utils/toast-utils';
+import { createSuccessToast, createUnknownErrorToast, useToastState } from '../utils/toast-utils';
 
 const addBackendStep = {
   title: 'Add backends',
@@ -238,20 +233,20 @@ export function GetStarted(props: AppDependencies) {
             <EuiButton
               iconType="refresh"
               fill
+              data-test-subj="purge-cache"
               onClick={async () => {
-                httpDelete(props.coreStart.http, API_ENDPOINT_CACHE)
-                  .then(() => {
-                    addToast(
-                      createSuccessToast(
-                        'cache-flush-success',
-                        'Cache purge successful',
-                        'Cache purge successful'
-                      )
-                    );
-                  })
-                  .catch(() =>
-                    addToast(createUnknownErrorToast('cache-flush-failed', 'purge cache'))
+                try {
+                  await httpDelete(props.coreStart.http, API_ENDPOINT_CACHE);
+                  addToast(
+                    createSuccessToast(
+                      'cache-flush-success',
+                      'Cache purge successful',
+                      'Cache purge successful'
+                    )
                   );
+                } catch (err) {
+                  addToast(createUnknownErrorToast('cache-flush-failed', 'purge cache'));
+                }
               }}
             >
               Purge cache

--- a/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
+++ b/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
@@ -14,14 +14,9 @@
  */
 
 import {
-  EuiBadge,
   EuiButton,
-  EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiInMemoryTable,
-  EuiLink,
-  EuiPageBody,
   EuiPageContent,
   EuiPageContentHeader,
   EuiPageContentHeaderSection,
@@ -29,51 +24,28 @@ import {
   EuiText,
   EuiTitle,
   EuiGlobalToastList,
-  EuiSwitch,
-  Query,
   EuiHorizontalRule,
-  EuiFormRow,
   EuiDescribedFormGroup,
   EuiSpacer,
   EuiCheckbox,
-  EuiModal,
-  EuiModalHeader,
-  EuiModalHeaderTitle,
-  EuiModalBody,
-  EuiModalFooter,
-  EuiCodeBlock,
   EuiCallOut,
   EuiBottomBar,
   EuiComboBox,
   EuiIcon,
-  EuiPanel,
 } from '@elastic/eui';
-import { ChangeEvent } from 'react';
-import React, { ReactNode, useState, useCallback } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { SaveChangesModalGenerator } from './save_changes_modal';
 import { AppDependencies } from '../../../types';
-import { displayBoolean } from '../../utils/display-utils';
-import { updateAuditLogging } from '../../utils/audit-logging-utils';
-import { AuditLoggingSettings } from '../audit-logging/types';
-import { AuthInfo } from '../../../../types';
-import { updateTenancyConfig } from '../../utils/tenancy-config_util';
 import { TenancyConfigSettings } from '../tenancy-config/types';
-import { getAuthInfo } from '../../../../utils/auth-info-utils';
 import {
   fetchTenants,
   transformTenantData,
   updateTenancyConfiguration,
-  updateTenant,
 } from '../../utils/tenant-utils';
-import { Action, Tenant } from '../../types';
-import { showTableStatusMessage } from '../../utils/loading-spinner-utils';
-import { useContextMenuState } from '../../utils/context-menu';
-import { TenantEditModal } from './edit-modal';
+import { Tenant } from '../../types';
 import {
   createTenancyErrorToast,
   createTenancySuccessToast,
-  createUnknownErrorToast,
-  getSuccessToastMessage,
   useToastState,
 } from '../../utils/toast-utils';
 import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -189,6 +189,7 @@ exports[`Get started (landing page) renders when backend configuration is disabl
           By default, the security plugin caches authenticated users, along with their roles and permissions. This option will purge cached users, roles and permissions.
         </p>
         <EuiButton
+          data-test-subj="purge-cache"
           fill={true}
           iconType="refresh"
           onClick={[Function]}
@@ -243,6 +244,12 @@ exports[`Get started (landing page) renders when backend configuration is disabl
       </EuiText>
     </EuiPanel>
   </div>
+  <EuiGlobalToastList
+    dismissToast={[MockFunction]}
+    side="right"
+    toastLifeTimeMs={10000}
+    toasts={Array []}
+  />
 </Fragment>
 `;
 
@@ -502,6 +509,7 @@ exports[`Get started (landing page) renders when backend configuration is enable
           By default, the security plugin caches authenticated users, along with their roles and permissions. This option will purge cached users, roles and permissions.
         </p>
         <EuiButton
+          data-test-subj="purge-cache"
           fill={true}
           iconType="refresh"
           onClick={[Function]}
@@ -556,5 +564,11 @@ exports[`Get started (landing page) renders when backend configuration is enable
       </EuiText>
     </EuiPanel>
   </div>
+  <EuiGlobalToastList
+    dismissToast={[MockFunction]}
+    side="right"
+    toastLifeTimeMs={10000}
+    toasts={Array []}
+  />
 </Fragment>
 `;

--- a/public/apps/configuration/panels/test/get-started.test.tsx
+++ b/public/apps/configuration/panels/test/get-started.test.tsx
@@ -148,7 +148,7 @@ describe('Get started (landing page)', () => {
       jest.clearAllMocks();
     });
 
-    it('Purge cache button clicks', async () => {
+    it('Purge cache button fails', async () => {
       const button = wrapper.find('[data-test-subj="purge-cache"]');
       expect(button).toHaveLength(1);
 
@@ -161,7 +161,7 @@ describe('Get started (landing page)', () => {
       expect(ToastUtils.createUnknownErrorToast).toHaveBeenCalledTimes(1);
     });
 
-    it('Purge cache button click', async () => {
+    it('Purge cache button works', async () => {
       const button = wrapper.find('[data-test-subj="purge-cache"]');
       expect(button).toHaveLength(1);
 

--- a/public/apps/configuration/panels/test/get-started.test.tsx
+++ b/public/apps/configuration/panels/test/get-started.test.tsx
@@ -20,6 +20,18 @@ import { Action } from '../../types';
 import { ResourceType } from '../../../../../common';
 import { buildHashUrl } from '../../utils/url-builder';
 import { GetStarted } from '../get-started';
+import * as ToastUtils from '../../utils/toast-utils'; // Import all functions from toast-utils
+import * as RequestUtils from '../../utils/request-utils'; // Import all functions from request-utils
+
+jest.mock('../../utils/toast-utils', () => ({
+  createSuccessToast: jest.fn(),
+  createUnknownErrorToast: jest.fn(),
+  useToastState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()]),
+}));
+
+jest.mock('../../utils/request-utils', () => ({
+  httpDelete: jest.fn(),
+}));
 
 describe('Get started (landing page)', () => {
   const mockCoreStart = {
@@ -71,6 +83,7 @@ describe('Get started (landing page)', () => {
           config={config as any}
         />
       );
+      jest.clearAllMocks();
     });
 
     it('Review authentication and authorization button click', () => {
@@ -118,6 +131,44 @@ describe('Get started (landing page)', () => {
       expect(button).toHaveLength(1);
       button.simulate('click');
       expect(window.location.hash).toBe(buildHashUrl(ResourceType.auditLogging));
+    });
+  });
+
+  describe('Tests purge cache button', () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = shallow(
+        <GetStarted
+          coreStart={mockCoreStart as any}
+          navigation={{} as any}
+          params={{} as any}
+          config={config as any}
+        />
+      );
+      jest.clearAllMocks();
+    });
+
+    it('Purge cache button clicks', async () => {
+      const button = wrapper.find('[data-test-subj="purge-cache"]');
+      expect(button).toHaveLength(1);
+
+      // Failure case: Mock httpDelete to reject
+      jest
+        .spyOn(RequestUtils, 'httpDelete')
+        .mockRejectedValueOnce(new Error('Failed to purge cache'));
+
+      await button.props().onClick(); // Simulate button click
+      expect(ToastUtils.createUnknownErrorToast).toHaveBeenCalledTimes(1);
+    });
+
+    it('Purge cache button click', async () => {
+      const button = wrapper.find('[data-test-subj="purge-cache"]');
+      expect(button).toHaveLength(1);
+
+      // Success case: Mock httpDelete to resolve
+      jest.spyOn(RequestUtils, 'httpDelete').mockResolvedValueOnce('nice');
+      await button.props().onClick(); // Simulate button click
+      expect(ToastUtils.createSuccessToast).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
### Description
This PR adds a toast message for success and failure of the purge cache action. 

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]
Enhancement
### Why these changes are required?
Today, there is no indication that a purge cache action succeeded or failed. This can be confusing to the user as they would not know the result unless they have the network tab open or are checking the backend logs. This adds visual indication and brings this action more inline with other actions such as create user. This also acts as a shim for end to end testing which can rely on the new toast to see if some action succeeded or failed.

### What is the old behavior before changes and new behavior after changes?
New behavior shown below:

https://github.com/opensearch-project/security-dashboards-plugin/assets/26328171/9c500548-1f85-407f-962a-66269fcdcc14



### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]
Fix: #1815 

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]
Manual testing, added tests

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).