### PR TITLE
Add multi datasource support for the Users tab

### DIFF
--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -34,7 +34,7 @@ export async function fetchAccountInfoSafe(http: HttpStart): Promise<AccountInfo
 }
 
 export async function logout(http: HttpStart, logoutUrl?: string): Promise<void> {
-  await httpPost(http, API_AUTH_LOGOUT);
+  await httpPost({ http, url: API_AUTH_LOGOUT });
   setShouldShowTenantPopup(null);
   // Clear everything in the sessionStorage since they can contain sensitive information
   sessionStorage.clear();
@@ -70,8 +70,12 @@ export async function updateNewPassword(
   newPassword: string,
   currentPassword: string
 ): Promise<void> {
-  await httpPost(http, API_ENDPOINT_ACCOUNT_INFO, {
-    password: newPassword,
-    current_password: currentPassword,
+  await httpPost({
+    http,
+    url: API_ENDPOINT_ACCOUNT_INFO,
+    body: {
+      password: newPassword,
+      current_password: currentPassword,
+    },
   });
 }

--- a/public/apps/configuration/panels/auth-view/auth-view.tsx
+++ b/public/apps/configuration/panels/auth-view/auth-view.tsx
@@ -25,6 +25,7 @@ import { getSecurityConfig } from '../../utils/auth-view-utils';
 import { InstructionView } from './instruction-view';
 import { DataSourceContext } from '../../app-router';
 import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
+import { createDataSourceQuery } from '../../../../utils/datasource-utils';
 
 export function AuthView(props: AppDependencies) {
   const [authentication, setAuthentication] = React.useState([]);
@@ -36,9 +37,10 @@ export function AuthView(props: AppDependencies) {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const config = await getSecurityConfig(props.coreStart.http, {
-          dataSourceId: dataSource.id,
-        });
+        const config = await getSecurityConfig(
+          props.coreStart.http,
+          createDataSourceQuery(dataSource.id)
+        );
 
         setAuthentication(config.authc);
         setAuthorization(config.authz);

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -39,6 +39,7 @@ import { httpDelete } from '../utils/request-utils';
 import { createSuccessToast, createUnknownErrorToast, useToastState } from '../utils/toast-utils';
 import { SecurityPluginTopNavMenu } from '../top-nav-menu';
 import { DataSourceContext } from '../app-router';
+import { getClusterInfoIfEnabled, createDataSourceQuery } from '../../../utils/datasource-utils';
 
 const addBackendStep = {
   title: 'Add backends',
@@ -161,13 +162,6 @@ const setOfSteps = [
   },
 ];
 
-export function getClusterInfoIfEnabled(dataSourceEnabled: boolean, cluster: DataSourceOption) {
-  if (dataSourceEnabled) {
-    return `for ${cluster.label || 'Local cluster'}`;
-  }
-  return '';
-}
-
 export function GetStarted(props: AppDependencies) {
   const dataSourceEnabled = !!props.depsStart.dataSource?.dataSourceEnabled;
   const { dataSource, setDataSource } = useContext(DataSourceContext)!;
@@ -258,9 +252,7 @@ export function GetStarted(props: AppDependencies) {
                   await httpDelete({
                     http: props.coreStart.http,
                     url: API_ENDPOINT_CACHE,
-                    query: {
-                      dataSourceId: dataSource.id,
-                    },
+                    query: createDataSourceQuery(dataSource.id),
                   });
                   addToast(
                     createSuccessToast(

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -206,7 +206,13 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
           </EuiButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton id="submit" fill onClick={updateUserHandler} disabled={!isFormValid}>
+          <EuiButton
+            id="submit"
+            fill
+            onClick={updateUserHandler}
+            disabled={!isFormValid}
+            data-test-subj="submit-save-user"
+          >
             {props.action === 'edit' ? 'Save changes' : 'Create'}
           </EuiButton>
         </EuiFlexItem>

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -24,7 +24,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { BreadcrumbsPageDependencies } from '../../../types';
 import { InternalUserUpdate } from '../../types';
 import { ResourceType } from '../../../../../common';
@@ -47,6 +47,9 @@ import { NameRow } from '../../utils/name-row';
 import { DocLinks } from '../../constants';
 import { constructErrorMessageAndLog } from '../../../error-utils';
 import { BackendRolePanel } from './backend-role-panel';
+import { DataSourceContext } from '../../app-router';
+import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
+import { createDataSourceQuery } from '../../../../utils/datasource-utils';
 
 interface InternalUserEditDeps extends BreadcrumbsPageDependencies {
   action: 'create' | 'edit' | 'duplicate';
@@ -72,13 +75,18 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
   const [toasts, addToast, removeToast] = useToastState();
 
   const [isFormValid, setIsFormValid] = useState<boolean>(true);
+  const { dataSource, setDataSource } = useContext(DataSourceContext)!;
 
   React.useEffect(() => {
     const action = props.action;
     if (action === 'edit' || action === 'duplicate') {
       const fetchData = async () => {
         try {
-          const user = await getUserDetail(props.coreStart.http, props.sourceUserName);
+          const user = await getUserDetail(
+            props.coreStart.http,
+            props.sourceUserName,
+            createDataSourceQuery(dataSource.id)
+          );
           setAttributes(buildAttributeState(user.attributes));
           setBackendRoles(user.backend_roles);
           setUserName(generateResourceName(action, props.sourceUserName));
@@ -90,7 +98,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
 
       fetchData();
     }
-  }, [addToast, props.action, props.coreStart.http, props.sourceUserName]);
+  }, [addToast, props.action, props.coreStart.http, props.sourceUserName, dataSource.id]);
 
   const updateUserHandler = async () => {
     try {
@@ -117,7 +125,12 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
         updateObject.password = password;
       }
 
-      await updateUser(props.coreStart.http, userName, updateObject);
+      await updateUser(
+        props.coreStart.http,
+        userName,
+        updateObject,
+        createDataSourceQuery(dataSource.id)
+      );
 
       setCrossPageToast(buildUrl(ResourceType.users), {
         id: 'updateUserSucceeded',
@@ -135,6 +148,12 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
 
   return (
     <>
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={true}
+        setDataSource={setDataSource}
+        selectedDataSource={dataSource}
+      />
       {props.buildBreadcrumbs(TITLE_TEXT_DICT[props.action])}
       <EuiSpacer />
       <EuiPageHeader>

--- a/public/apps/configuration/panels/internal-user-edit/test/internal-user-edit.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/internal-user-edit.test.tsx
@@ -31,6 +31,10 @@ jest.mock('../../../utils/toast-utils', () => ({
   createUnknownErrorToast: jest.fn(),
   useToastState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()]),
 }));
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 
 describe('Internal user edit', () => {
   const sampleUsername = 'user1';
@@ -79,7 +83,9 @@ describe('Internal user edit', () => {
       />
     );
 
-    expect(getUserDetail).toBeCalledWith(mockCoreStart.http, sampleUsername);
+    expect(getUserDetail).toBeCalledWith(mockCoreStart.http, sampleUsername, {
+      dataSourceId: 'test',
+    });
   });
 
   it('should not submit if password is empty on creation', () => {

--- a/public/apps/configuration/panels/test/get-started.test.tsx
+++ b/public/apps/configuration/panels/test/get-started.test.tsx
@@ -175,11 +175,5 @@ describe('Get started (landing page)', () => {
       await button.props().onClick(); // Simulate button click
       expect(ToastUtils.createSuccessToast).toHaveBeenCalledTimes(1);
     });
-
-    it('Tests the GetClusterDescription helper function', () => {
-      expect(getClusterInfoIfEnabled(false, { id: 'blah', label: 'blah' })).toBe('');
-      expect(getClusterInfoIfEnabled(true, { id: '', label: '' })).toBe('for Local cluster');
-      expect(getClusterInfoIfEnabled(true, { id: 'test', label: 'test' })).toBe('for test');
-    });
   });
 });

--- a/public/apps/configuration/panels/test/user-list.test.tsx
+++ b/public/apps/configuration/panels/test/user-list.test.tsx
@@ -37,6 +37,10 @@ jest.mock('../../utils/context-menu', () => ({
     .fn()
     .mockImplementation((buttonText, buttonProps, children) => [children, jest.fn()]),
 }));
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 
 import { getAuthInfo } from '../../../../utils/auth-info-utils';
 import { buildHashUrl } from '../../utils/url-builder';

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -31,7 +31,7 @@ import {
   Query,
 } from '@elastic/eui';
 import { Dictionary, difference, isEmpty, map } from 'lodash';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { getAuthInfo } from '../../../utils/auth-info-utils';
 import { AppDependencies } from '../../types';
 import { API_ENDPOINT_INTERNALUSERS, DocLinks } from '../constants';
@@ -48,6 +48,9 @@ import {
 } from '../utils/internal-user-list-utils';
 import { showTableStatusMessage } from '../utils/loading-spinner-utils';
 import { buildHashUrl } from '../utils/url-builder';
+import { DataSourceContext } from '../app-router';
+import { SecurityPluginTopNavMenu } from '../top-nav-menu';
+import { createDataSourceQuery } from '../../../utils/datasource-utils';
 
 export function dictView(items: Dictionary<string>) {
   if (isEmpty(items)) {
@@ -103,12 +106,17 @@ export function UserList(props: AppDependencies) {
   const [currentUsername, setCurrentUsername] = useState('');
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState<Query | null>(null);
+  const { dataSource, setDataSource } = useContext(DataSourceContext)!;
 
   React.useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const userDataPromise = getUserList(props.coreStart.http, ResourceType.users);
+        const userDataPromise = getUserList(
+          props.coreStart.http,
+          ResourceType.users,
+          createDataSourceQuery(dataSource.id)
+        );
         setCurrentUsername((await getAuthInfo(props.coreStart.http)).user_name);
         setUserData(await userDataPromise);
       } catch (e) {
@@ -120,12 +128,16 @@ export function UserList(props: AppDependencies) {
     };
 
     fetchData();
-  }, [props.coreStart.http]);
+  }, [props.coreStart.http, dataSource.id]);
 
   const handleDelete = async () => {
     const usersToDelete: string[] = selection.map((r) => r.username);
     try {
-      await requestDeleteUsers(props.coreStart.http, usersToDelete);
+      await requestDeleteUsers(
+        props.coreStart.http,
+        usersToDelete,
+        createDataSourceQuery(dataSource.id)
+      );
       // Refresh from server (calling fetchData) does not work here, the server still return the users
       // that had been just deleted, probably because ES takes some time to sync to all nodes.
       // So here remove the selected users from local memory directly.
@@ -194,6 +206,12 @@ export function UserList(props: AppDependencies) {
 
   return (
     <>
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={false}
+        setDataSource={setDataSource}
+        selectedDataSource={dataSource}
+      />
       <EuiPageHeader>
         <EuiTitle size="l">
           <h1>Internal users</h1>

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -242,7 +242,11 @@ export function UserList(props: AppDependencies) {
             <EuiFlexGroup>
               <EuiFlexItem>{actionsMenu}</EuiFlexItem>
               <EuiFlexItem>
-                <EuiButton fill href={buildHashUrl(ResourceType.users, Action.create)}>
+                <EuiButton
+                  fill
+                  href={buildHashUrl(ResourceType.users, Action.create)}
+                  data-test-subj="create-user"
+                >
                   Create user account
                 </EuiButton>
               </EuiFlexItem>

--- a/public/apps/configuration/test/top-nav-menu.test.tsx
+++ b/public/apps/configuration/test/top-nav-menu.test.tsx
@@ -29,7 +29,7 @@ describe('SecurityPluginTopNavMenu', () => {
 
   const dataSourceManagementMock = {
     ui: {
-      DataSourceMenu: dataSourceMenuMock,
+      getDataSourceMenu: jest.fn().mockReturnValue(dataSourceMenuMock),
     },
   };
 

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -32,6 +32,7 @@ export const SecurityPluginTopNavMenu = (props: TopNavMenuProps) => {
     dataSourceManagement,
     setDataSource,
     selectedDataSource,
+    dataSourcePickerReadOnly,
   } = props;
   const { setHeaderActionMenu } = params;
   const DataSourceMenu = dataSourceManagement?.ui.DataSourceMenu;
@@ -45,6 +46,7 @@ export const SecurityPluginTopNavMenu = (props: TopNavMenuProps) => {
       setMenuMountPoint={setHeaderActionMenu}
       notifications={coreStart.notifications}
       dataSourceCallBackFunc={setDataSource}
+      disableDataSourceSelectable={dataSourcePickerReadOnly}
       // Single select for now
       selectedOption={[selectedDataSource]}
       hideLocalCluster={false}

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -49,7 +49,10 @@ export const SecurityPluginTopNavMenu = (props: TopNavMenuProps) => {
         showDataSourceSelectable: dataSourceEnabled,
         notifications: coreStart.notifications,
         activeOption: [selectedDataSource],
-        onSelectedDataSources: setDataSource,
+        onSelectedDataSources: (dataSources: DataSourceOption[]) => {
+          // single select for now
+          setDataSource(dataSources[0]);
+        },
       }}
     />
   ) : null;

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -14,7 +14,8 @@
  */
 
 import React from 'react';
-import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
+import { DataSourceSelectableConfig } from 'src/plugins/data_source_management/public';
+import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
 import { PLUGIN_NAME } from '../../../common';
 import { AppDependencies } from '../types';
 
@@ -35,7 +36,7 @@ export const SecurityPluginTopNavMenu = (props: TopNavMenuProps) => {
     dataSourcePickerReadOnly,
   } = props;
   const { setHeaderActionMenu } = params;
-  const DataSourceMenu = dataSourceManagement?.ui.getDataSourceMenu();
+  const DataSourceMenu = dataSourceManagement?.ui.getDataSourceMenu<DataSourceSelectableConfig>();
 
   const dataSourceEnabled = !!depsStart.dataSource?.dataSourceEnabled;
 
@@ -45,14 +46,13 @@ export const SecurityPluginTopNavMenu = (props: TopNavMenuProps) => {
       componentType={dataSourcePickerReadOnly ? 'DataSourceView' : 'DataSourceSelectable'}
       componentConfig={{
         savedObjects: coreStart.savedObjects.client,
-        appName: PLUGIN_NAME,
-        showDataSourceSelectable: dataSourceEnabled,
         notifications: coreStart.notifications,
         activeOption: [selectedDataSource],
-        onSelectedDataSources: (dataSources: DataSourceOption[]) => {
+        onSelectedDataSources: (dataSources) => {
           // single select for now
           setDataSource(dataSources[0]);
         },
+        fullWidth: true,
       }}
     />
   ) : null;

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -14,7 +14,6 @@
  */
 
 import React from 'react';
-import { DataSourceComponentType } from 'src/plugins/data_source_management/public';
 import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { PLUGIN_NAME } from '../../../common';
 import { AppDependencies } from '../types';
@@ -43,11 +42,7 @@ export const SecurityPluginTopNavMenu = (props: TopNavMenuProps) => {
   return dataSourceEnabled ? (
     <DataSourceMenu
       setMenuMountPoint={setHeaderActionMenu}
-      componentType={
-        dataSourcePickerReadOnly
-          ? DataSourceComponentType.DataSourceView
-          : DataSourceComponentType.DataSourceSelectable
-      }
+      componentType={dataSourcePickerReadOnly ? 'DataSourceView' : 'DataSourceSelectable'}
       componentConfig={{
         savedObjects: coreStart.savedObjects.client,
         appName: PLUGIN_NAME,

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -14,6 +14,7 @@
  */
 
 import React from 'react';
+import { DataSourceComponentType } from 'src/plugins/data_source_management/public';
 import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { PLUGIN_NAME } from '../../../common';
 import { AppDependencies } from '../types';
@@ -35,22 +36,26 @@ export const SecurityPluginTopNavMenu = (props: TopNavMenuProps) => {
     dataSourcePickerReadOnly,
   } = props;
   const { setHeaderActionMenu } = params;
-  const DataSourceMenu = dataSourceManagement?.ui.DataSourceMenu;
+  const DataSourceMenu = dataSourceManagement?.ui.getDataSourceMenu();
+
   const dataSourceEnabled = !!depsStart.dataSource?.dataSourceEnabled;
 
   return dataSourceEnabled ? (
     <DataSourceMenu
-      showDataSourceSelectable={dataSourceEnabled}
-      appName={PLUGIN_NAME}
-      savedObjects={coreStart.savedObjects.client}
       setMenuMountPoint={setHeaderActionMenu}
-      notifications={coreStart.notifications}
-      dataSourceCallBackFunc={setDataSource}
-      disableDataSourceSelectable={dataSourcePickerReadOnly}
-      // Single select for now
-      selectedOption={[selectedDataSource]}
-      hideLocalCluster={false}
-      fullWidth={false}
+      componentType={
+        dataSourcePickerReadOnly
+          ? DataSourceComponentType.DataSourceView
+          : DataSourceComponentType.DataSourceSelectable
+      }
+      componentConfig={{
+        savedObjects: coreStart.savedObjects.client,
+        appName: PLUGIN_NAME,
+        showDataSourceSelectable: dataSourceEnabled,
+        notifications: coreStart.notifications,
+        activeOption: [selectedDataSource],
+        onSelectedDataSources: setDataSource,
+      }}
     />
   ) : null;
 };

--- a/public/apps/configuration/utils/action-groups-utils.tsx
+++ b/public/apps/configuration/utils/action-groups-utils.tsx
@@ -93,7 +93,11 @@ export async function updateActionGroup(
   groupName: string,
   updateObject: ActionGroupUpdate
 ): Promise<ActionGroupUpdate> {
-  return await httpPost(http, getResourceUrl(API_ENDPOINT_ACTIONGROUPS, groupName), updateObject);
+  return await httpPost({
+    http,
+    url: getResourceUrl(API_ENDPOINT_ACTIONGROUPS, groupName),
+    body: updateObject,
+  });
 }
 
 export async function requestDeleteActionGroups(http: HttpStart, groups: string[]) {

--- a/public/apps/configuration/utils/audit-logging-utils.tsx
+++ b/public/apps/configuration/utils/audit-logging-utils.tsx
@@ -19,7 +19,7 @@ import { API_ENDPOINT_AUDITLOGGING, API_ENDPOINT_AUDITLOGGING_UPDATE } from '../
 import { httpGet, httpPost } from './request-utils';
 
 export async function updateAuditLogging(http: HttpStart, updateObject: AuditLoggingSettings) {
-  return await httpPost(http, API_ENDPOINT_AUDITLOGGING_UPDATE, updateObject);
+  return await httpPost({ http, url: API_ENDPOINT_AUDITLOGGING_UPDATE, body: updateObject });
 }
 
 export async function getAuditLogging(http: HttpStart): Promise<AuditLoggingSettings> {

--- a/public/apps/configuration/utils/internal-user-detail-utils.tsx
+++ b/public/apps/configuration/utils/internal-user-detail-utils.tsx
@@ -13,23 +13,34 @@
  *   permissions and limitations under the License.
  */
 
-import { HttpStart } from 'opensearch-dashboards/public';
+import { HttpFetchQuery, HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_INTERNALUSERS } from '../constants';
 import { InternalUser, InternalUserUpdate } from '../types';
 import { httpGet, httpPost } from './request-utils';
 import { getResourceUrl } from './resource-utils';
 
-export async function getUserDetail(http: HttpStart, username: string): Promise<InternalUser> {
+export async function getUserDetail(
+  http: HttpStart,
+  username: string,
+  query: HttpFetchQuery
+): Promise<InternalUser> {
   return await httpGet<InternalUser>({
     http,
     url: getResourceUrl(API_ENDPOINT_INTERNALUSERS, username),
+    query,
   });
 }
 
 export async function updateUser(
   http: HttpStart,
   username: string,
-  updateObject: InternalUserUpdate
+  updateObject: InternalUserUpdate,
+  query: HttpFetchQuery
 ): Promise<InternalUser> {
-  return await httpPost(http, getResourceUrl(API_ENDPOINT_INTERNALUSERS, username), updateObject);
+  return await httpPost({
+    http,
+    url: getResourceUrl(API_ENDPOINT_INTERNALUSERS, username),
+    body: updateObject,
+    query,
+  });
 }

--- a/public/apps/configuration/utils/internal-user-list-utils.tsx
+++ b/public/apps/configuration/utils/internal-user-list-utils.tsx
@@ -43,7 +43,7 @@ export async function requestDeleteUsers(http: HttpStart, users: string[], query
   }
 }
 
-async function getUserListRaw(
+export async function getUserListRaw(
   http: HttpStart,
   userType: string,
   query?: HttpFetchQuery

--- a/public/apps/configuration/utils/internal-user-list-utils.tsx
+++ b/public/apps/configuration/utils/internal-user-list-utils.tsx
@@ -14,7 +14,7 @@
  */
 
 import { map } from 'lodash';
-import { HttpStart } from '../../../../../../src/core/public';
+import { HttpFetchQuery, HttpStart } from '../../../../../../src/core/public';
 import {
   API_ENDPOINT_INTERNALACCOUNTS,
   API_ENDPOINT_INTERNALUSERS,
@@ -37,29 +37,31 @@ export function transformUserData(rawData: DataObject<InternalUser>): InternalUs
   }));
 }
 
-export async function requestDeleteUsers(http: HttpStart, users: string[]) {
+export async function requestDeleteUsers(http: HttpStart, users: string[], query: HttpFetchQuery) {
   for (const user of users) {
-    await httpDelete({ http, url: getResourceUrl(API_ENDPOINT_INTERNALUSERS, user) });
+    await httpDelete({ http, url: getResourceUrl(API_ENDPOINT_INTERNALUSERS, user), query });
   }
 }
 
 async function getUserListRaw(
   http: HttpStart,
-  userType: string
+  userType: string,
+  query?: HttpFetchQuery
 ): Promise<ObjectsMessage<InternalUser>> {
   let ENDPOINT = API_ENDPOINT_INTERNALACCOUNTS;
   if (userType === ResourceType.serviceAccounts) {
     ENDPOINT = API_ENDPOINT_SERVICEACCOUNTS;
   }
 
-  return await httpGet<ObjectsMessage<InternalUser>>({ http, url: ENDPOINT });
+  return await httpGet<ObjectsMessage<InternalUser>>({ http, url: ENDPOINT, query });
 }
 
 export async function getUserList(
   http: HttpStart,
-  userType: string
+  userType: string,
+  query?: HttpFetchQuery
 ): Promise<InternalUsersListing[]> {
-  const rawData = await getUserListRaw(http, userType);
+  const rawData = await getUserListRaw(http, userType, query);
   return transformUserData(rawData.data);
 }
 

--- a/public/apps/configuration/utils/request-utils.ts
+++ b/public/apps/configuration/utils/request-utils.ts
@@ -39,8 +39,9 @@ export async function httpGet<T>(params: RequestType): Promise<T> {
   return await request<T>(http.get, url, body, query);
 }
 
-export async function httpPost<T>(http: HttpStart, url: string, body?: object): Promise<T> {
-  return await request<T>(http.post, url, body);
+export async function httpPost<T>(params: RequestType): Promise<T> {
+  const { http, url, body, query } = params;
+  return await request<T>(http.post, url, body, query);
 }
 
 export async function httpPut<T>(http: HttpStart, url: string, body?: object): Promise<T> {

--- a/public/apps/configuration/utils/role-detail-utils.tsx
+++ b/public/apps/configuration/utils/role-detail-utils.tsx
@@ -24,5 +24,9 @@ export async function getRoleDetail(http: HttpStart, roleName: string): Promise<
 }
 
 export async function updateRole(http: HttpStart, roleName: string, updateObject: RoleUpdate) {
-  return await httpPost(http, getResourceUrl(API_ENDPOINT_ROLES, roleName), updateObject);
+  return await httpPost({
+    http,
+    url: getResourceUrl(API_ENDPOINT_ROLES, roleName),
+    body: updateObject,
+  });
 }

--- a/public/apps/configuration/utils/role-mapping-utils.tsx
+++ b/public/apps/configuration/utils/role-mapping-utils.tsx
@@ -57,5 +57,9 @@ export async function updateRoleMapping(
   roleName: string,
   updateObject: RoleMappingDetail
 ) {
-  return await httpPost(http, getResourceUrl(API_ENDPOINT_ROLESMAPPING, roleName), updateObject);
+  return await httpPost({
+    http,
+    url: getResourceUrl(API_ENDPOINT_ROLESMAPPING, roleName),
+    body: updateObject,
+  });
 }

--- a/public/apps/configuration/utils/tenancy-config_util.tsx
+++ b/public/apps/configuration/utils/tenancy-config_util.tsx
@@ -19,7 +19,7 @@ import { httpGet, httpPut, httpPost } from './request-utils';
 import { TenancyConfigSettings } from '../panels/tenancy-config/types';
 
 export async function updateTenancyConfig(http: HttpStart, updateObject: TenancyConfigSettings) {
-  return await httpPost(http, API_ENDPOINT_TENANCY_CONFIGS, updateObject);
+  return await httpPost({ http, url: API_ENDPOINT_TENANCY_CONFIGS, body: updateObject });
 }
 
 export async function getTenancyConfig(http: HttpStart): Promise<TenancyConfigSettings> {

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -97,7 +97,11 @@ export async function updateTenant(
   tenantName: string,
   updateObject: TenantUpdate
 ) {
-  return await httpPost(http, getResourceUrl(API_ENDPOINT_TENANTS, tenantName), updateObject);
+  return await httpPost({
+    http,
+    url: getResourceUrl(API_ENDPOINT_TENANTS, tenantName),
+    body: updateObject,
+  });
 }
 
 export async function updateTenancyConfiguration(
@@ -116,7 +120,7 @@ export async function requestDeleteTenant(http: HttpStart, tenants: string[]) {
 }
 
 export async function selectTenant(http: HttpStart, selectObject: TenantSelect): Promise<string> {
-  return await httpPost<string>(http, API_ENDPOINT_MULTITENANCY, selectObject);
+  return await httpPost<string>({ http, url: API_ENDPOINT_MULTITENANCY, body: selectObject });
 }
 
 export const RESOLVED_GLOBAL_TENANT = 'Global';

--- a/public/apps/configuration/utils/test/internal-user-list-utils.test.tsx
+++ b/public/apps/configuration/utils/test/internal-user-list-utils.test.tsx
@@ -13,7 +13,13 @@
  *   permissions and limitations under the License.
  */
 
-import { transformUserData } from '../internal-user-list-utils';
+import { fetchUserNameList, getUserList, transformUserData } from '../internal-user-list-utils';
+import { httpGet } from '../request-utils';
+import * as InternalUserListUtils from '../internal-user-list-utils';
+
+jest.mock('../../utils/request-utils', () => ({
+  httpGet: jest.fn().mockResolvedValue({ data: {} }),
+}));
 
 describe('Internal user list utils', () => {
   const userList = {
@@ -31,5 +37,103 @@ describe('Internal user list utils', () => {
       },
     ];
     expect(result).toEqual(expectedUserList);
+  });
+
+  it('getUserList calls httpGet with the correct parameters for internal users', async () => {
+    const httpMock = {}; // Mock HttpStart object
+    const userType = 'internalaccounts';
+    const query = { dataSourceId: 'test' };
+
+    // Mock the response data from httpGet
+    const mockRawData = {
+      data: {
+        // your mocked data here
+      },
+    };
+
+    // Mock the return value of getUserListRaw
+    jest.spyOn(InternalUserListUtils, 'getUserListRaw').mockResolvedValue(mockRawData);
+
+    // Call the function you want to test
+    const test = await getUserList(httpMock, userType, query);
+
+    // Assert that httpGet was called with the correct parameters
+    expect(httpGet).toHaveBeenCalledWith({
+      http: httpMock,
+      url: '/api/v1/configuration/internalaccounts',
+      query,
+    });
+    expect(test).toEqual([]);
+  });
+
+  it('getUserList calls httpGet with the correct parameters for service accounts', async () => {
+    const httpMock = {}; // Mock HttpStart object
+    const userType = 'serviceAccounts';
+    const query = { dataSourceId: 'test' };
+
+    // Mock the response data from httpGet
+    const mockRawData = {
+      data: {},
+    };
+
+    // Mock the return value of getUserListRaw
+    jest.spyOn(InternalUserListUtils, 'getUserListRaw').mockResolvedValue(mockRawData);
+
+    // Call the function you want to test
+    const test = await getUserList(httpMock, userType, query);
+
+    // Assert that httpGet was called with the correct parameters
+    expect(httpGet).toHaveBeenCalledWith({
+      http: httpMock,
+      url: '/api/v1/configuration/serviceaccounts',
+      query,
+    });
+    expect(test).toEqual([]);
+  });
+
+  it('fetchUserNameList calls httpGet with the correct parameters for service accounts', async () => {
+    const httpMock = {}; // Mock HttpStart object
+    const userType = 'serviceAccounts';
+
+    // Mock the response data from httpGet
+    const mockRawData = {
+      data: {},
+    };
+
+    // Mock the return value of getUserListRaw
+    jest.spyOn(InternalUserListUtils, 'getUserListRaw').mockResolvedValue(mockRawData);
+
+    // Call the function you want to test
+    const test = await fetchUserNameList(httpMock, userType);
+
+    // Assert that httpGet was called with the correct parameters
+    expect(httpGet).toHaveBeenCalledWith({
+      http: httpMock,
+      url: '/api/v1/configuration/serviceaccounts',
+    });
+    expect(test).toEqual([]);
+  });
+
+  it('fetchUserNameList calls httpGet with the correct parameters for internal users', async () => {
+    const httpMock = {}; // Mock HttpStart object
+    const userType = 'internalaccounts';
+
+    // Mock the response data from httpGet
+    const mockRawData = {
+      data: {},
+    };
+
+    // Mock the return value of getUserListRaw
+    jest.spyOn(InternalUserListUtils, 'getUserListRaw').mockResolvedValue(mockRawData);
+
+    // Call the function you want to test
+    const test = await fetchUserNameList(httpMock, userType);
+
+    // Assert that httpGet was called with the correct parameters
+    expect(httpGet).toHaveBeenCalledWith({
+      http: httpMock,
+      url: '/api/v1/configuration/internalaccounts',
+    });
+    expect(test).toEqual([]);
   });
 });

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -13,20 +13,15 @@
  *   permissions and limitations under the License.
  */
 
-import { HttpStart } from 'opensearch-dashboards/public';
-import { httpPost } from '../apps/configuration/utils/request-utils';
+import { DataSourceOption } from '../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 
-export async function validateCurrentPassword(
-  http: HttpStart,
-  userName: string,
-  currentPassword: string
-): Promise<void> {
-  await httpPost({
-    http,
-    url: '/auth/login',
-    body: {
-      username: userName,
-      password: currentPassword,
-    },
-  });
+export function createDataSourceQuery(dataSourceId: string) {
+  return { dataSourceId };
+}
+
+export function getClusterInfoIfEnabled(dataSourceEnabled: boolean, cluster: DataSourceOption) {
+  if (dataSourceEnabled) {
+    return `for ${cluster.label || 'Local cluster'}`;
+  }
+  return '';
 }

--- a/public/utils/test/datasource-utils.test.ts
+++ b/public/utils/test/datasource-utils.test.ts
@@ -1,0 +1,28 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { createDataSourceQuery, getClusterInfoIfEnabled } from '../datasource-utils';
+
+describe('Tests datasource utils', () => {
+  it('Tests the GetClusterDescription helper function', () => {
+    expect(getClusterInfoIfEnabled(false, { id: 'blah', label: 'blah' })).toBe('');
+    expect(getClusterInfoIfEnabled(true, { id: '', label: '' })).toBe('for Local cluster');
+    expect(getClusterInfoIfEnabled(true, { id: 'test', label: 'test' })).toBe('for test');
+  });
+
+  it('Tests the create DataSource query helper function', () => {
+    expect(createDataSourceQuery('test')).toStrictEqual({ dataSourceId: 'test' });
+  });
+});

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -257,7 +257,12 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
         if (request.params.resourceName === ResourceType.serviceAccounts.toLowerCase()) {
           esResp = await client.callAsCurrentUser('opensearch_security.listServiceAccounts');
         } else if (request.params.resourceName === 'internalaccounts') {
-          esResp = await client.callAsCurrentUser('opensearch_security.listInternalAccounts');
+          esResp = await wrapRouteWithDataSource(
+            dataSourceEnabled,
+            context,
+            request,
+            'opensearch_security.listInternalAccounts'
+          );
         } else {
           esResp = await wrapRouteWithDataSource(
             dataSourceEnabled,
@@ -359,6 +364,9 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
           resourceName: schema.string(),
           id: schema.string(),
         }),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (
@@ -366,13 +374,17 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.getResource', {
-          resourceName: request.params.resourceName,
-          id: request.params.id,
-        });
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.getResource',
+          {
+            resourceName: request.params.resourceName,
+            id: request.params.id,
+          }
+        );
         return response.ok({ body: esResp[request.params.id] });
       } catch (error) {
         return errorResponse(response, error);
@@ -393,6 +405,9 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
             minLength: 1,
           }),
         }),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (
@@ -400,13 +415,17 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.deleteResource', {
-          resourceName: request.params.resourceName,
-          id: request.params.id,
-        });
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.deleteResource',
+          {
+            resourceName: request.params.resourceName,
+            id: request.params.id,
+          }
+        );
         return response.ok({
           body: {
             message: esResp.message,
@@ -436,6 +455,9 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
           resourceName: schema.string(),
         }),
         body: schema.any(),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (
@@ -448,13 +470,17 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
       } catch (error) {
         return response.badRequest({ body: error });
       }
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.saveResourceWithoutId', {
-          resourceName: request.params.resourceName,
-          body: request.body,
-        });
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.saveResourceWithoutId',
+          {
+            resourceName: request.params.resourceName,
+            body: request.body,
+          }
+        );
         return response.ok({
           body: {
             message: esResp.message,
@@ -480,6 +506,9 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
           }),
         }),
         body: schema.any(),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (
@@ -492,14 +521,18 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
       } catch (error) {
         return response.badRequest({ body: error });
       }
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.saveResource', {
-          resourceName: request.params.resourceName,
-          id: request.params.id,
-          body: request.body,
-        });
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.saveResource',
+          {
+            resourceName: request.params.resourceName,
+            id: request.params.id,
+            body: request.body,
+          }
+        );
         return response.ok({
           body: {
             message: esResp.message,

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -85,7 +85,7 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
   });
 
-  it.skip('Checks Auth Tab', () => {
+  it('Checks Auth Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
     // Local cluster auth
     cy.get('.panel-header-count').first().invoke('text').should('contain', '(6)');
@@ -102,8 +102,10 @@ describe('Multi-datasources enabled', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/users');
     // Create an internal user in the remote cluster
     cy.contains('h3', 'Internal users');
+    cy.contains('a', 'logstash');
+    // TODO replace these with navigating to urls that get read to determine datasource, since these are flaky
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
-    cy.get('li.euiSelectableListItem[title="9202"]').should('be.visible').click();
+    cy.contains('li.euiSelectableListItem', '9202').click();
     cy.get('[data-test-subj="create-user"]').click();
     cy.get('[data-test-subj="name-text"]').focus().type('9202-user');
     cy.get('[data-test-subj="password"]').focus().type('myStrongPassword123!');

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -85,7 +85,7 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
   });
 
-  it('Checks Auth Tab', () => {
+  it.skip('Checks Auth Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
     // Local cluster auth
     cy.get('.panel-header-count').first().invoke('text').should('contain', '(6)');
@@ -103,7 +103,7 @@ describe('Multi-datasources enabled', () => {
     // Create an internal user in the remote cluster
     cy.contains('h3', 'Internal users');
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
-    cy.contains('li.euiSelectableListItem', '9202', { timeout: 5000 }).click();
+    cy.get('li.euiSelectableListItem[title="9202"]').should('be.visible').click();
     cy.get('[data-test-subj="create-user"]').click();
     cy.get('[data-test-subj="name-text"]').focus().type('9202-user');
     cy.get('[data-test-subj="password"]').focus().type('myStrongPassword123!');

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -37,10 +37,25 @@ const createDataSource = () => {
 };
 
 const deleteAllDataSources = () => {
-  cy.visit('http://localhost:5601/app/management/opensearch-dashboards/dataSources');
-  cy.get('[data-test-subj="checkboxSelectAll"]').click();
-  cy.get('[data-test-subj="deleteDataSourceConnections"]').click();
-  cy.get('[data-test-subj="confirmModalConfirmButton"]').click();
+  cy.request(
+    'GET',
+    `${Cypress.config(
+      'baseUrl'
+    )}/api/saved_objects/_find?fields=id&fields=description&fields=title&per_page=10000&type=data-source`
+  ).then((resp) => {
+    if (resp && resp.body && resp.body.saved_objects) {
+      resp.body.saved_objects.map(({ id }) => {
+        cy.request({
+          method: 'DELETE',
+          url: `${Cypress.config('baseUrl')}/api/saved_objects/data-source/${id}`,
+          body: { force: false },
+          headers: {
+            'osd-xsrf': true,
+          },
+        });
+      });
+    }
+  });
 };
 
 describe('Multi-datasources enabled', () => {
@@ -78,5 +93,29 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
     cy.contains('li.euiSelectableListItem', '9202').click();
     cy.get('.panel-header-count').first().invoke('text').should('contain', '(2)');
+    cy.visit('http://localhost:5601/app/security-dashboards-plugin#/users');
+    // Data source persisted across tabs
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
+  });
+
+  it('Checks Users Tab', () => {
+    cy.visit('http://localhost:5601/app/security-dashboards-plugin#/users');
+    // Create an internal user in the remote cluster
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
+    cy.contains('li.euiSelectableListItem', '9202').click();
+    cy.get('[data-test-subj="create-user"]').click();
+    cy.get('[data-test-subj="name-text"]').focus().type('9202');
+    cy.get('[data-test-subj="password"]').focus().type('myStrongPassword123!');
+    cy.get('[data-test-subj="re-enter-password"]').focus().type('myStrongPassword123!');
+    cy.get('[data-test-subj="submit-save-user"]').click();
+
+    // Internal user exists on the remote
+    cy.visit('http://localhost:5601/app/security-dashboards-plugin#/users');
+    cy.contains('.euiTableRowCell', '9202').should('exist');
+
+    // Internal user doesn't exist on local cluster
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
+    cy.contains('li.euiSelectableListItem', 'Local cluster').click();
+    cy.contains('.euiTableRowCell', '9202').should('exist');
   });
 });

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -70,7 +70,7 @@ describe('Multi-datasources enabled', () => {
     cy.clearLocalStorage();
   });
 
-  it.skip('Checks Get Started Tab', () => {
+  it('Checks Get Started Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/getstarted');
     // Local cluster purge cache
     cy.get('[data-test-subj="purge-cache"]').click();
@@ -85,7 +85,7 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
   });
 
-  it.skip('Checks Auth Tab', () => {
+  it('Checks Auth Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
     // Local cluster auth
     cy.get('.panel-header-count').first().invoke('text').should('contain', '(6)');
@@ -103,7 +103,7 @@ describe('Multi-datasources enabled', () => {
     // Create an internal user in the remote cluster
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
     // Increase timeout for this since it is immediately after page load
-    cy.contains('li.euiSelectableListItem', '9202', { timeout: 1000 }).click();
+    cy.contains('li.euiSelectableListItem', '9202', { timeout: 3000 }).click();
     cy.get('[data-test-subj="create-user"]').click();
     cy.get('[data-test-subj="name-text"]').focus().type('9202-user');
     cy.get('[data-test-subj="password"]').focus().type('myStrongPassword123!');

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -101,9 +101,9 @@ describe('Multi-datasources enabled', () => {
   it('Checks Users Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/users');
     // Create an internal user in the remote cluster
+    cy.contains('h3', 'Internal users');
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
-    // Increase timeout for this since it is immediately after page load
-    cy.contains('li.euiSelectableListItem', '9202', { timeout: 3000 }).click();
+    cy.contains('li.euiSelectableListItem', '9202').click();
     cy.get('[data-test-subj="create-user"]').click();
     cy.get('[data-test-subj="name-text"]').focus().type('9202-user');
     cy.get('[data-test-subj="password"]').focus().type('myStrongPassword123!');

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -70,7 +70,7 @@ describe('Multi-datasources enabled', () => {
     cy.clearLocalStorage();
   });
 
-  it('Checks Get Started Tab', () => {
+  it.skip('Checks Get Started Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/getstarted');
     // Local cluster purge cache
     cy.get('[data-test-subj="purge-cache"]').click();
@@ -85,7 +85,7 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
   });
 
-  it('Checks Auth Tab', () => {
+  it.skip('Checks Auth Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
     // Local cluster auth
     cy.get('.panel-header-count').first().invoke('text').should('contain', '(6)');
@@ -102,7 +102,8 @@ describe('Multi-datasources enabled', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/users');
     // Create an internal user in the remote cluster
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
-    cy.contains('li.euiSelectableListItem', '9202').click();
+    // Increase timeout for this since it is immediately after page load
+    cy.contains('li.euiSelectableListItem', '9202', { timeout: 1000 }).click();
     cy.get('[data-test-subj="create-user"]').click();
     cy.get('[data-test-subj="name-text"]').focus().type('9202-user');
     cy.get('[data-test-subj="password"]').focus().type('myStrongPassword123!');

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -85,7 +85,7 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
   });
 
-  it('Checks Auth Tab', () => {
+  it.skip('Checks Auth Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
     // Local cluster auth
     cy.get('.panel-header-count').first().invoke('text').should('contain', '(6)');
@@ -102,7 +102,7 @@ describe('Multi-datasources enabled', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/users');
     // Create an internal user in the remote cluster
     cy.contains('h3', 'Internal users');
-    cy.contains('a', 'logstash');
+    cy.contains('a', 'admin');
     // TODO replace these with navigating to urls that get read to determine datasource, since these are flaky
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
     cy.contains('li.euiSelectableListItem', '9202').click();
@@ -114,11 +114,11 @@ describe('Multi-datasources enabled', () => {
 
     // Internal user exists on the remote
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/users');
-    cy.contains('.euiTableRowCell', '9202-user').should('exist');
+    cy.get('[data-test-subj="checkboxSelectRow-9202-user"]').should('exist');
 
     // Internal user doesn't exist on local cluster
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
     cy.contains('li.euiSelectableListItem', 'Local cluster').click();
-    cy.contains('.euiTableRowCell', '9202-user').should('not.exist');
+    cy.get('[data-test-subj="checkboxSelectRow-9202-user"]').should('not.exist');
   });
 });

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -85,7 +85,7 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
   });
 
-  it.skip('Checks Auth Tab', () => {
+  it('Checks Auth Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
     // Local cluster auth
     cy.get('.panel-header-count').first().invoke('text').should('contain', '(6)');

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -114,7 +114,6 @@ describe('Multi-datasources enabled', () => {
     cy.contains('.euiTableRowCell', '9202').should('exist');
 
     // Internal user doesn't exist on local cluster
-    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
     cy.contains('li.euiSelectableListItem', 'Local cluster').click();
     cy.contains('.euiTableRowCell', '9202').should('exist');
   });

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -103,7 +103,7 @@ describe('Multi-datasources enabled', () => {
     // Create an internal user in the remote cluster
     cy.contains('h3', 'Internal users');
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
-    cy.contains('li.euiSelectableListItem', '9202').click();
+    cy.contains('li.euiSelectableListItem', '9202', { timeout: 5000 }).click();
     cy.get('[data-test-subj="create-user"]').click();
     cy.get('[data-test-subj="name-text"]').focus().type('9202-user');
     cy.get('[data-test-subj="password"]').focus().type('myStrongPassword123!');

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -85,7 +85,7 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').contains('9202');
   });
 
-  it('Checks Auth Tab', () => {
+  it.skip('Checks Auth Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auth');
     // Local cluster auth
     cy.get('.panel-header-count').first().invoke('text').should('contain', '(6)');
@@ -104,17 +104,18 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
     cy.contains('li.euiSelectableListItem', '9202').click();
     cy.get('[data-test-subj="create-user"]').click();
-    cy.get('[data-test-subj="name-text"]').focus().type('9202');
+    cy.get('[data-test-subj="name-text"]').focus().type('9202-user');
     cy.get('[data-test-subj="password"]').focus().type('myStrongPassword123!');
     cy.get('[data-test-subj="re-enter-password"]').focus().type('myStrongPassword123!');
     cy.get('[data-test-subj="submit-save-user"]').click();
 
     // Internal user exists on the remote
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/users');
-    cy.contains('.euiTableRowCell', '9202').should('exist');
+    cy.contains('.euiTableRowCell', '9202-user').should('exist');
 
     // Internal user doesn't exist on local cluster
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
     cy.contains('li.euiSelectableListItem', 'Local cluster').click();
-    cy.contains('.euiTableRowCell', '9202').should('exist');
+    cy.contains('.euiTableRowCell', '9202-user').should('not.exist');
   });
 });

--- a/test/helper/entity_operation.ts
+++ b/test/helper/entity_operation.ts
@@ -33,3 +33,27 @@ export async function getEntityAsAdmin(root: Root, entityType: string, entityId:
     .get(root, `/api/v1/configuration/${entityType}/${entityId}`)
     .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 }
+
+export async function createOrUpdateEntityAsAdminWithDataSource(
+  root: Root,
+  entityType: string,
+  entityId: string,
+  body: any,
+  dataSourceId: string
+) {
+  return await osdTestServer.request
+    .post(root, `/api/v1/configuration/${entityType}/${entityId}?dataSourceId=${dataSourceId}`)
+    .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS)
+    .send(body);
+}
+
+export async function getEntityAsAdminWithDataSource(
+  root: Root,
+  entityType: string,
+  entityId: string,
+  dataSourceId: string
+) {
+  return await osdTestServer.request
+    .get(root, `/api/v1/configuration/${entityType}/${entityId}?dataSourceId=${dataSourceId}`)
+    .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
+}


### PR DESCRIPTION
### Description
Supports multi datasources in the user tab, both for fetching user and for creating/deleting/editing users. 

### Category
New Feature

### Why these changes are required?
To support multi datasources in the users tab

### What is the old behavior before changes and new behavior after changes?

https://github.com/opensearch-project/security-dashboards-plugin/assets/26328171/d5878764-7058-42f6-a5cb-d65d675f07cb



### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).