### PR TITLE
Bump jose from 4.11.2 to 5.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "cypress": "^13.6.0",
     "cypress-mochawesome-reporter": "^3.3.0",
     "gulp-rename": "2.0.0",
-    "jose": "^4.11.2",
+    "jose": "^5.2.4",
     "saml-idp": "^1.2.1",
     "selfsigned": "^2.0.1",
     "typescript": "4.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2811,10 +2811,10 @@ isstream@~0.1.2:
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
   integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
-jose@^4.11.2:
-  version "4.15.4"
-  resolved "https://registry.yarnpkg.com/jose/-/jose-4.15.4.tgz#02a9a763803e3872cf55f29ecef0dfdcc218cc03"
-  integrity sha512-W+oqK4H+r5sITxfxpSU+MMdr/YSWGvgZMQDIsNoBDGGy4i7GBPTtvFKibQzW06n3U3TqHjhvBJsirShsEJ6eeQ==
+jose@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-5.2.4.tgz#c0d296caeeed0b8444a8b8c3b68403d61aa4ed72"
+  integrity sha512-6ScbIk2WWCeXkmzF6bRPmEuaqy1m8SbsRFMa/FLrSCkGIhj8OLVG/IH+XHVmNMx/KUo8cVWEE6oKR4dJ+S0Rkg==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"


### PR DESCRIPTION
### Description

Bump jose from 4.11.2 to 5.2.4

Addresses [CVE-2024-28176](https://nvd.nist.gov/vuln/detail/CVE-2024-28176)

### Category

Maintenance

### Check List
- [X] New functionality includes testing
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).