### PR TITLE
Lift state up one and generalize flow, render picker for auth tab

### DIFF
--- a/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
@@ -70,6 +70,50 @@ jobs:
           node.max_local_storage_nodes: 3
           EOT
 
+      # Add Custom Configuration to differentiate between local and remote cluster
+      - name: Create Custom Configuration for Linux
+        if: ${{ runner.os == 'Linux'}}
+        run: |
+          echo "Creating new custom configuration"
+          cat << 'EOT' > config_custom.yml
+          ---
+          _meta:
+            type: "config"
+            config_version: 2
+          config:
+            dynamic:
+              http:
+                anonymous_auth_enabled: false
+              authc:
+                basic_internal_auth_domain:
+                  description: "Authenticate via HTTP Basic against internal users database"
+                  http_enabled: true
+                  transport_enabled: true
+                  order: 0
+                  http_authenticator:
+                    type: basic
+                    challenge: false
+                  authentication_backend:
+                    type: intern
+                saml_auth_domain:
+                  http_enabled: true
+                  transport_enabled: false
+                  order: 1
+                  http_authenticator:
+                    type: saml
+                    challenge: true
+                    config:
+                      idp:
+                        entity_id: urn:example:idp
+                        metadata_url: http://localhost:7000/metadata
+                      sp:
+                        entity_id: https://localhost:9200
+                      kibana_url: http://localhost:5601
+                      exchange_key: 6aff3042-1327-4f3d-82f0-40a157ac4464
+                  authentication_backend:
+                    type: noop
+          EOT
+
       - name: Download security plugin and create setup scripts
         uses: ./.github/actions/download-plugin
         with:
@@ -84,7 +128,7 @@ jobs:
           plugins: "file:$(pwd)/opensearch-security.zip"
           security-enabled: true
           admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
-          security_config_file: ${{ inputs.security_config_file }}
+          security_config_file: config_custom.yml
           opensearch_yml_file: remote_opensearch.yml
           opensearch_port: 9202
 

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -26,7 +26,7 @@ import { httpGet, httpGetWithIgnores, httpPost } from '../configuration/utils/re
 import { setShouldShowTenantPopup } from '../../utils/storage-utils';
 
 export function fetchAccountInfo(http: HttpStart): Promise<AccountInfo> {
-  return httpGet(http, API_ENDPOINT_ACCOUNT_INFO);
+  return httpGet({ http, url: API_ENDPOINT_ACCOUNT_INFO });
 }
 
 export async function fetchAccountInfoSafe(http: HttpStart): Promise<AccountInfo | undefined> {

--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -17,10 +17,7 @@ import { EuiBreadcrumb, EuiPage, EuiPageBody, EuiPageSideBar } from '@elastic/eu
 import { flow, partial } from 'lodash';
 import React, { createContext, useState } from 'react';
 import { HashRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
-import {
-  DataSourceOption,
-  LocalCluster,
-} from '../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
+import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { AppDependencies } from '../types';
 import { AuditLogging } from './panels/audit-logging/audit-logging';
 import { AuditLoggingEditSettings } from './panels/audit-logging/audit-logging-edit-settings';
@@ -156,7 +153,11 @@ export const DataSourceContext = createContext<DataSourceContextType | null>(nul
 
 export function AppRouter(props: AppDependencies) {
   const setGlobalBreadcrumbs = flow(getBreadcrumbs, props.coreStart.chrome.setBreadcrumbs);
-  const [dataSource, setDataSource] = useState<DataSourceOption>(LocalCluster);
+  const [dataSource, setDataSource] = useState<DataSourceOption>({
+    id: '',
+    label: 'Local cluster',
+    checked: 'on',
+  });
 
   return (
     <DataSourceContext.Provider value={{ dataSource, setDataSource }}>

--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -17,7 +17,7 @@ import { EuiBreadcrumb, EuiPage, EuiPageBody, EuiPageSideBar } from '@elastic/eu
 import { flow, partial } from 'lodash';
 import React, { createContext, useState } from 'react';
 import { HashRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
-import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
+import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { AppDependencies } from '../types';
 import { AuditLogging } from './panels/audit-logging/audit-logging';
 import { AuditLoggingEditSettings } from './panels/audit-logging/audit-logging-edit-settings';

--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -15,8 +15,9 @@
 
 import { EuiBreadcrumb, EuiPage, EuiPageBody, EuiPageSideBar } from '@elastic/eui';
 import { flow, partial } from 'lodash';
-import React from 'react';
+import React, { createContext, useState } from 'react';
 import { HashRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
+import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { AppDependencies } from '../types';
 import { AuditLogging } from './panels/audit-logging/audit-logging';
 import { AuditLoggingEditSettings } from './panels/audit-logging/audit-logging-edit-settings';
@@ -143,140 +144,154 @@ function decodeParams(params: { [k: string]: string }): any {
   }, {});
 }
 
+export interface DataSourceContextType {
+  dataSource: DataSourceOption;
+  setDataSource: React.Dispatch<React.SetStateAction<DataSourceOption>>;
+}
+
+export const DataSourceContext = createContext<DataSourceContextType | null>(null);
+
 export function AppRouter(props: AppDependencies) {
   const setGlobalBreadcrumbs = flow(getBreadcrumbs, props.coreStart.chrome.setBreadcrumbs);
+  const [dataSource, setDataSource] = useState<DataSourceOption>({
+    id: '',
+    label: 'Local cluster',
+    checked: 'on',
+  });
 
   return (
-    <Router basename={props.params.appBasePath}>
-      <EuiPage>
-        {allNavPanelUrls.map((route) => (
-          // Create different routes to update the 'selected' nav item .
-          <Route key={route} path={route} exact>
-            <EuiPageSideBar>
-              <NavPanel items={ROUTE_LIST} />
-            </EuiPageSideBar>
-          </Route>
-        ))}
-        <EuiPageBody>
-          <Switch>
-            <Route
-              path={buildUrl(ResourceType.roles, Action.edit) + '/:roleName/' + SubAction.mapuser}
-              render={(match) => (
-                <RoleEditMappedUser
-                  buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
-                  {...{ ...props, ...decodeParams(match.match.params) }}
-                />
-              )}
-            />
-            <Route
-              path={buildUrl(ResourceType.roles, Action.view) + '/:roleName/:prevAction?'}
-              render={(match) => (
-                <RoleView
-                  buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
-                  {...{ ...props, ...decodeParams(match.match.params) }}
-                />
-              )}
-            />
-            <Route
-              path={buildUrl(ResourceType.roles) + '/:action/:sourceRoleName?'}
-              render={(match) => (
-                <RoleEdit
-                  buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
-                  {...{ ...props, ...decodeParams(match.match.params) }}
-                />
-              )}
-            />
-            <Route
-              path={ROUTE_MAP.roles.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.roles);
-                return <RoleList {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.auth.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.auth);
-                return <AuthView {...props} />;
-              }}
-            />
-            <Route
-              path={buildUrl(ResourceType.users) + '/:action/:sourceUserName?'}
-              render={(match) => (
-                <InternalUserEdit
-                  buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.users)}
-                  {...{ ...props, ...decodeParams(match.match.params) }}
-                />
-              )}
-            />
-            <Route
-              path={ROUTE_MAP.users.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.users);
-                return <UserList {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.serviceAccounts.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.serviceAccounts);
-                return <ServiceAccountList {...props} />;
-              }}
-            />
-            <Route
-              path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.auditLogging, 'General settings');
-                return <AuditLoggingEditSettings setting={'general'} {...props} />;
-              }}
-            />
-            <Route
-              path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.auditLogging, 'Compliance settings');
-                return <AuditLoggingEditSettings setting={'compliance'} {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.auditLogging.href + '/:fromType?'}
-              render={(match) => {
-                setGlobalBreadcrumbs(ResourceType.auditLogging);
-                return <AuditLogging {...{ ...props, ...match.match.params }} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.permissions.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.permissions);
-                return <PermissionList {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.tenants.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.tenants);
-                return <TenantList tabID={'Manage'} {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.tenantsConfigureTab.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.tenants);
-                return <TenantList tabID={'Configure'} {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.getStarted.href}
-              render={() => {
-                setGlobalBreadcrumbs();
-                return <GetStarted {...props} />;
-              }}
-            />
-            <Redirect exact from="/" to={LANDING_PAGE_URL} />
-          </Switch>
-        </EuiPageBody>
-        <CrossPageToast />
-      </EuiPage>
-    </Router>
+    <DataSourceContext.Provider value={{ dataSource, setDataSource }}>
+      <Router basename={props.params.appBasePath}>
+        <EuiPage>
+          {allNavPanelUrls.map((route) => (
+            // Create different routes to update the 'selected' nav item .
+            <Route key={route} path={route} exact>
+              <EuiPageSideBar>
+                <NavPanel items={ROUTE_LIST} />
+              </EuiPageSideBar>
+            </Route>
+          ))}
+          <EuiPageBody>
+            <Switch>
+              <Route
+                path={buildUrl(ResourceType.roles, Action.edit) + '/:roleName/' + SubAction.mapuser}
+                render={(match) => (
+                  <RoleEditMappedUser
+                    buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
+                    {...{ ...props, ...decodeParams(match.match.params) }}
+                  />
+                )}
+              />
+              <Route
+                path={buildUrl(ResourceType.roles, Action.view) + '/:roleName/:prevAction?'}
+                render={(match) => (
+                  <RoleView
+                    buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
+                    {...{ ...props, ...decodeParams(match.match.params) }}
+                  />
+                )}
+              />
+              <Route
+                path={buildUrl(ResourceType.roles) + '/:action/:sourceRoleName?'}
+                render={(match) => (
+                  <RoleEdit
+                    buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
+                    {...{ ...props, ...decodeParams(match.match.params) }}
+                  />
+                )}
+              />
+              <Route
+                path={ROUTE_MAP.roles.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.roles);
+                  return <RoleList {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.auth.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.auth);
+                  return <AuthView {...props} />;
+                }}
+              />
+              <Route
+                path={buildUrl(ResourceType.users) + '/:action/:sourceUserName?'}
+                render={(match) => (
+                  <InternalUserEdit
+                    buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.users)}
+                    {...{ ...props, ...decodeParams(match.match.params) }}
+                  />
+                )}
+              />
+              <Route
+                path={ROUTE_MAP.users.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.users);
+                  return <UserList {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.serviceAccounts.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.serviceAccounts);
+                  return <ServiceAccountList {...props} />;
+                }}
+              />
+              <Route
+                path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.auditLogging, 'General settings');
+                  return <AuditLoggingEditSettings setting={'general'} {...props} />;
+                }}
+              />
+              <Route
+                path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.auditLogging, 'Compliance settings');
+                  return <AuditLoggingEditSettings setting={'compliance'} {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.auditLogging.href + '/:fromType?'}
+                render={(match) => {
+                  setGlobalBreadcrumbs(ResourceType.auditLogging);
+                  return <AuditLogging {...{ ...props, ...match.match.params }} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.permissions.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.permissions);
+                  return <PermissionList {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.tenants.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.tenants);
+                  return <TenantList tabID={'Manage'} {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.tenantsConfigureTab.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.tenants);
+                  return <TenantList tabID={'Configure'} {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.getStarted.href}
+                render={() => {
+                  setGlobalBreadcrumbs();
+                  return <GetStarted {...props} />;
+                }}
+              />
+              <Redirect exact from="/" to={LANDING_PAGE_URL} />
+            </Switch>
+          </EuiPageBody>
+          <CrossPageToast />
+        </EuiPage>
+      </Router>
+    </DataSourceContext.Provider>
   );
 }

--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -17,7 +17,10 @@ import { EuiBreadcrumb, EuiPage, EuiPageBody, EuiPageSideBar } from '@elastic/eu
 import { flow, partial } from 'lodash';
 import React, { createContext, useState } from 'react';
 import { HashRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
-import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
+import {
+  DataSourceOption,
+  LocalCluster,
+} from '../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { AppDependencies } from '../types';
 import { AuditLogging } from './panels/audit-logging/audit-logging';
 import { AuditLoggingEditSettings } from './panels/audit-logging/audit-logging-edit-settings';
@@ -153,11 +156,7 @@ export const DataSourceContext = createContext<DataSourceContextType | null>(nul
 
 export function AppRouter(props: AppDependencies) {
   const setGlobalBreadcrumbs = flow(getBreadcrumbs, props.coreStart.chrome.setBreadcrumbs);
-  const [dataSource, setDataSource] = useState<DataSourceOption>({
-    id: '',
-    label: 'Local cluster',
-    checked: 'on',
-  });
+  const [dataSource, setDataSource] = useState<DataSourceOption>(LocalCluster);
 
   return (
     <DataSourceContext.Provider value={{ dataSource, setDataSource }}>

--- a/public/apps/configuration/panels/auth-view/auth-view.tsx
+++ b/public/apps/configuration/panels/auth-view/auth-view.tsx
@@ -36,7 +36,7 @@ export function AuthView(props: AppDependencies) {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const config = await getSecurityConfig(props.coreStart.http, undefined, {
+        const config = await getSecurityConfig(props.coreStart.http, {
           dataSourceId: dataSource.id,
         });
 

--- a/public/apps/configuration/panels/auth-view/auth-view.tsx
+++ b/public/apps/configuration/panels/auth-view/auth-view.tsx
@@ -36,7 +36,9 @@ export function AuthView(props: AppDependencies) {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const config = await getSecurityConfig(props.coreStart.http);
+        const config = await getSecurityConfig(props.coreStart.http, undefined, {
+          dataSourceId: dataSource.id,
+        });
 
         setAuthentication(config.authc);
         setAuthorization(config.authz);
@@ -48,7 +50,7 @@ export function AuthView(props: AppDependencies) {
     };
 
     fetchData();
-  }, [props.coreStart.http]);
+  }, [props.coreStart.http, dataSource.id]);
 
   if (isEmpty(authentication)) {
     return <InstructionView config={props.config} />;

--- a/public/apps/configuration/panels/auth-view/auth-view.tsx
+++ b/public/apps/configuration/panels/auth-view/auth-view.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { EuiPageHeader, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { isEmpty } from 'lodash';
 import { AuthenticationSequencePanel } from './authentication-sequence-panel';
@@ -23,11 +23,14 @@ import { AppDependencies } from '../../../types';
 import { ExternalLinkButton } from '../../utils/display-utils';
 import { getSecurityConfig } from '../../utils/auth-view-utils';
 import { InstructionView } from './instruction-view';
+import { DataSourceContext } from '../../app-router';
+import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
 
 export function AuthView(props: AppDependencies) {
   const [authentication, setAuthentication] = React.useState([]);
   const [authorization, setAuthorization] = React.useState([]);
   const [loading, setLoading] = useState(false);
+  const { dataSource, setDataSource } = useContext(DataSourceContext)!;
 
   React.useEffect(() => {
     const fetchData = async () => {
@@ -53,6 +56,12 @@ export function AuthView(props: AppDependencies) {
 
   return (
     <>
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={false}
+        setDataSource={setDataSource}
+        selectedDataSource={dataSource}
+      />
       <EuiPageHeader>
         <EuiTitle size="l">
           <h1>Authentication and authorization</h1>

--- a/public/apps/configuration/panels/auth-view/test/auth-view.test.tsx
+++ b/public/apps/configuration/panels/auth-view/test/auth-view.test.tsx
@@ -17,6 +17,11 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { AuthView } from '../auth-view';
 
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
+
 // eslint-disable-next-line
 const mockAuthViewUtils = require('../../../utils/auth-view-utils');
 

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -255,8 +255,12 @@ export function GetStarted(props: AppDependencies) {
               data-test-subj="purge-cache"
               onClick={async () => {
                 try {
-                  await httpDelete(props.coreStart.http, API_ENDPOINT_CACHE, undefined, {
-                    dataSourceId: dataSource.id,
+                  await httpDelete({
+                    http: props.coreStart.http,
+                    url: API_ENDPOINT_CACHE,
+                    query: {
+                      dataSourceId: dataSource.id,
+                    },
                   });
                   addToast(
                     createSuccessToast(

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -26,8 +26,9 @@ import {
   EuiTitle,
   EuiGlobalToastList,
 } from '@elastic/eui';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
+import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { AppDependencies } from '../../types';
 import { buildHashUrl } from '../utils/url-builder';
 import { Action } from '../types';
@@ -38,6 +39,7 @@ import { httpDelete } from '../utils/request-utils';
 import { createSuccessToast, createUnknownErrorToast, useToastState } from '../utils/toast-utils';
 import { SecurityPluginTopNavMenu } from '../top-nav-menu';
 import { Cluster } from '../../../types';
+import { DataSourceContext } from '../app-router';
 
 const addBackendStep = {
   title: 'Add backends',
@@ -160,7 +162,7 @@ const setOfSteps = [
   },
 ];
 
-export function getClusterInfoIfEnabled(dataSourceEnabled: boolean, cluster: Cluster) {
+export function getClusterInfoIfEnabled(dataSourceEnabled: boolean, cluster: DataSourceOption) {
   if (dataSourceEnabled) {
     return `for ${cluster.label || 'Local cluster'}`;
   }
@@ -169,7 +171,7 @@ export function getClusterInfoIfEnabled(dataSourceEnabled: boolean, cluster: Clu
 
 export function GetStarted(props: AppDependencies) {
   const dataSourceEnabled = !!props.depsStart.dataSource?.dataSourceEnabled;
-  const [dataSource, setDataSource] = useState<Cluster>({ id: '', label: '' });
+  const { dataSource, setDataSource } = useContext(DataSourceContext)!;
 
   let steps;
   if (props.config.ui.backend_configurable) {
@@ -185,7 +187,8 @@ export function GetStarted(props: AppDependencies) {
         <SecurityPluginTopNavMenu
           {...props}
           dataSourcePickerReadOnly={false}
-          setDatasourceId={setDataSource}
+          setDataSource={setDataSource}
+          selectedDataSource={dataSource}
         />
         <EuiPageHeader>
           <EuiTitle size="l">

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -28,7 +28,7 @@ import {
 } from '@elastic/eui';
 import React, { useContext, useState } from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
-import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
+import { DataSourceOption } from '../../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { AppDependencies } from '../../types';
 import { buildHashUrl } from '../utils/url-builder';
 import { Action } from '../types';
@@ -38,7 +38,6 @@ import { ExternalLink, ExternalLinkButton } from '../utils/display-utils';
 import { httpDelete } from '../utils/request-utils';
 import { createSuccessToast, createUnknownErrorToast, useToastState } from '../utils/toast-utils';
 import { SecurityPluginTopNavMenu } from '../top-nav-menu';
-import { Cluster } from '../../../types';
 import { DataSourceContext } from '../app-router';
 
 const addBackendStep = {
@@ -256,7 +255,7 @@ export function GetStarted(props: AppDependencies) {
               data-test-subj="purge-cache"
               onClick={async () => {
                 try {
-                  await httpDelete(props.coreStart.http, API_ENDPOINT_CACHE, {
+                  await httpDelete(props.coreStart.http, API_ENDPOINT_CACHE, undefined, {
                     dataSourceId: dataSource.id,
                   });
                   addToast(

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -21,7 +21,12 @@ exports[`Get started (landing page) renders when backend configuration is disabl
       dataSourcePickerReadOnly={false}
       depsStart={Object {}}
       params={Object {}}
-      setDatasourceId={[Function]}
+      selectedDataSource={
+        Object {
+          "id": "test",
+        }
+      }
+      setDataSource={[MockFunction]}
     />
     <EuiPageHeader>
       <EuiTitle
@@ -292,7 +297,12 @@ exports[`Get started (landing page) renders when backend configuration is enable
       dataSourcePickerReadOnly={false}
       depsStart={Object {}}
       params={Object {}}
-      setDatasourceId={[Function]}
+      selectedDataSource={
+        Object {
+          "id": "test",
+        }
+      }
+      setDataSource={[MockFunction]}
     />
     <EuiPageHeader>
       <EuiTitle

--- a/public/apps/configuration/panels/test/get-started.test.tsx
+++ b/public/apps/configuration/panels/test/get-started.test.tsx
@@ -33,6 +33,11 @@ jest.mock('../../utils/request-utils', () => ({
   httpDelete: jest.fn(),
 }));
 
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
+
 describe('Get started (landing page)', () => {
   const mockCoreStart = {
     http: 1,

--- a/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
+++ b/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
   value={
     Object {
       "dataSource": Object {
-        "checked": "on",
         "id": "",
         "label": "Local cluster",
       },

--- a/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
+++ b/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
@@ -5,6 +5,7 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
   value={
     Object {
       "dataSource": Object {
+        "checked": "on",
         "id": "",
         "label": "Local cluster",
       },

--- a/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
+++ b/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
@@ -1,0 +1,643 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enabled 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "dataSource": Object {
+        "checked": "on",
+        "id": "",
+        "label": "Local cluster",
+      },
+      "setDataSource": [Function],
+    }
+  }
+>
+  <HashRouter
+    basename=""
+  >
+    <EuiPage>
+      <Route
+        exact={true}
+        key="/getstarted"
+        path="/getstarted"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/auth"
+        path="/auth"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/roles"
+        path="/roles"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/users"
+        path="/users"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/serviceAccounts"
+        path="/serviceAccounts"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/permissions"
+        path="/permissions"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/tenants"
+        path="/tenants"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/auditLogging"
+        path="/auditLogging"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/tenantsConfigureTab"
+        path="/tenantsConfigureTab"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/auditLogging/edit/generalSettings"
+        path="/auditLogging/edit/generalSettings"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/auditLogging/edit/complianceSettings"
+        path="/auditLogging/edit/complianceSettings"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <EuiPageBody>
+        <Switch>
+          <Route
+            path="/roles/edit/:roleName/mapuser"
+            render={[Function]}
+          />
+          <Route
+            path="/roles/view/:roleName/:prevAction?"
+            render={[Function]}
+          />
+          <Route
+            path="/roles/:action/:sourceRoleName?"
+            render={[Function]}
+          />
+          <Route
+            path="/roles"
+            render={[Function]}
+          />
+          <Route
+            path="/auth"
+            render={[Function]}
+          />
+          <Route
+            path="/users/:action/:sourceUserName?"
+            render={[Function]}
+          />
+          <Route
+            path="/users"
+            render={[Function]}
+          />
+          <Route
+            path="/serviceAccounts"
+            render={[Function]}
+          />
+          <Route
+            path="/auditLogging/edit/generalSettings"
+            render={[Function]}
+          />
+          <Route
+            path="/auditLogging/edit/complianceSettings"
+            render={[Function]}
+          />
+          <Route
+            path="/auditLogging/:fromType?"
+            render={[Function]}
+          />
+          <Route
+            path="/permissions"
+            render={[Function]}
+          />
+          <Route
+            path="/tenants"
+            render={[Function]}
+          />
+          <Route
+            path="/tenantsConfigureTab"
+            render={[Function]}
+          />
+          <Route
+            path="/getstarted"
+            render={[Function]}
+          />
+          <Redirect
+            exact={true}
+            from="/"
+            to="/getstarted"
+          />
+        </Switch>
+      </EuiPageBody>
+      <CrossPageToast />
+    </EuiPage>
+  </HashRouter>
+</ContextProvider>
+`;

--- a/public/apps/configuration/test/app-router.test.tsx
+++ b/public/apps/configuration/test/app-router.test.tsx
@@ -25,8 +25,8 @@ describe('SecurityPluginTopNavMenu', () => {
     },
     notifications: jest.fn(),
     chrome: {
-        setBreadcrumbs: jest.fn()
-    }
+      setBreadcrumbs: jest.fn(),
+    },
   };
 
   const dataSourceMenuMock = jest.fn(() => <div>Mock DataSourceMenu</div>);
@@ -44,9 +44,7 @@ describe('SecurityPluginTopNavMenu', () => {
       },
     };
 
-    const wrapper = shallow(
-      <AppRouter coreStart={coreStartMock} params={{appBasePath: ''}}/>
-    );
+    const wrapper = shallow(<AppRouter coreStart={coreStartMock} params={{ appBasePath: '' }} />);
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/public/apps/configuration/test/app-router.test.tsx
+++ b/public/apps/configuration/test/app-router.test.tsx
@@ -1,0 +1,53 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { SecurityPluginTopNavMenu } from '../top-nav-menu';
+import { AppRouter } from '../app-router';
+
+describe('SecurityPluginTopNavMenu', () => {
+  const coreStartMock = {
+    savedObjects: {
+      client: jest.fn(),
+    },
+    notifications: jest.fn(),
+    chrome: {
+        setBreadcrumbs: jest.fn()
+    }
+  };
+
+  const dataSourceMenuMock = jest.fn(() => <div>Mock DataSourceMenu</div>);
+
+  const dataSourceManagementMock = {
+    ui: {
+      DataSourceMenu: dataSourceMenuMock,
+    },
+  };
+
+  it('renders DataSourceMenu when dataSource is enabled', () => {
+    const securityPluginStartDepsMock = {
+      dataSource: {
+        dataSourceEnabled: true,
+      },
+    };
+
+    const wrapper = shallow(
+      <AppRouter coreStart={coreStartMock} params={{appBasePath: ''}}/>
+    );
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -14,20 +14,25 @@
  */
 
 import React from 'react';
-import { CoreStart } from 'opensearch-dashboards/public';
-import { NavigationPublicPluginStart } from 'src/plugins/navigation/public/types';
-import { ClientConfigType } from '../../types';
+import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { PLUGIN_NAME } from '../../../common';
 import { AppDependencies } from '../types';
-import { Cluster } from '../../types';
 
 export interface TopNavMenuProps extends AppDependencies {
   dataSourcePickerReadOnly: boolean;
-  setDatasourceId: React.Dispatch<React.SetStateAction<Cluster>>;
+  setDataSource: React.Dispatch<React.SetStateAction<DataSourceOption>>;
+  selectedDataSource: DataSourceOption;
 }
 
 export const SecurityPluginTopNavMenu = (props: TopNavMenuProps) => {
-  const { coreStart, depsStart, params, dataSourceManagement, setDatasourceId } = props;
+  const {
+    coreStart,
+    depsStart,
+    params,
+    dataSourceManagement,
+    setDataSource,
+    selectedDataSource,
+  } = props;
   const { setHeaderActionMenu } = params;
   const DataSourceMenu = dataSourceManagement?.ui.DataSourceMenu;
   const dataSourceEnabled = !!depsStart.dataSource?.dataSourceEnabled;
@@ -39,7 +44,9 @@ export const SecurityPluginTopNavMenu = (props: TopNavMenuProps) => {
       savedObjects={coreStart.savedObjects.client}
       setMenuMountPoint={setHeaderActionMenu}
       notifications={coreStart.notifications}
-      dataSourceCallBackFunc={(datasource) => setDatasourceId(datasource)}
+      dataSourceCallBackFunc={setDataSource}
+      // Single select for now
+      selectedOption={[selectedDataSource]}
       hideLocalCluster={false}
       fullWidth={false}
     />

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -14,7 +14,7 @@
  */
 
 import React from 'react';
-import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
+import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { PLUGIN_NAME } from '../../../common';
 import { AppDependencies } from '../types';
 

--- a/public/apps/configuration/utils/action-groups-utils.tsx
+++ b/public/apps/configuration/utils/action-groups-utils.tsx
@@ -30,10 +30,10 @@ export interface PermissionListingItem {
 }
 
 export async function fetchActionGroups(http: HttpStart): Promise<DataObject<ActionGroupItem>> {
-  const actiongroups = await httpGet<ObjectsMessage<ActionGroupItem>>(
+  const actiongroups = await httpGet<ObjectsMessage<ActionGroupItem>>({
     http,
-    API_ENDPOINT_ACTIONGROUPS
-  );
+    url: API_ENDPOINT_ACTIONGROUPS,
+  });
   return actiongroups.data;
 }
 
@@ -98,6 +98,6 @@ export async function updateActionGroup(
 
 export async function requestDeleteActionGroups(http: HttpStart, groups: string[]) {
   for (const group of groups) {
-    await httpDelete(http, getResourceUrl(API_ENDPOINT_ACTIONGROUPS, group));
+    await httpDelete({ http, url: getResourceUrl(API_ENDPOINT_ACTIONGROUPS, group) });
   }
 }

--- a/public/apps/configuration/utils/audit-logging-utils.tsx
+++ b/public/apps/configuration/utils/audit-logging-utils.tsx
@@ -23,6 +23,6 @@ export async function updateAuditLogging(http: HttpStart, updateObject: AuditLog
 }
 
 export async function getAuditLogging(http: HttpStart): Promise<AuditLoggingSettings> {
-  const rawConfiguration = await httpGet<any>(http, API_ENDPOINT_AUDITLOGGING);
+  const rawConfiguration = await httpGet<any>({ http, url: API_ENDPOINT_AUDITLOGGING });
   return rawConfiguration?.config;
 }

--- a/public/apps/configuration/utils/auth-view-utils.tsx
+++ b/public/apps/configuration/utils/auth-view-utils.tsx
@@ -13,11 +13,11 @@
  *   permissions and limitations under the License.
  */
 
-import { HttpStart } from 'opensearch-dashboards/public';
+import { HttpFetchQuery, HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_SECURITYCONFIG } from '../constants';
 import { httpGet } from './request-utils';
 
-export async function getSecurityConfig(http: HttpStart) {
-  const rawSecurityConfig = await httpGet<any>(http, API_ENDPOINT_SECURITYCONFIG);
+export async function getSecurityConfig(http: HttpStart, body?: object, query?: HttpFetchQuery) {
+  const rawSecurityConfig = await httpGet<any>(http, API_ENDPOINT_SECURITYCONFIG, body, query);
   return rawSecurityConfig.data.config.dynamic;
 }

--- a/public/apps/configuration/utils/auth-view-utils.tsx
+++ b/public/apps/configuration/utils/auth-view-utils.tsx
@@ -17,7 +17,7 @@ import { HttpFetchQuery, HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_SECURITYCONFIG } from '../constants';
 import { httpGet } from './request-utils';
 
-export async function getSecurityConfig(http: HttpStart, body?: object, query?: HttpFetchQuery) {
-  const rawSecurityConfig = await httpGet<any>(http, API_ENDPOINT_SECURITYCONFIG, body, query);
+export async function getSecurityConfig(http: HttpStart, query?: HttpFetchQuery) {
+  const rawSecurityConfig = await httpGet<any>({ http, url: API_ENDPOINT_SECURITYCONFIG, query });
   return rawSecurityConfig.data.config.dynamic;
 }

--- a/public/apps/configuration/utils/internal-user-detail-utils.tsx
+++ b/public/apps/configuration/utils/internal-user-detail-utils.tsx
@@ -20,7 +20,10 @@ import { httpGet, httpPost } from './request-utils';
 import { getResourceUrl } from './resource-utils';
 
 export async function getUserDetail(http: HttpStart, username: string): Promise<InternalUser> {
-  return await httpGet<InternalUser>(http, getResourceUrl(API_ENDPOINT_INTERNALUSERS, username));
+  return await httpGet<InternalUser>({
+    http,
+    url: getResourceUrl(API_ENDPOINT_INTERNALUSERS, username),
+  });
 }
 
 export async function updateUser(

--- a/public/apps/configuration/utils/internal-user-list-utils.tsx
+++ b/public/apps/configuration/utils/internal-user-list-utils.tsx
@@ -39,7 +39,7 @@ export function transformUserData(rawData: DataObject<InternalUser>): InternalUs
 
 export async function requestDeleteUsers(http: HttpStart, users: string[]) {
   for (const user of users) {
-    await httpDelete(http, getResourceUrl(API_ENDPOINT_INTERNALUSERS, user));
+    await httpDelete({ http, url: getResourceUrl(API_ENDPOINT_INTERNALUSERS, user) });
   }
 }
 
@@ -52,7 +52,7 @@ async function getUserListRaw(
     ENDPOINT = API_ENDPOINT_SERVICEACCOUNTS;
   }
 
-  return await httpGet<ObjectsMessage<InternalUser>>(http, ENDPOINT);
+  return await httpGet<ObjectsMessage<InternalUser>>({ http, url: ENDPOINT });
 }
 
 export async function getUserList(

--- a/public/apps/configuration/utils/request-utils.ts
+++ b/public/apps/configuration/utils/request-utils.ts
@@ -15,6 +15,13 @@
 
 import { HttpStart, HttpHandler, HttpFetchQuery } from 'opensearch-dashboards/public';
 
+interface RequestType {
+  http: HttpStart;
+  url: string;
+  body?: object;
+  query?: HttpFetchQuery;
+}
+
 export async function request<T>(
   requestFunc: HttpHandler,
   url: string,
@@ -27,12 +34,8 @@ export async function request<T>(
   return (await requestFunc(url, { query })) as T;
 }
 
-export async function httpGet<T>(
-  http: HttpStart,
-  url: string,
-  body?: object,
-  query?: HttpFetchQuery
-): Promise<T> {
+export async function httpGet<T>(params: RequestType): Promise<T> {
+  const { http, url, body, query } = params;
   return await request<T>(http.get, url, body, query);
 }
 
@@ -44,14 +47,8 @@ export async function httpPut<T>(http: HttpStart, url: string, body?: object): P
   return await request<T>(http.put, url, body);
 }
 
-export async function httpDelete<T>(
-  http: HttpStart,
-  url: string,
-  body?: object,
-  query?: HttpFetchQuery
-): Promise<T> {
-  console.log(query);
-  console.log(body);
+export async function httpDelete<T>(params: RequestType): Promise<T> {
+  const { http, url, body, query } = params;
   return await request<T>(http.delete, url, body, query);
 }
 

--- a/public/apps/configuration/utils/request-utils.ts
+++ b/public/apps/configuration/utils/request-utils.ts
@@ -13,17 +13,27 @@
  *   permissions and limitations under the License.
  */
 
-import { HttpStart, HttpHandler } from 'opensearch-dashboards/public';
+import { HttpStart, HttpHandler, HttpFetchQuery } from 'opensearch-dashboards/public';
 
-export async function request<T>(requestFunc: HttpHandler, url: string, body?: object): Promise<T> {
+export async function request<T>(
+  requestFunc: HttpHandler,
+  url: string,
+  body?: object,
+  query?: HttpFetchQuery
+): Promise<T> {
   if (body) {
-    return (await requestFunc(url, { body: JSON.stringify(body) })) as T;
+    return (await requestFunc(url, { body: JSON.stringify(body), query })) as T;
   }
-  return (await requestFunc(url)) as T;
+  return (await requestFunc(url, { query })) as T;
 }
 
-export async function httpGet<T>(http: HttpStart, url: string): Promise<T> {
-  return await request<T>(http.get, url);
+export async function httpGet<T>(
+  http: HttpStart,
+  url: string,
+  body?: object,
+  query?: HttpFetchQuery
+): Promise<T> {
+  return await request<T>(http.get, url, body, query);
 }
 
 export async function httpPost<T>(http: HttpStart, url: string, body?: object): Promise<T> {
@@ -34,8 +44,15 @@ export async function httpPut<T>(http: HttpStart, url: string, body?: object): P
   return await request<T>(http.put, url, body);
 }
 
-export async function httpDelete<T>(http: HttpStart, url: string, body?: object): Promise<T> {
-  return await request<T>(http.delete, url, body);
+export async function httpDelete<T>(
+  http: HttpStart,
+  url: string,
+  body?: object,
+  query?: HttpFetchQuery
+): Promise<T> {
+  console.log(query);
+  console.log(body);
+  return await request<T>(http.delete, url, body, query);
 }
 
 /**

--- a/public/apps/configuration/utils/role-detail-utils.tsx
+++ b/public/apps/configuration/utils/role-detail-utils.tsx
@@ -20,7 +20,7 @@ import { httpGet, httpPost } from './request-utils';
 import { getResourceUrl } from './resource-utils';
 
 export async function getRoleDetail(http: HttpStart, roleName: string): Promise<RoleDetail> {
-  return await httpGet<RoleDetail>(http, getResourceUrl(API_ENDPOINT_ROLES, roleName));
+  return await httpGet<RoleDetail>({ http, url: getResourceUrl(API_ENDPOINT_ROLES, roleName) });
 }
 
 export async function updateRole(http: HttpStart, roleName: string, updateObject: RoleUpdate) {

--- a/public/apps/configuration/utils/role-list-utils.tsx
+++ b/public/apps/configuration/utils/role-list-utils.tsx
@@ -106,5 +106,5 @@ export function fetchRole(http: HttpStart): Promise<any> {
 
 // TODO: have a type definition for it
 export function fetchRoleMapping(http: HttpStart): Promise<any> {
-  return httpGet<any>(http, API_ENDPOINT_ROLESMAPPING);
+  return httpGet<any>({ http, url: API_ENDPOINT_ROLESMAPPING });
 }

--- a/public/apps/configuration/utils/role-list-utils.tsx
+++ b/public/apps/configuration/utils/role-list-utils.tsx
@@ -94,14 +94,14 @@ export function buildSearchFilterOptions(roleList: any[], attrName: string): Arr
 // Submit request to delete given roles. No error handling in this function.
 export async function requestDeleteRoles(http: HttpStart, roles: string[]) {
   for (const role of roles) {
-    await httpDelete(http, getResourceUrl(API_ENDPOINT_ROLES, role));
+    await httpDelete({ http, url: getResourceUrl(API_ENDPOINT_ROLES, role) });
     await httpDeleteWithIgnores(http, getResourceUrl(API_ENDPOINT_ROLESMAPPING, role), [404]);
   }
 }
 
 // TODO: have a type definition for it
 export function fetchRole(http: HttpStart): Promise<any> {
-  return httpGet<any>(http, API_ENDPOINT_ROLES);
+  return httpGet<any>({ http, url: API_ENDPOINT_ROLES });
 }
 
 // TODO: have a type definition for it

--- a/public/apps/configuration/utils/tenancy-config_util.tsx
+++ b/public/apps/configuration/utils/tenancy-config_util.tsx
@@ -23,6 +23,6 @@ export async function updateTenancyConfig(http: HttpStart, updateObject: Tenancy
 }
 
 export async function getTenancyConfig(http: HttpStart): Promise<TenancyConfigSettings> {
-  const rawConfiguration = await httpGet<any>(http, API_ENDPOINT_TENANCY_CONFIGS);
+  const rawConfiguration = await httpGet<any>({ http, url: API_ENDPOINT_TENANCY_CONFIGS });
   return rawConfiguration;
 }

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -64,7 +64,7 @@ export const PRIVATE_USER_DICT: { [key: string]: string } = {
 };
 
 export async function fetchTenants(http: HttpStart): Promise<DataObject<Tenant>> {
-  return (await httpGet<ObjectsMessage<Tenant>>(http, API_ENDPOINT_TENANTS)).data;
+  return (await httpGet<ObjectsMessage<Tenant>>({ http, url: API_ENDPOINT_TENANTS })).data;
 }
 
 export async function fetchTenantNameList(http: HttpStart): Promise<string[]> {
@@ -89,7 +89,7 @@ export function transformTenantData(rawTenantData: DataObject<Tenant>): Tenant[]
 }
 
 export async function fetchCurrentTenant(http: HttpStart): Promise<string> {
-  return await httpGet<string>(http, API_ENDPOINT_MULTITENANCY);
+  return await httpGet<string>({ http, url: API_ENDPOINT_MULTITENANCY });
 }
 
 export async function updateTenant(
@@ -111,7 +111,7 @@ export async function updateTenancyConfiguration(
 
 export async function requestDeleteTenant(http: HttpStart, tenants: string[]) {
   for (const tenant of tenants) {
-    await httpDelete(http, getResourceUrl(API_ENDPOINT_TENANTS, tenant));
+    await httpDelete({ http, url: getResourceUrl(API_ENDPOINT_TENANTS, tenant) });
   }
 }
 

--- a/public/utils/auth-info-utils.tsx
+++ b/public/utils/auth-info-utils.tsx
@@ -19,7 +19,7 @@ import { httpGet } from '../apps/configuration/utils/request-utils';
 import { AuthInfo } from '../types';
 
 export async function getAuthInfo(http: HttpStart) {
-  return await httpGet<AuthInfo>(http, API_ENDPOINT_AUTHINFO);
+  return await httpGet<AuthInfo>({ http, url: API_ENDPOINT_AUTHINFO });
 }
 
 export async function getCurrentUser(http: HttpStart) {

--- a/public/utils/dashboards-info-utils.tsx
+++ b/public/utils/dashboards-info-utils.tsx
@@ -17,11 +17,9 @@ import { HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_DASHBOARDSINFO } from '../../common';
 import { httpGet, httpGetWithIgnores } from '../apps/configuration/utils/request-utils';
 import { DashboardsInfo } from '../types';
-import { AccountInfo } from '../apps/account/types';
-import { API_ENDPOINT_ACCOUNT_INFO } from '../apps/account/constants';
 
 export async function getDashboardsInfo(http: HttpStart) {
-  return await httpGet<DashboardsInfo>(http, API_ENDPOINT_DASHBOARDSINFO);
+  return await httpGet<DashboardsInfo>({ http, url: API_ENDPOINT_DASHBOARDSINFO });
 }
 
 export async function getDashboardsInfoSafe(http: HttpStart): Promise<DashboardsInfo | undefined> {

--- a/public/utils/logout-utils.tsx
+++ b/public/utils/logout-utils.tsx
@@ -45,5 +45,5 @@ export function interceptError(logoutUrl: string, thisWindow: Window): any {
 }
 
 export async function fetchCurrentAuthType(http: HttpStart): Promise<any> {
-  return await httpGet(http, API_ENDPOINT_AUTHTYPE);
+  return await httpGet({ http, url: API_ENDPOINT_AUTHTYPE });
 }

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -72,13 +72,11 @@ describe('Multi-datasources enabled', () => {
 
   it('Checks Get Started Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
-    // Local cluster purge cache
-    cy.get('.panel-header-count"]').contains('6');
-    // Remote cluster purge cache
+    // Local cluster auth
+    cy.get('.container .panel-header-count').first().invoke('text').should('eq', '(6)');
+    // Remote cluster auth
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
     cy.contains('li.euiSelectableListItem', '9202').click();
-    cy.get('.panel-header-count"]').contains('2');
-    // Data source persisted across tabs
-    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
+    cy.get('.container .panel-header-count').first().invoke('text').should('eq', '(2)');
   });
 });

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -73,7 +73,7 @@ describe('Multi-datasources enabled', () => {
   it('Checks Get Started Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
     // Local cluster auth
-    cy.get('.container .panel-header-count').first().invoke('text').should('eq', '(6)');
+    cy.get('.panel-header-count').first().invoke('text').should('contain', '(6)');
     // Remote cluster auth
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
     cy.contains('li.euiSelectableListItem', '9202').click();

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -70,7 +70,7 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
   });
 
-  it('Checks Get Started Tab', () => {
+  it('Checks Auth Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
     // Local cluster auth
     cy.get('.panel-header-count').first().invoke('text').should('contain', '(6)');

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -77,6 +77,6 @@ describe('Multi-datasources enabled', () => {
     // Remote cluster auth
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
     cy.contains('li.euiSelectableListItem', '9202').click();
-    cy.get('.container .panel-header-count').first().invoke('text').should('eq', '(2)');
+    cy.get('.panel-header-count').first().invoke('text').should('contain', '(2)');
   });
 });

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -65,5 +65,20 @@ describe('Multi-datasources enabled', () => {
     cy.contains('li.euiSelectableListItem', '9202').click();
     cy.get('[data-test-subj="purge-cache"]').click();
     cy.get('.euiToastHeader__title').should('contain', 'successful for 9202');
+    cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
+    // Data source persisted across tabs
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
+  });
+
+  it('Checks Get Started Tab', () => {
+    cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
+    // Local cluster purge cache
+    cy.get('.panel-header-count"]').contains('6');
+    // Remote cluster purge cache
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
+    cy.contains('li.euiSelectableListItem', '9202').click();
+    cy.get('.panel-header-count"]').contains('2');
+    // Data source persisted across tabs
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
   });
 });

--- a/test/jest_integration/security_entity_api.test.ts
+++ b/test/jest_integration/security_entity_api.test.ts
@@ -509,7 +509,7 @@ describe('start OpenSearch Dashboards server multi datasources enabled', () => {
 
   it('Gets auth page correctly', async () => {
     const getAuthResponseWrongDataSource = await osdTestServer.request
-      .get(root, '/api/v1/configuration/securityconfiguration?dataSourceId=test')
+      .get(root, '/api/v1/configuration/securityconfig?dataSourceId=test')
       .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 
     // Getting auth info on a datasource that does not exist
@@ -519,14 +519,14 @@ describe('start OpenSearch Dashboards server multi datasources enabled', () => {
     );
 
     const getAuthResponseEmptyDataSource = await osdTestServer.request
-      .get(root, '/api/v1/configuration/securityconfiguration')
+      .get(root, '/api/v1/configuration/securityconfig?dataSourceId=')
       .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 
     // Getting auth info on an empty datasource calls local cluster
     expect(getAuthResponseEmptyDataSource.status).toEqual(200);
 
     const getAuthResponseRemoteDataSource = await osdTestServer.request
-      .get(root, `/api/v1/configuration/securityconfiguration?dataSourceId=${dataSourceId}`)
+      .get(root, `/api/v1/configuration/securityconfig?dataSourceId=${dataSourceId}`)
       .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 
     // Getting auth info on an empty datasource calls local cluster

--- a/test/jest_integration/security_entity_api.test.ts
+++ b/test/jest_integration/security_entity_api.test.ts
@@ -464,9 +464,8 @@ describe('start OpenSearch Dashboards server multi datasources enabled', () => {
 
   it('delete cache', async () => {
     const deleteCacheResponseWrongDataSource = await osdTestServer.request
-      .delete(root, '/api/v1/configuration/cache')
-      .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS)
-      .send({ dataSourceId: 'test' });
+      .delete(root, '/api/v1/configuration/cache?dataSourceId=test')
+      .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 
     // Calling clear cache on a datasource that does not exist
     expect(deleteCacheResponseWrongDataSource.status).not.toEqual(200);
@@ -476,8 +475,7 @@ describe('start OpenSearch Dashboards server multi datasources enabled', () => {
 
     const deleteCacheResponseEmptyDataSource = await osdTestServer.request
       .delete(root, '/api/v1/configuration/cache')
-      .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS)
-      .send({ dataSourceId: '' });
+      .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 
     // Calling clear cache on an empty datasource calls local cluster
     expect(deleteCacheResponseEmptyDataSource.status).toEqual(200);
@@ -501,9 +499,8 @@ describe('start OpenSearch Dashboards server multi datasources enabled', () => {
       });
 
     const deleteCacheResponseRemoteDataSource = await osdTestServer.request
-      .delete(root, '/api/v1/configuration/cache')
-      .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS)
-      .send({ dataSourceId: createDataSource.body.id });
+      .delete(root, `/api/v1/configuration/cache?dataSourceId=${createDataSource.body.id}`)
+      .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 
     // Calling clear cache on an empty datasource calls local cluster
     expect(deleteCacheResponseRemoteDataSource.status).toEqual(200);

--- a/test/jest_integration/security_entity_api.test.ts
+++ b/test/jest_integration/security_entity_api.test.ts
@@ -473,7 +473,7 @@ describe('start OpenSearch Dashboards server multi datasources enabled', () => {
           },
         },
       });
-      dataSourceId=createDataSource.body.id;
+    dataSourceId = createDataSource.body.id;
   });
 
   afterAll(async () => {
@@ -512,25 +512,24 @@ describe('start OpenSearch Dashboards server multi datasources enabled', () => {
       .get(root, '/api/v1/configuration/securityconfiguration?dataSourceId=test')
       .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 
-    // Calling clear cache on a datasource that does not exist
+    // Getting auth info on a datasource that does not exist
     expect(getAuthResponseWrongDataSource.status).not.toEqual(200);
     expect(getAuthResponseWrongDataSource.text).toContain(
       'Data Source Error: Saved object [data-source/test] not found'
     );
 
     const getAuthResponseEmptyDataSource = await osdTestServer.request
-    .get(root, '/api/v1/configuration/securityconfiguration')
+      .get(root, '/api/v1/configuration/securityconfiguration')
       .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 
-    // Calling clear cache on an empty datasource calls local cluster
+    // Getting auth info on an empty datasource calls local cluster
     expect(getAuthResponseEmptyDataSource.status).toEqual(200);
 
     const getAuthResponseRemoteDataSource = await osdTestServer.request
-    .get(root, `/api/v1/configuration/securityconfiguration?dataSourceId=${dataSourceId}`)
+      .get(root, `/api/v1/configuration/securityconfiguration?dataSourceId=${dataSourceId}`)
       .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 
-    // Calling clear cache on an empty datasource calls local cluster
+    // Getting auth info on an empty datasource calls local cluster
     expect(getAuthResponseRemoteDataSource.status).toEqual(200);
-
-  })
+  });
 });


### PR DESCRIPTION
### Description
Supports multi datasources for the "Authentication Tab". Lifts the state up to be managed/saved across Get Started and Authentication tabs. 

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?

https://github.com/opensearch-project/security-dashboards-plugin/assets/26328171/6dc676fb-52b9-4e1a-86c0-f96f5d0d24b7



### Issues Resolved
Fix: #1797, Fix: #1816 

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).