### PR TITLE
Clear session storage on auto-logout & remove unused saml function

### DIFF
--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -14,7 +14,7 @@
  */
 
 import { HttpStart } from 'opensearch-dashboards/public';
-import { API_AUTH_LOGOUT, OPENID_AUTH_LOGOUT } from '../../../common';
+import { API_AUTH_LOGOUT } from '../../../common';
 import { setShouldShowTenantPopup } from '../../utils/storage-utils';
 import { httpGet, httpGetWithIgnores, httpPost } from '../configuration/utils/request-utils';
 import { API_ENDPOINT_ACCOUNT_INFO } from './constants';
@@ -38,13 +38,6 @@ export async function logout(http: HttpStart, logoutUrl?: string): Promise<void>
   const nextUrl = encodeURIComponent(basePath);
   window.location.href =
     logoutUrl || `${http.basePath.serverBasePath}/app/login?nextUrl=${nextUrl}`;
-}
-
-export async function openidLogout(http: HttpStart): Promise<void> {
-  // This will ensure tenancy is picked up from local storage in the next login.
-  setShouldShowTenantPopup(null);
-  sessionStorage.clear();
-  window.location.href = `${http.basePath.serverBasePath}${OPENID_AUTH_LOGOUT}`;
 }
 
 export async function externalLogout(http: HttpStart, logoutEndpoint: string): Promise<void> {

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -14,11 +14,11 @@
  */
 
 import { HttpStart } from 'opensearch-dashboards/public';
-import { API_AUTH_LOGOUT, OPENID_AUTH_LOGOUT, SAML_AUTH_LOGOUT } from '../../../common';
+import { API_AUTH_LOGOUT, OPENID_AUTH_LOGOUT } from '../../../common';
+import { setShouldShowTenantPopup } from '../../utils/storage-utils';
+import { httpGet, httpGetWithIgnores, httpPost } from '../configuration/utils/request-utils';
 import { API_ENDPOINT_ACCOUNT_INFO } from './constants';
 import { AccountInfo } from './types';
-import { httpGet, httpGetWithIgnores, httpPost } from '../configuration/utils/request-utils';
-import { setShouldShowTenantPopup } from '../../utils/storage-utils';
 
 export function fetchAccountInfo(http: HttpStart): Promise<AccountInfo> {
   return httpGet(http, API_ENDPOINT_ACCOUNT_INFO);
@@ -38,12 +38,6 @@ export async function logout(http: HttpStart, logoutUrl?: string): Promise<void>
   const nextUrl = encodeURIComponent(basePath);
   window.location.href =
     logoutUrl || `${http.basePath.serverBasePath}/app/login?nextUrl=${nextUrl}`;
-}
-
-export async function samlLogout(http: HttpStart): Promise<void> {
-  // This will ensure tenancy is picked up from local storage in the next login.
-  setShouldShowTenantPopup(null);
-  window.location.href = `${http.basePath.serverBasePath}${SAML_AUTH_LOGOUT}`;
 }
 
 export async function openidLogout(http: HttpStart): Promise<void> {

--- a/public/utils/logout-utils.tsx
+++ b/public/utils/logout-utils.tsx
@@ -13,19 +13,21 @@
  *   permissions and limitations under the License.
  */
 
-import { setShouldShowTenantPopup } from './storage-utils';
 import {
   HttpInterceptorResponseError,
   HttpStart,
   IHttpInterceptController,
 } from '../../../../src/core/public';
-import { CUSTOM_ERROR_PAGE_URI, LOGIN_PAGE_URI, API_ENDPOINT_AUTHTYPE } from '../../common';
+import { API_ENDPOINT_AUTHTYPE, CUSTOM_ERROR_PAGE_URI, LOGIN_PAGE_URI } from '../../common';
 import { httpGet } from '../apps/configuration/utils/request-utils';
+import { setShouldShowTenantPopup } from './storage-utils';
 
 export function interceptError(logoutUrl: string, thisWindow: Window): any {
   return (httpErrorResponse: HttpInterceptorResponseError, _: IHttpInterceptController) => {
     if (httpErrorResponse.response?.status === 401) {
       setShouldShowTenantPopup(null);
+      // Clear everything in the sessionStorage since they can contain sensitive information
+      sessionStorage.clear();
       if (
         !(
           thisWindow.location.pathname.toLowerCase().includes(LOGIN_PAGE_URI) ||


### PR DESCRIPTION
### Description
Clear session storage on auto-logout & remove unused saml function

### Category
Bug fix

### Why these changes are required?
We want to clear the Session storage on auto-logout since they can contain sensitive information. Today this functionality already exists in logout feature. 

### What is the old behavior before changes and new behavior after changes?
* Old Behaviour: Session storage is preserved even after auto-logout. 
* New Behaviour: Session storage is cleared after auto-logout. 

### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
Added unit tests to verify the clear session storage function is called in before landing the login page. 

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).