### PR TITLE
Update copy for tenancy tab

### DIFF
--- a/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
+++ b/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
@@ -328,7 +328,7 @@ export function ConfigureTab1(props: AppDependencies) {
         <EuiPageContentHeader>
           <EuiPageContentHeaderSection>
             <EuiTitle size="l">
-              <h3>Multi-tenancy</h3>
+              <h3>Dashboards multi-tenancy</h3>
             </EuiTitle>
             <EuiHorizontalRule />
 
@@ -360,7 +360,7 @@ export function ConfigureTab1(props: AppDependencies) {
         <EuiPageContentHeader>
           <EuiPageContentHeaderSection>
             <EuiTitle size="l">
-              <h3>Tenants</h3>
+              <h3>Dashboards tenants</h3>
             </EuiTitle>
             <EuiHorizontalRule />
             <EuiDescribedFormGroup
@@ -368,7 +368,7 @@ export function ConfigureTab1(props: AppDependencies) {
               description={
                 <p4>
                   {' '}
-                  Global tenant is shared amaong all Dashboards users and cannot be disabled.{' '}
+                  Global tenant is shared among all Dashboards users and cannot be disabled.{' '}
                 </p4>
               }
               className="described-form-group2"
@@ -407,7 +407,7 @@ export function ConfigureTab1(props: AppDependencies) {
         <EuiPageContentHeader>
           <EuiPageContentHeaderSection>
             <EuiTitle size="l">
-              <h3>Default tenant</h3>
+              <h3>Dashboards default tenant</h3>
             </EuiTitle>
             <EuiHorizontalRule />
             <EuiDescribedFormGroup

--- a/public/apps/configuration/panels/tenant-list/manage_tab.tsx
+++ b/public/apps/configuration/panels/tenant-list/manage_tab.tsx
@@ -487,7 +487,7 @@ export function ManageTab(props: AppDependencies) {
           <EuiPageContentHeaderSection>
             <EuiTitle size="s">
               <h3>
-                Tenants
+                Dashboards tenants
                 <span className="panel-header-count">
                   {' '}
                   ({Query.execute(query || '', tenantData).length})

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -135,7 +135,7 @@ export function TenantList(props: TenantListProps) {
     <>
       <EuiPageHeader>
         <EuiTitle size="l">
-          <h1>Multi-tenancy</h1>
+          <h1>Dashboards multi-tenancy</h1>
         </EuiTitle>
       </EuiPageHeader>
       <EuiText size="s" color="subdued" grow={true} textAlign={'left'}>

--- a/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
+++ b/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Tenant list Action menu click Duplicate click 1`] = `
           size="s"
         >
           <h3>
-            Tenants
+            Dashboards tenants
             <span
               className="panel-header-count"
             >
@@ -198,7 +198,7 @@ exports[`Tenant list Action menu click Edit click 1`] = `
           size="s"
         >
           <h3>
-            Tenants
+            Dashboards tenants
             <span
               className="panel-header-count"
             >


### PR DESCRIPTION
### Description
Updates copy on the tenancy tab to be clear that it is talking about a front end only concept of tenancy. It can get confusing since the security plugin stores tenants as backend objects, but with multi datasource changes coming, we want to clear up that this tab is only talking about the frontend concept (locked to the local instance of dashboards).

### Category
Enhancement

### Why these changes are required?
Fix: #1878 

### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
Fix: #1878 

### Testing
Copy changes - no testing needed - update snapshots

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).