### PR TITLE
Add cluster:monitor/term to permissions dropdown

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -213,6 +213,7 @@ export const CLUSTER_PERMISSIONS: string[] = [
   'cluster:monitor/task/get',
   'cluster:monitor/tasks/list',
   'cluster:monitor/tasks/list*',
+  'cluster:monitor/term',
   'restapi:admin/actiongroups',
   'restapi:admin/allowlist',
   'restapi:admin/internalusers',


### PR DESCRIPTION
### Description

Add the `cluster:monitor/term` action introduced in https://github.com/opensearch-project/OpenSearch/pull/12252 to the permissions dropdown in security-dashboards-plugin.

### Category

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).