### PR TITLE
Support multi datasources on service accounts page

### DIFF
--- a/public/apps/configuration/panels/service-account-list.tsx
+++ b/public/apps/configuration/panels/service-account-list.tsx
@@ -161,7 +161,7 @@ export function ServiceAccountList(props: AppDependencies) {
 
   return (
     <>
-    <SecurityPluginTopNavMenu
+      <SecurityPluginTopNavMenu
         {...props}
         dataSourcePickerReadOnly={true}
         setDataSource={() => {}}

--- a/public/apps/configuration/panels/service-account-list.tsx
+++ b/public/apps/configuration/panels/service-account-list.tsx
@@ -42,6 +42,8 @@ import { ExternalLink, tableItemsUIProps, truncatedListView } from '../utils/dis
 import { getUserList, InternalUsersListing } from '../utils/internal-user-list-utils';
 import { showTableStatusMessage } from '../utils/loading-spinner-utils';
 import { buildHashUrl } from '../utils/url-builder';
+import { LocalCluster } from '../app-router';
+import { SecurityPluginTopNavMenu } from '../top-nav-menu';
 
 export function dictView(items: Dictionary<string>) {
   if (isEmpty(items)) {
@@ -159,6 +161,12 @@ export function ServiceAccountList(props: AppDependencies) {
 
   return (
     <>
+    <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={true}
+        setDataSource={() => {}}
+        selectedDataSource={LocalCluster}
+      />
       <EuiPageHeader>
         <EuiTitle size="l">
           <h1>Service accounts</h1>

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -191,6 +191,17 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceViewContextMenuHeaderLink"]').should('be.disabled');
   });
 
+  it('Checks Service Accounts Tab', () => {
+    // Datasource is locked to local cluster for tenancy tab
+    cy.visit('http://localhost:5601/app/security-dashboards-plugin#/serviceAccounts');
+    cy.contains('h1', 'Multi-tenancy');
+    cy.get('[data-test-subj="dataSourceViewContextMenuHeaderLink"]').should(
+      'contain',
+      'Local cluster'
+    );
+    cy.get('[data-test-subj="dataSourceViewContextMenuHeaderLink"]').should('be.disabled');
+  });
+
   it('Checks Audit Logs Tab', () => {
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/auditLogging');
     cy.get('[data-test-subj="general-settings"]').should('exist');

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -192,9 +192,8 @@ describe('Multi-datasources enabled', () => {
   });
 
   it('Checks Service Accounts Tab', () => {
-    // Datasource is locked to local cluster for tenancy tab
+    // Datasource is locked to local cluster for service accounts tab
     cy.visit('http://localhost:5601/app/security-dashboards-plugin#/serviceAccounts');
-    cy.contains('h1', 'Multi-tenancy');
     cy.get('[data-test-subj="dataSourceViewContextMenuHeaderLink"]').should(
       'contain',
       'Local cluster'


### PR DESCRIPTION
### Description
Adds selector on service accounts tab

### Category
Enhancement

### Why these changes are required?
Support multi datasources in the service accounts tab

### What is the old behavior before changes and new behavior after changes?
Selector is introduced with read only behavior to the local cluster. Since this tab does not exist in 2.x line, I kept the changes minimal.

### Issues Resolved
#1799 

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).