### PR TITLE
Add multi datasource support for the tenant and audit log tabs

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -149,15 +149,13 @@ export interface DataSourceContextType {
   setDataSource: React.Dispatch<React.SetStateAction<DataSourceOption>>;
 }
 
+export const LocalCluster = { label: 'Local cluster', id: '' };
+
 export const DataSourceContext = createContext<DataSourceContextType | null>(null);
 
 export function AppRouter(props: AppDependencies) {
   const setGlobalBreadcrumbs = flow(getBreadcrumbs, props.coreStart.chrome.setBreadcrumbs);
-  const [dataSource, setDataSource] = useState<DataSourceOption>({
-    id: '',
-    label: 'Local cluster',
-    checked: 'on',
-  });
+  const [dataSource, setDataSource] = useState<DataSourceOption>(LocalCluster);
 
   return (
     <DataSourceContext.Provider value={{ dataSource, setDataSource }}>

--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -37,13 +37,14 @@ import { useToastState } from '../../utils/toast-utils';
 import { setCrossPageToast } from '../../utils/storage-utils';
 import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
 import { DataSourceContext } from '../../app-router';
-import { createDataSourceQuery } from '../../../../utils/datasource-utils';
+import { createDataSourceQuery, getClusterInfoIfEnabled } from '../../../../utils/datasource-utils';
 
 interface AuditLoggingEditSettingProps extends AppDependencies {
   setting: 'general' | 'compliance';
 }
 
 export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
+  const dataSourceEnabled = !!props.depsStart.dataSource?.dataSourceEnabled;
   const [editConfig, setEditConfig] = React.useState<AuditLoggingSettings>({});
   const [toasts, addToast, removeToast] = useToastState();
   const [invalidSettings, setInvalidSettings] = React.useState<string[]>([]);
@@ -132,9 +133,13 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
       };
 
       if (props.setting === 'general') {
-        addSuccessToast('General settings saved');
+        addSuccessToast(
+          `General settings saved ${getClusterInfoIfEnabled(dataSourceEnabled, dataSource)}`
+        );
       } else {
-        addSuccessToast('Compliance settings saved');
+        addSuccessToast(
+          `Compliance settings saved ${getClusterInfoIfEnabled(dataSourceEnabled, dataSource)}`
+        );
       }
 
       window.location.href = buildHashUrl(ResourceType.auditLogging);
@@ -143,7 +148,11 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
         id: 'update-result',
         color: 'danger',
         iconType: 'alert',
-        title: 'Failed to update audit configuration due to ' + e?.message,
+        title:
+          `Failed to update audit configuration ${getClusterInfoIfEnabled(
+            dataSourceEnabled,
+            dataSource
+          )} due to ` + e?.message,
       };
 
       addToast(failureToast);

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -185,7 +185,7 @@ export function AuditLogging(props: AuditLoggingProps) {
         {statusPanel}
         <EuiSpacer />
 
-        <EuiPanel>
+        <EuiPanel data-test-subj="general-settings">
           <EuiFlexGroup>
             <EuiFlexItem>
               <EuiTitle>

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -28,7 +28,7 @@ import {
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
-import React from 'react';
+import React, { useContext } from 'react';
 import { FormattedMessage } from '@osd/i18n/react';
 import { AppDependencies } from '../../../types';
 import { ResourceType } from '../../../../../common';
@@ -43,6 +43,9 @@ import {
 import { AuditLoggingSettings } from './types';
 import { ViewSettingGroup } from './view-setting-group';
 import { DocLinks } from '../../constants';
+import { DataSourceContext } from '../../app-router';
+import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
+import { createDataSourceQuery } from '../../../../utils/datasource-utils';
 
 interface AuditLoggingProps extends AppDependencies {
   fromType: string;
@@ -134,13 +137,18 @@ export function renderComplianceSettings(config: AuditLoggingSettings) {
 
 export function AuditLogging(props: AuditLoggingProps) {
   const [configuration, setConfiguration] = React.useState<AuditLoggingSettings>({});
+  const { dataSource, setDataSource } = useContext(DataSourceContext)!;
 
   const onSwitchChange = async () => {
     try {
       const updatedConfiguration = { ...configuration };
       updatedConfiguration.enabled = !updatedConfiguration.enabled;
 
-      await updateAuditLogging(props.coreStart.http, updatedConfiguration);
+      await updateAuditLogging(
+        props.coreStart.http,
+        updatedConfiguration,
+        createDataSourceQuery(dataSource.id)
+      );
 
       setConfiguration(updatedConfiguration);
     } catch (e) {
@@ -151,7 +159,10 @@ export function AuditLogging(props: AuditLoggingProps) {
   React.useEffect(() => {
     const fetchData = async () => {
       try {
-        const auditLogging = await getAuditLogging(props.coreStart.http);
+        const auditLogging = await getAuditLogging(
+          props.coreStart.http,
+          createDataSourceQuery(dataSource.id)
+        );
         setConfiguration(auditLogging);
       } catch (e) {
         // TODO: switch to better error handling.
@@ -160,7 +171,7 @@ export function AuditLogging(props: AuditLoggingProps) {
     };
 
     fetchData();
-  }, [props.coreStart.http, props.fromType]);
+  }, [props.coreStart.http, props.fromType, dataSource.id]);
 
   const statusPanel = renderStatusPanel(onSwitchChange, configuration.enabled || false);
 
@@ -226,5 +237,15 @@ export function AuditLogging(props: AuditLoggingProps) {
     );
   }
 
-  return <div className="panel-restrict-width">{content}</div>;
+  return (
+    <div className="panel-restrict-width">
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={false}
+        setDataSource={setDataSource}
+        selectedDataSource={dataSource}
+      />
+      {content}
+    </div>
+  );
 }

--- a/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
+++ b/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
@@ -336,7 +336,9 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
     </EuiForm>
   </EuiPanel>
   <EuiSpacer />
-  <EuiPanel>
+  <EuiPanel
+    data-test-subj="general-settings"
+  >
     <EuiFlexGroup>
       <EuiFlexItem>
         <EuiTitle>

--- a/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
+++ b/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
@@ -241,6 +241,21 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
 <div
   className="panel-restrict-width"
 >
+  <SecurityPluginTopNavMenu
+    coreStart={
+      Object {
+        "http": 1,
+      }
+    }
+    dataSourcePickerReadOnly={false}
+    navigation={Object {}}
+    selectedDataSource={
+      Object {
+        "id": "test",
+      }
+    }
+    setDataSource={[MockFunction]}
+  />
   <EuiPanel>
     <EuiTitle>
       <h3>

--- a/public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
@@ -21,6 +21,10 @@ import { buildHashUrl } from '../../../utils/url-builder';
 import { ResourceType } from '../../../../../../common';
 
 jest.mock('../../../utils/audit-logging-utils');
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 
 // eslint-disable-next-line
 const mockAuditLoggingUtils = require('../../../utils/audit-logging-utils');

--- a/public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
@@ -57,7 +57,7 @@ describe('Audit logs edit', () => {
     shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="general"
         params={{} as any}
         config={{} as any}
@@ -93,7 +93,7 @@ describe('Audit logs edit', () => {
     shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="compliance"
         params={{} as any}
         config={{} as any}
@@ -116,7 +116,7 @@ describe('Audit logs edit', () => {
     shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="compliance"
         params={{} as any}
         config={{} as any}
@@ -133,7 +133,7 @@ describe('Audit logs edit', () => {
     const component = shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="compliance"
         params={{} as any}
         config={{} as any}
@@ -147,7 +147,7 @@ describe('Audit logs edit', () => {
     const component = shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="compliance"
         params={{} as any}
         config={{} as any}
@@ -162,7 +162,7 @@ describe('Audit logs edit', () => {
     const component = shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="general"
         params={{} as any}
         config={{} as any}

--- a/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
@@ -25,6 +25,10 @@ import {
 } from '../constants';
 
 jest.mock('../../../utils/audit-logging-utils');
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 
 // eslint-disable-next-line
 const mockAuditLoggingUtils = require('../../../utils/audit-logging-utils');

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -23,7 +23,7 @@ import {
   EuiButton,
 } from '@elastic/eui';
 import { Route } from 'react-router-dom';
-import React, { useState, useMemo, useCallback } from 'react';
+import React, { useState, useMemo, useCallback, useContext } from 'react';
 import { ManageTab } from './manage_tab';
 import { ConfigureTab1 } from './configure_tab1';
 import { AppDependencies } from '../../../types';
@@ -32,6 +32,8 @@ import { displayBoolean } from '../../utils/display-utils';
 import { DocLinks } from '../../constants';
 import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
 import { TenantInstructionView } from './tenant-instruction-view';
+import { DataSourceContext, LocalCluster } from '../../app-router';
+import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
 
 interface TenantListProps extends AppDependencies {
   tabID: string;
@@ -134,6 +136,12 @@ export function TenantList(props: TenantListProps) {
 
   return (
     <>
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={true}
+        setDataSource={() => {}}
+        selectedDataSource={LocalCluster}
+      />
       <EuiPageHeader>
         <EuiTitle size="l">
           <h1>Multi-tenancy</h1>

--- a/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
+++ b/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
@@ -5,7 +5,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
   value={
     Object {
       "dataSource": Object {
-        "checked": "on",
         "id": "",
         "label": "Local cluster",
       },

--- a/public/apps/configuration/utils/audit-logging-utils.tsx
+++ b/public/apps/configuration/utils/audit-logging-utils.tsx
@@ -13,16 +13,23 @@
  *   permissions and limitations under the License.
  */
 
-import { HttpStart } from 'opensearch-dashboards/public';
+import { HttpFetchQuery, HttpStart } from 'opensearch-dashboards/public';
 import { AuditLoggingSettings } from '../panels/audit-logging/types';
 import { API_ENDPOINT_AUDITLOGGING, API_ENDPOINT_AUDITLOGGING_UPDATE } from '../constants';
 import { httpGet, httpPost } from './request-utils';
 
-export async function updateAuditLogging(http: HttpStart, updateObject: AuditLoggingSettings) {
-  return await httpPost({ http, url: API_ENDPOINT_AUDITLOGGING_UPDATE, body: updateObject });
+export async function updateAuditLogging(
+  http: HttpStart,
+  updateObject: AuditLoggingSettings,
+  query: HttpFetchQuery
+) {
+  return await httpPost({ http, url: API_ENDPOINT_AUDITLOGGING_UPDATE, body: updateObject, query });
 }
 
-export async function getAuditLogging(http: HttpStart): Promise<AuditLoggingSettings> {
-  const rawConfiguration = await httpGet<any>({ http, url: API_ENDPOINT_AUDITLOGGING });
+export async function getAuditLogging(
+  http: HttpStart,
+  query: HttpFetchQuery
+): Promise<AuditLoggingSettings> {
+  const rawConfiguration = await httpGet<any>({ http, url: API_ENDPOINT_AUDITLOGGING, query });
   return rawConfiguration?.config;
 }

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -193,6 +193,7 @@ describe('Multi-datasources enabled', () => {
 
   it('Checks Audit Logs Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auditLogging');
+    cy.get('[data-test-subj="general-settings"]').should('exist');
 
     // Select remote cluster
     cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -179,4 +179,45 @@ describe('Multi-datasources enabled', () => {
     );
     cy.get('[data-test-subj="checkboxSelectRow-test_permission_ag"]').should('not.exist');
   });
+
+  it('Checks Tenancy Tab', () => {
+    // Datasource is locked to local cluster for tenancy tab
+    cy.visit('http://localhost:5601/app/security-dashboards-plugin#/tenants');
+    cy.contains('h1', 'Multi-tenancy');
+    cy.get('[data-test-subj="dataSourceViewContextMenuHeaderLink"]').should(
+      'contain',
+      'Local cluster'
+    );
+    cy.get('[data-test-subj="dataSourceViewContextMenuHeaderLink"]').should('be.disabled');
+  });
+
+  it('Checks Audit Logs Tab', () => {
+    cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auditLogging');
+
+    // Select remote cluster
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
+    cy.get('[title="9202"]').click();
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').should(
+      'contain',
+      '9202'
+    );
+
+    cy.get('[data-test-subj="general-settings-configure"]').click();
+    cy.get('[data-test-subj="dataSourceViewContextMenuHeaderLink"]').should('contain', '9202');
+
+    cy.get('[data-test-subj="comboBoxInput"]').last().type('blah');
+    cy.get('[data-test-subj="save"]').click();
+
+    cy.get('[data-test-subj="general-settings"]').should('contain', 'blah');
+
+    // Select local cluster
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').click();
+    cy.get('[title="Local cluster"]').click();
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').should(
+      'contain',
+      'Local cluster'
+    );
+
+    cy.get('[data-test-subj="general-settings"]').should('not.contain', 'blah');
+  });
 });

--- a/test/jest_integration/constants.ts
+++ b/test/jest_integration/constants.ts
@@ -1,0 +1,74 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+export const testAuditLogDisabledSettings = {
+  enabled: false,
+  audit: {
+    enable_rest: false,
+    disabled_rest_categories: ['FAILED_LOGIN', 'AUTHENTICATED'],
+    enable_transport: true,
+    disabled_transport_categories: ['GRANTED_PRIVILEGES'],
+    resolve_bulk_requests: true,
+    log_request_body: false,
+    resolve_indices: true,
+    exclude_sensitive_headers: true,
+    ignore_users: ['admin'],
+    ignore_requests: ['SearchRequest', 'indices:data/read/*'],
+  },
+  compliance: {
+    enabled: true,
+    internal_config: false,
+    external_config: false,
+    read_metadata_only: false,
+    read_watched_fields: {
+      indexName1: ['field1', 'fields-*'],
+    },
+    read_ignore_users: ['opensearchdashboardsserver', 'operator/*'],
+    write_metadata_only: false,
+    write_log_diffs: false,
+    write_watched_indices: ['indexName2', 'indexPatterns-*'],
+    write_ignore_users: ['admin'],
+  },
+};
+
+export const testAuditLogEnabledSettings = {
+  enabled: true,
+  audit: {
+    enable_rest: false,
+    disabled_rest_categories: ['FAILED_LOGIN', 'AUTHENTICATED'],
+    enable_transport: true,
+    disabled_transport_categories: ['GRANTED_PRIVILEGES'],
+    resolve_bulk_requests: true,
+    log_request_body: false,
+    resolve_indices: true,
+    exclude_sensitive_headers: true,
+    ignore_users: ['admin'],
+    ignore_requests: ['SearchRequest', 'indices:data/read/*'],
+  },
+  compliance: {
+    enabled: true,
+    internal_config: false,
+    external_config: false,
+    read_metadata_only: false,
+    read_watched_fields: {
+      indexName1: ['field1', 'fields-*'],
+    },
+    read_ignore_users: ['opensearchdashboardsserver', 'operator/*'],
+    write_metadata_only: false,
+    write_log_diffs: false,
+    write_watched_indices: ['indexName2', 'indexPatterns-*'],
+    write_ignore_users: ['admin'],
+  },
+};


### PR DESCRIPTION
### Description
This PR adds multi datasource support for the tenancy and audit logging tabs. 

### Category
Feature

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?

https://github.com/opensearch-project/security-dashboards-plugin/assets/26328171/fb296a44-9745-4d72-9488-c881da6f1865



### Issues Resolved
Resolves: https://github.com/opensearch-project/security-dashboards-plugin/issues/1800
Resolves: https://github.com/opensearch-project/security-dashboards-plugin/issues/1801

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).