### PR TITLE
Add husky to pre-lint any commits, remove unused imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
   },
   plugins: [
     'cypress',
+    "unused-imports"
   ],
   rules: {
     // "@osd/eslint/require-license-header": "off"
@@ -44,6 +45,9 @@ module.exports = {
     'cypress/assertion-before-screenshot': 'warn',
     'cypress/no-force': 'warn',
     'cypress/no-async-tests': 'error',
+    // Unused imports and variables rules
+    "no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "error",
   },
   overrides: [
     {

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn lint:es --fix

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "lint": "yarn run lint:es && yarn run lint:style",
     "pretest:jest_server": "node ./test/jest_integration/runIdpServer.js &",
     "test:jest_server": "node ./test/run_jest_tests.js --config ./test/jest.config.server.js",
-    "test:jest_ui": "node ./test/run_jest_tests.js --config ./test/jest.config.ui.js"
+    "test:jest_ui": "node ./test/run_jest_tests.js --config ./test/jest.config.ui.js",
+    "prepare": "husky install"
   },
   "devDependencies": {
     "@elastic/eslint-import-resolver-kibana": "link:../../packages/osd-eslint-import-resolver-opensearch-dashboards",
@@ -34,7 +35,9 @@
     "saml-idp": "^1.2.1",
     "selfsigned": "^2.0.1",
     "typescript": "4.0.2",
-    "eslint-plugin-cypress": "^2.8.1"
+    "eslint-plugin-cypress": "^2.8.1",
+    "eslint-plugin-unused-imports": "3.1.0",
+    "husky": "^8.0.0"
   },
   "dependencies": {
     "@hapi/cryptiles": "5.0.0",

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -40,7 +40,7 @@ import {
 } from '../configuration/utils/tenant-utils';
 import { fetchAccountInfo } from './utils';
 import { constructErrorMessageAndLog } from '../error-utils';
-import { getSavedTenant, setSavedTenant } from '../../utils/storage-utils';
+import { setSavedTenant } from '../../utils/storage-utils';
 import { getDashboardsInfo } from '../../utils/dashboards-info-utils';
 
 interface TenantSwitchPanelProps {

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -14,12 +14,7 @@
  */
 
 import { HttpStart } from 'opensearch-dashboards/public';
-import {
-  API_AUTH_LOGOUT,
-  LOGIN_PAGE_URI,
-  OPENID_AUTH_LOGOUT,
-  SAML_AUTH_LOGOUT,
-} from '../../../common';
+import { API_AUTH_LOGOUT, OPENID_AUTH_LOGOUT, SAML_AUTH_LOGOUT } from '../../../common';
 import { API_ENDPOINT_ACCOUNT_INFO } from './constants';
 import { AccountInfo } from './types';
 import { httpGet, httpGetWithIgnores, httpPost } from '../configuration/utils/request-utils';

--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -14,7 +14,7 @@
  */
 
 import { EuiBreadcrumb, EuiPage, EuiPageBody, EuiPageSideBar } from '@elastic/eui';
-import { flow, map, mapValues, partial } from 'lodash';
+import { flow, partial } from 'lodash';
 import React from 'react';
 import { HashRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
 import { AppDependencies } from '../types';

--- a/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
@@ -13,8 +13,8 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiFieldText, EuiFlexGroup, EuiFormRow } from '@elastic/eui';
-import { mount, shallow } from 'enzyme';
+import { EuiFieldText, EuiFlexGroup } from '@elastic/eui';
+import { shallow } from 'enzyme';
 import React from 'react';
 import {
   appendElementToArray,

--- a/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiButton, EuiFieldText } from '@elastic/eui';
+import { EuiButton } from '@elastic/eui';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { updateRole } from '../../../utils/role-detail-utils';
@@ -21,7 +21,7 @@ import { setCrossPageToast } from '../../../utils/storage-utils';
 import { fetchTenantNameList } from '../../../utils/tenant-utils';
 import { ClusterPermissionPanel } from '../cluster-permission-panel';
 import { IndexPermissionPanel } from '../index-permission-panel';
-import { getSuccessToastMessage, RoleEdit } from '../role-edit';
+import { RoleEdit } from '../role-edit';
 import { TenantPanel } from '../tenant-panel';
 
 jest.mock('../../../utils/role-detail-utils', () => ({

--- a/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
+++ b/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
@@ -23,7 +23,7 @@ import {
   EuiTitle,
   EuiGlobalToastList,
 } from '@elastic/eui';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { BreadcrumbsPageDependencies } from '../../../types';
 import { InternalUsersPanel } from './users-panel';
 import {

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import {
   EuiButton,

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import {
   EuiInMemoryTable,
   EuiLink,

--- a/public/apps/configuration/panels/service-account-list.tsx
+++ b/public/apps/configuration/panels/service-account-list.tsx
@@ -29,7 +29,7 @@ import {
   EuiTitle,
   Query,
 } from '@elastic/eui';
-import { Dictionary, difference, isEmpty, map } from 'lodash';
+import { Dictionary, isEmpty, map } from 'lodash';
 import React, { useState } from 'react';
 import { getAuthInfo } from '../../../utils/auth-info-utils';
 import { AppDependencies } from '../../types';

--- a/public/apps/configuration/panels/tenant-list/manage_tab.tsx
+++ b/public/apps/configuration/panels/tenant-list/manage_tab.tsx
@@ -68,7 +68,7 @@ import { useContextMenuState } from '../../utils/context-menu';
 import { generateResourceName } from '../../utils/resource-utils';
 import { DocLinks } from '../../constants';
 import { TenantList } from './tenant-list';
-import { getBreadcrumbs, Route_MAP } from '../../app-router';
+import { getBreadcrumbs } from '../../app-router';
 import { buildUrl } from '../../utils/url-builder';
 import { CrossPageToast } from '../../cross-page-toast';
 import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -23,12 +23,11 @@ import {
   EuiButton,
 } from '@elastic/eui';
 import { Route } from 'react-router-dom';
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo } from 'react';
 import { ManageTab } from './manage_tab';
 import { ConfigureTab1 } from './configure_tab1';
 import { AppDependencies } from '../../../types';
 import { ExternalLink } from '../../utils/display-utils';
-import { displayBoolean } from '../../utils/display-utils';
 import { DocLinks } from '../../constants';
 import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
 import { TenantInstructionView } from './tenant-instruction-view';

--- a/public/apps/configuration/utils/tenancy-config_util.tsx
+++ b/public/apps/configuration/utils/tenancy-config_util.tsx
@@ -15,7 +15,7 @@
 
 import { HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_TENANCY_CONFIGS } from '../constants';
-import { httpGet, httpPut, httpPost } from './request-utils';
+import { httpGet, httpPost } from './request-utils';
 import { TenancyConfigSettings } from '../panels/tenancy-config/types';
 
 export async function updateTenancyConfig(http: HttpStart, updateObject: TenancyConfigSettings) {

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -39,7 +39,6 @@ import {
 import { httpDelete, httpGet, httpPost, httpPut } from './request-utils';
 import { getResourceUrl } from './resource-utils';
 import {
-  API_ENDPOINT_DASHBOARDSINFO,
   DEFAULT_TENANT,
   GLOBAL_TENANT_RENDERING_TEXT,
   GLOBAL_TENANT_SYMBOL,
@@ -47,7 +46,6 @@ import {
   isGlobalTenant,
   isRenderingPrivateTenant,
   PRIVATE_TENANT_RENDERING_TEXT,
-  SAML_AUTH_LOGIN,
 } from '../../../../common';
 import { TenancyConfigSettings } from '../panels/tenancy-config/types';
 

--- a/public/apps/configuration/utils/test/password-edit-panel.test.tsx
+++ b/public/apps/configuration/utils/test/password-edit-panel.test.tsx
@@ -16,7 +16,6 @@
 import { mount, shallow } from 'enzyme';
 import React from 'react';
 import { PasswordEditPanel } from '../password-edit-panel';
-import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
 
 const mockDashboardsInfo = {
   multitenancy_enabled: true,

--- a/public/apps/login/login-app.tsx
+++ b/public/apps/login/login-app.tsx
@@ -15,7 +15,7 @@
 
 import './_index.scss';
 // @ts-ignore : Component not used
-import React, { Component } from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
 import { AppMountParameters, CoreStart } from '../../../../../src/core/public';
 import { LoginPage } from './login-page';

--- a/public/utils/dashboards-info-utils.tsx
+++ b/public/utils/dashboards-info-utils.tsx
@@ -17,8 +17,6 @@ import { HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_DASHBOARDSINFO } from '../../common';
 import { httpGet, httpGetWithIgnores } from '../apps/configuration/utils/request-utils';
 import { DashboardsInfo } from '../types';
-import { AccountInfo } from '../apps/account/types';
-import { API_ENDPOINT_ACCOUNT_INFO } from '../apps/account/constants';
 
 export async function getDashboardsInfo(http: HttpStart) {
   return await httpGet<DashboardsInfo>(http, API_ENDPOINT_DASHBOARDSINFO);

--- a/server/auth/types/jwt/jwt_auth.ts
+++ b/server/auth/types/jwt/jwt_auth.ts
@@ -13,7 +13,6 @@
  *   permissions and limitations under the License.
  */
 
-import { ParsedUrlQuery } from 'querystring';
 import {
   SessionStorageFactory,
   IRouter,

--- a/server/auth/types/jwt/jwt_helper.test.ts
+++ b/server/auth/types/jwt/jwt_helper.test.ts
@@ -388,5 +388,5 @@ describe('JWT Expiry Tests', () => {
     jwtAuth.buildAuthHeaderFromCookie.mockRestore();
   });
 
-  /* @typescript-eslint/no-var-requires */
+  /* eslint-enable @typescript-eslint/no-var-requires */
 });

--- a/server/auth/types/jwt/jwt_helper.test.ts
+++ b/server/auth/types/jwt/jwt_helper.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { getAuthenticationHandler } from '../../auth_handler_factory';
-import { JWT_DEFAULT_EXTRA_STORAGE_OPTIONS, JwtAuthentication } from './jwt_auth';
+import { JWT_DEFAULT_EXTRA_STORAGE_OPTIONS } from './jwt_auth';
 import {
   CoreSetup,
   ILegacyClusterClient,
@@ -215,7 +215,7 @@ describe('test jwt auth library', () => {
   });
 }); // re-import JWTAuth to change cookie splitter to a no-op
 
-/* eslint-disable no-shadow, @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-var-requires */
 describe('JWT Expiry Tests', () => {
   const setExtraAuthStorageMock = jest.fn();
   jest.resetModules();
@@ -388,5 +388,5 @@ describe('JWT Expiry Tests', () => {
     jwtAuth.buildAuthHeaderFromCookie.mockRestore();
   });
 
-  /* eslint-enable no-shadow, @typescript-eslint/no-var-requires */
+  /* @typescript-eslint/no-var-requires */
 });

--- a/server/auth/types/multiple/multi_auth.ts
+++ b/server/auth/types/multiple/multi_auth.ts
@@ -24,7 +24,7 @@ import {
 } from 'opensearch-dashboards/server';
 import { OpenSearchDashboardsResponse } from '../../../../../../src/core/server/http/router';
 import { SecurityPluginConfigType } from '../../..';
-import { AuthenticationType, IAuthenticationType } from '../authentication_type';
+import { AuthenticationType } from '../authentication_type';
 import { ANONYMOUS_AUTH_LOGIN, AuthType, LOGIN_PAGE_URI } from '../../../../common';
 import { composeNextUrlQueryParam } from '../../../utils/next_url';
 import { MultiAuthRoutes } from './routes';

--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -39,10 +39,9 @@ import {
 import { OpenIdAuthRoutes } from './routes';
 import { AuthenticationType } from '../authentication_type';
 import { callTokenEndpoint } from './helper';
-import { composeNextUrlQueryParam } from '../../../utils/next_url';
 import { getObjectProperties } from '../../../utils/object_properties_defined';
 import { getExpirationDate } from './helper';
-import { AuthType, OPENID_AUTH_LOGIN } from '../../../../common';
+import { AuthType } from '../../../../common';
 import {
   ExtraAuthStorageOptions,
   getExtraAuthStorageValue,

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -43,7 +43,6 @@ import {
   AUTH_GRANT_TYPE,
   AUTH_RESPONSE_TYPE,
   OPENID_AUTH_LOGOUT,
-  LOGIN_PAGE_URI,
 } from '../../../../common';
 
 import {

--- a/server/auth/types/proxy/proxy_auth.ts
+++ b/server/auth/types/proxy/proxy_auth.ts
@@ -30,7 +30,6 @@ import { SecurityPluginConfigType } from '../../..';
 import { SecuritySessionCookie } from '../../../session/security_cookie';
 import { ProxyAuthRoutes } from './routes';
 import { AuthenticationType } from '../authentication_type';
-import { isValidTenant } from '../../../multitenancy/tenant_resolver';
 
 export class ProxyAuthentication extends AuthenticationType {
   private static readonly XFF: string = 'x-forwarded-for';

--- a/server/backend/opensearch_security_client.ts
+++ b/server/backend/opensearch_security_client.ts
@@ -15,7 +15,6 @@
 
 import { ILegacyClusterClient, OpenSearchDashboardsRequest } from '../../../../src/core/server';
 import { User } from '../auth/user';
-import { getAuthInfo } from '../../public/utils/auth-info-utils';
 import { TenancyConfigSettings } from '../../public/apps/configuration/panels/tenancy-config/types';
 
 export class SecurityClient {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1729,6 +1729,18 @@ eslint-plugin-cypress@^2.8.1:
   dependencies:
     globals "^13.20.0"
 
+eslint-plugin-unused-imports@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-3.1.0.tgz#db015b569d3774e17a482388c95c17bd303bc602"
+  integrity sha512-9l1YFCzXKkw1qtAru1RWUtG2EVDZY0a0eChKXcL+EZ5jitG7qxdctu4RnvhOJHv4xfmUf7h+JJPINlVpGhZMrw==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -2442,6 +2454,11 @@ human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+
+husky@^8.0.0:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
 
 iconv-lite@0.4.24:
   version "0.4.24"


### PR DESCRIPTION
### Description
Adds a rule to lint any commits prior to pushing. This should fix cases where work is pushed up but not linted, failing CI. TODO: should we add running tests here? 

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?
Linting was not done automatically and developer cycles were needed to remember to manually run that command

### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]
Fix: https://github.com/opensearch-project/security-dashboards-plugin/issues/1805

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).