### PR TITLE
[Backport 2.x] Adds Multiple Datasources Support for Security Dashboards Plugin (#1888)

### DIFF
--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: 'The version of security plugin that should be used, e.g "2.6.0.0"'
     required: true
 
+  download-location:
+    description: 'The location of where to download the plugin'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -22,26 +26,6 @@ runs:
         -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots/ \
         -Dartifact=org.opensearch.plugin:${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip \
         -Dtransitive=false \
-        -Ddest=${{ inputs.plugin-name }}.zip
+        -Ddest=${{ inputs.download-location }}.zip
       shell: bash
-
-    - name: Create Setup Script for Linux
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        cat > setup.sh <<'EOF'
-        chmod +x  ./opensearch-${{ inputs.opensearch-version}}-SNAPSHOT/plugins/${{ inputs.plugin-name }}/tools/install_demo_configuration.sh 
-        /bin/bash -c "yes | ./opensearch-${{ inputs.opensearch-version}}-SNAPSHOT/plugins/${{ inputs.plugin-name }}/tools/install_demo_configuration.sh -t"
-        echo "plugins.security.unsupported.restapi.allow_securityconfig_modification: true" >> ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/config/opensearch.yml
-        echo "cluster.routing.allocation.disk.threshold_enabled: false" >> ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT/config/opensearch.yml
-        EOF
-      shell: bash
-
-    - name: Create Setup Script for Windows
-      if: ${{ runner.os == 'Windows' }}
-      run: |
-        New-Item .\setup.bat -type file
-        Set-Content .\setup.bat -Value "powershell.exe -noexit -command `".\opensearch-${{ inputs.opensearch-version}}-SNAPSHOT\plugins\${{ inputs.plugin-name }}\tools\install_demo_configuration.bat -y -i -c -t`""
-        Add-Content -Path .\setup.bat -Value "echo plugins.security.unsupported.restapi.allow_securityconfig_modification: true >> .\opensearch-${{ inputs.opensearch-version}}-SNAPSHOT\config\opensearch.yml"
-        Add-Content -Path .\setup.bat -Value "echo cluster.routing.allocation.disk.threshold_enabled: false >> .\opensearch-${{ inputs.opensearch-version}}-SNAPSHOT\config\opensearch.yml"
-        Get-Content .\setup.bat
-      shell: pwsh
+      

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -34,6 +34,7 @@ runs:
         opensearch-version: ${{ env.OPENSEARCH_VERSION }}
         plugin-name: ${{ env.PLUGIN_NAME }}
         plugin-version: ${{ env.PLUGIN_VERSION }}
+        download-location: ${{ env.PLUGIN_NAME }}
     
     - name: Run Opensearch with A Single Plugin
       uses: derek-ho/start-opensearch@v2
@@ -62,7 +63,7 @@ runs:
       if: ${{ runner.os == 'Linux' }}
       run: |
         cd ./OpenSearch-Dashboards
-        nohup yarn start --no-base-path --no-watch | tee dashboard.log &
+        nohup yarn start --no-base-path --no-watch --csp.warnLegacyBrowsers=false | tee dashboard.log &
       shell: bash
 
     # Check if OSD is ready with a max timeout of 600 seconds
@@ -84,8 +85,11 @@ runs:
         done
       shell: bash
 
-    - name: Run Cypress
-      run : |
-        yarn add cypress --save-dev
-        eval ${{ inputs.yarn_command }}
-      shell: bash
+    - name: Run Cypress Tests with retry
+      uses: Wandalen/wretry.action@v3.3.0
+      with:
+        attempt_limit: 5
+        attempt_delay: 2000
+        command: |
+          yarn add cypress --save-dev
+          eval ${{ inputs.yarn_command }} 

--- a/.github/workflows/cypress-test-multidatasources-disabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-disabled-e2e.yml
@@ -1,0 +1,49 @@
+name: E2E multi datasources disabled workflow
+
+on: [ push, pull_request ]
+
+env:
+  OPENSEARCH_VERSION: '3.0.0'
+  CI: 1
+  # avoid warnings like "tput: No value for $TERM and no -T specified"
+  TERM: xterm
+  PLUGIN_NAME: opensearch-security
+  OPENSEARCH_INITIAL_ADMIN_PASSWORD: myStrongPassword123!
+  
+jobs:
+  tests:
+    name: Run Cypress multidatasources tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+
+      # Configure the Dashboard for multi datasources disabled (default)
+      - name: Create OpenSearch Dashboards Config
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          cat << 'EOT' > opensearch_dashboards_multidatasources.yml
+          server.host: "0.0.0.0"
+          opensearch.hosts: ["https://localhost:9200"]
+          opensearch.ssl.verificationMode: none
+          opensearch.username: "kibanaserver"
+          opensearch.password: "kibanaserver"
+          opensearch.requestHeadersWhitelist: [ authorization,securitytenant ]
+          opensearch_security.multitenancy.enabled: false
+          opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
+          opensearch_security.readonly_mode.roles: ["kibana_read_only"]
+          opensearch_security.cookie.secure: false
+          data_source.enabled: false
+          home.disableWelcomeScreen: true
+          EOT
+
+      - name: Run Cypress Tests
+        uses: ./.github/actions/run-cypress-tests
+        with:
+          dashboards_config_file: opensearch_dashboards_multidatasources.yml
+          yarn_command: 'yarn cypress:run --browser chrome --headless --env LOGIN_AS_ADMIN=true --spec "test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js"'

--- a/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
@@ -1,0 +1,109 @@
+name: E2E multi datasources enabled workflow
+
+on: [ push, pull_request ]
+
+env:
+  OPENSEARCH_VERSION: '3.0.0'
+  CI: 1
+  # avoid warnings like "tput: No value for $TERM and no -T specified"
+  TERM: xterm
+  PLUGIN_NAME: opensearch-security
+  OPENSEARCH_INITIAL_ADMIN_PASSWORD: myStrongPassword123!
+  
+jobs:
+  tests:
+    name: Run Cypress multidatasources tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+
+      - name: Set env
+        run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
+          plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
+          echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+        shell: bash
+
+      # Add Custom Configuration to differentiate between local and remote cluster
+      - name: Create Custom Configuration for Linux
+        if: ${{ runner.os == 'Linux'}}
+        run: |
+          echo "Creating new custom configuration"
+          cat << 'EOT' > config_custom.yml
+          ---
+          _meta:
+            type: "config"
+            config_version: 2
+          config:
+            dynamic:
+              http:
+                anonymous_auth_enabled: false
+              authc:
+                basic_internal_auth_domain:
+                  description: "Authenticate via HTTP Basic against internal users database"
+                  http_enabled: true
+                  transport_enabled: true
+                  order: 0
+                  http_authenticator:
+                    type: basic
+                    challenge: false
+                  authentication_backend:
+                    type: intern
+          EOT
+
+      - name: Download security plugin and create setup scripts
+        uses: ./.github/actions/download-plugin
+        with:
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          plugin-name: ${{ env.PLUGIN_NAME }}
+          plugin-version: ${{ env.PLUGIN_VERSION }}
+          download-location: ${{env.PLUGIN_NAME}}
+      
+      - name: Run Opensearch with A Single Plugin
+        uses: derek-ho/start-opensearch@v4
+        with:
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          plugins: "file:$(pwd)/opensearch-security.zip"
+          security-enabled: true
+          admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
+          security_config_file: config_custom.yml
+          port: 9202
+
+      - name: Check OpenSearch is running
+          # Verify that the server is operational
+        run: |
+          curl https://localhost:9202/_cat/plugins -v -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} -k
+        shell: bash
+
+      # Configure the Dashboard for multi datasources
+      - name: Create OpenSearch Dashboards Config
+        if: ${{ runner.os == 'Linux' }}
+        run: |
+          cat << 'EOT' > opensearch_dashboards_multidatasources.yml
+          server.host: "localhost"
+          opensearch.hosts: ["https://localhost:9200"]
+          opensearch.ssl.verificationMode: none
+          opensearch.username: "kibanaserver"
+          opensearch.password: "kibanaserver"
+          opensearch.requestHeadersWhitelist: [ authorization,securitytenant ]
+          opensearch_security.multitenancy.enabled: true
+          opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
+          opensearch_security.readonly_mode.roles: ["kibana_read_only"]
+          opensearch_security.cookie.secure: false
+          data_source.enabled: true
+          home.disableWelcomeScreen: true
+          data_source.ssl.verificationMode: none
+          EOT
+
+      - name: Run Cypress Tests
+        uses: ./.github/actions/run-cypress-tests
+        with:
+          dashboards_config_file: opensearch_dashboards_multidatasources.yml
+          yarn_command: 'yarn cypress:run --browser chrome --headless --env LOGIN_AS_ADMIN=true --spec "test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js"'

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -44,6 +44,7 @@ jobs:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugin-name: ${{ env.PLUGIN_NAME }}
           plugin-version: ${{ env.PLUGIN_VERSION }}
+          download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
         uses: derek-ho/start-opensearch@v2

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -44,6 +44,7 @@ jobs:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugin-name: ${{ env.PLUGIN_NAME }}
           plugin-version: ${{ env.PLUGIN_VERSION }}
+          download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
         uses: derek-ho/start-opensearch@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -36,12 +36,36 @@ jobs:
           echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash
 
-      - name: Download security plugin and create setup scripts
+      - name: Download security plugin and create setup scripts for remote cluster
         uses: ./.github/actions/download-plugin
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugin-name: ${{ env.PLUGIN_NAME }}
+          download-location: ${{env.PLUGIN_NAME}}-${{ env.OPENSEARCH_VERSION }}
           plugin-version: ${{ env.PLUGIN_VERSION }}
+
+      - name: Download security plugin and create setup scripts for local cluster
+        uses: ./.github/actions/download-plugin
+        with:
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          plugin-name: ${{ env.PLUGIN_NAME }}
+          download-location: ${{env.PLUGIN_NAME}}
+          plugin-version: ${{ env.PLUGIN_VERSION }}
+      
+      - name: Run Opensearch with A Single Plugin Remote Cluster
+        uses: derek-ho/start-opensearch@v4
+        with:
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          plugins: "file:$(pwd)/opensearch-security-${{ env.OPENSEARCH_VERSION }}.zip"
+          security-enabled: true
+          admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
+          security_config_file: ${{ inputs.security_config_file }}
+          port: 9202
+
+      - name: Check OpenSearch remote is running
+        run: |
+          curl https://localhost:9202/_cat/plugins -v -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} -k
+        shell: bash
 
       - name: Run Opensearch with security
         uses: derek-ho/start-opensearch@v2

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -16,8 +16,6 @@ jobs:
       matrix:
         os: [ ubuntu-latest , windows-latest ]
     runs-on: ${{ matrix.os }}
-    env:
-      OPENSEARCH_INITIAL_ADMIN_PASSWORD: admin
 
     steps:
       - name: Checkout Branch

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -36,6 +36,7 @@ jobs:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugin-name: ${{ env.PLUGIN_NAME }}
           plugin-version: ${{ env.PLUGIN_VERSION }}
+          download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
         uses: derek-ho/start-opensearch@v2

--- a/common/index.ts
+++ b/common/index.ts
@@ -56,6 +56,8 @@ export const MAX_INTEGER = 2147483647;
 export const MAX_LENGTH_OF_COOKIE_BYTES = 4000;
 export const ESTIMATED_IRON_COOKIE_OVERHEAD = 1.5;
 
+export const LOCAL_CLUSTER_ID = '';
+
 export enum AuthType {
   BASIC = 'basicauth',
   OPEN_ID = 'openid',

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -31,5 +31,9 @@ module.exports = defineConfig({
     openSearchUrl: 'https://localhost:9200',
     adminUserName: 'admin',
     adminPassword: 'myStrongPassword123!',
+    externalDataSourceAdminUserName: 'admin',
+    externalDataSourceAdminPassword: 'myStrongPassword123!',
+    externalDataSourceLabel: '9202',
+    externalDataSourceEndpoint: 'https://localhost:9202'
   },
 });

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -10,7 +10,9 @@
     "savedObjectsManagement"
   ],
   "optionalPlugins": [
-    "managementOverview"
+    "managementOverview",
+    "dataSource",
+    "dataSourceManagement"
   ],
   "server": true,
   "ui": true

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -16,20 +16,30 @@
 import { HttpStart } from 'opensearch-dashboards/public';
 import { API_AUTH_LOGOUT } from '../../../common';
 import { setShouldShowTenantPopup } from '../../utils/storage-utils';
-import { httpGet, httpGetWithIgnores, httpPost } from '../configuration/utils/request-utils';
 import { API_ENDPOINT_ACCOUNT_INFO } from './constants';
 import { AccountInfo } from './types';
+import { createLocalClusterRequestContext } from '../configuration/utils/request-utils';
 
 export function fetchAccountInfo(http: HttpStart): Promise<AccountInfo> {
-  return httpGet(http, API_ENDPOINT_ACCOUNT_INFO);
+  return createLocalClusterRequestContext().httpGet({
+    http,
+    url: API_ENDPOINT_ACCOUNT_INFO,
+  });
 }
 
 export async function fetchAccountInfoSafe(http: HttpStart): Promise<AccountInfo | undefined> {
-  return httpGetWithIgnores<AccountInfo>(http, API_ENDPOINT_ACCOUNT_INFO, [401]);
+  return createLocalClusterRequestContext().httpGetWithIgnores<AccountInfo>({
+    http,
+    url: API_ENDPOINT_ACCOUNT_INFO,
+    ignores: [401],
+  });
 }
 
 export async function logout(http: HttpStart, logoutUrl?: string): Promise<void> {
-  await httpPost(http, API_AUTH_LOGOUT);
+  await createLocalClusterRequestContext().httpPost({
+    http,
+    url: API_AUTH_LOGOUT,
+  });
   setShouldShowTenantPopup(null);
   // Clear everything in the sessionStorage since they can contain sensitive information
   sessionStorage.clear();
@@ -52,8 +62,12 @@ export async function updateNewPassword(
   newPassword: string,
   currentPassword: string
 ): Promise<void> {
-  await httpPost(http, API_ENDPOINT_ACCOUNT_INFO, {
-    password: newPassword,
-    current_password: currentPassword,
+  await createLocalClusterRequestContext().httpPost({
+    http,
+    url: API_ENDPOINT_ACCOUNT_INFO,
+    body: {
+      password: newPassword,
+      current_password: currentPassword,
+    },
   });
 }

--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -15,8 +15,9 @@
 
 import { EuiBreadcrumb, EuiPage, EuiPageBody, EuiPageSideBar } from '@elastic/eui';
 import { flow, partial } from 'lodash';
-import React from 'react';
+import React, { createContext, useState } from 'react';
 import { HashRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
+import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
 import { AppDependencies } from '../types';
 import { AuditLogging } from './panels/audit-logging/audit-logging';
 import { AuditLoggingEditSettings } from './panels/audit-logging/audit-logging-edit-settings';
@@ -39,6 +40,7 @@ import { Action, RouteItem, SubAction } from './types';
 import { ResourceType } from '../../../common';
 import { buildHashUrl, buildUrl } from './utils/url-builder';
 import { CrossPageToast } from './cross-page-toast';
+import { getDataSourceFromUrl } from '../../utils/datasource-utils';
 
 const LANDING_PAGE_URL = '/getstarted';
 
@@ -137,133 +139,147 @@ function decodeParams(params: { [k: string]: string }): any {
   }, {});
 }
 
+export interface DataSourceContextType {
+  dataSource: DataSourceOption;
+  setDataSource: React.Dispatch<React.SetStateAction<DataSourceOption>>;
+}
+
+export const LocalCluster = { label: 'Local cluster', id: '' };
+
+export const DataSourceContext = createContext<DataSourceContextType | null>(null);
+
 export function AppRouter(props: AppDependencies) {
   const setGlobalBreadcrumbs = flow(getBreadcrumbs, props.coreStart.chrome.setBreadcrumbs);
+  const dataSourceFromUrl = getDataSourceFromUrl();
+
+  const [dataSource, setDataSource] = useState<DataSourceOption>(dataSourceFromUrl);
 
   return (
-    <Router basename={props.params.appBasePath}>
-      <EuiPage>
-        {allNavPanelUrls.map((route) => (
-          // Create different routes to update the 'selected' nav item .
-          <Route key={route} path={route} exact>
-            <EuiPageSideBar>
-              <NavPanel items={ROUTE_LIST} />
-            </EuiPageSideBar>
-          </Route>
-        ))}
-        <EuiPageBody>
-          <Switch>
-            <Route
-              path={buildUrl(ResourceType.roles, Action.edit) + '/:roleName/' + SubAction.mapuser}
-              render={(match) => (
-                <RoleEditMappedUser
-                  buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
-                  {...{ ...props, ...decodeParams(match.match.params) }}
-                />
-              )}
-            />
-            <Route
-              path={buildUrl(ResourceType.roles, Action.view) + '/:roleName/:prevAction?'}
-              render={(match) => (
-                <RoleView
-                  buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
-                  {...{ ...props, ...decodeParams(match.match.params) }}
-                />
-              )}
-            />
-            <Route
-              path={buildUrl(ResourceType.roles) + '/:action/:sourceRoleName?'}
-              render={(match) => (
-                <RoleEdit
-                  buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
-                  {...{ ...props, ...decodeParams(match.match.params) }}
-                />
-              )}
-            />
-            <Route
-              path={ROUTE_MAP.roles.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.roles);
-                return <RoleList {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.auth.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.auth);
-                return <AuthView {...props} />;
-              }}
-            />
-            <Route
-              path={buildUrl(ResourceType.users) + '/:action/:sourceUserName?'}
-              render={(match) => (
-                <InternalUserEdit
-                  buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.users)}
-                  {...{ ...props, ...decodeParams(match.match.params) }}
-                />
-              )}
-            />
-            <Route
-              path={ROUTE_MAP.users.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.users);
-                return <UserList {...props} />;
-              }}
-            />
-            <Route
-              path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.auditLogging, 'General settings');
-                return <AuditLoggingEditSettings setting={'general'} {...props} />;
-              }}
-            />
-            <Route
-              path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.auditLogging, 'Compliance settings');
-                return <AuditLoggingEditSettings setting={'compliance'} {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.auditLogging.href + '/:fromType?'}
-              render={(match) => {
-                setGlobalBreadcrumbs(ResourceType.auditLogging);
-                return <AuditLogging {...{ ...props, ...match.match.params }} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.permissions.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.permissions);
-                return <PermissionList {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.tenants.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.tenants);
-                return <TenantList tabID={'Manage'} {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.tenantsConfigureTab.href}
-              render={() => {
-                setGlobalBreadcrumbs(ResourceType.tenants);
-                return <TenantList tabID={'Configure'} {...props} />;
-              }}
-            />
-            <Route
-              path={ROUTE_MAP.getStarted.href}
-              render={() => {
-                setGlobalBreadcrumbs();
-                return <GetStarted {...props} />;
-              }}
-            />
-            <Redirect exact from="/" to={LANDING_PAGE_URL} />
-          </Switch>
-        </EuiPageBody>
-        <CrossPageToast />
-      </EuiPage>
-    </Router>
+    <DataSourceContext.Provider value={{ dataSource, setDataSource }}>
+      <Router basename={props.params.appBasePath}>
+        <EuiPage>
+          {allNavPanelUrls.map((route) => (
+            // Create different routes to update the 'selected' nav item .
+            <Route key={route} path={route} exact>
+              <EuiPageSideBar>
+                <NavPanel items={ROUTE_LIST} />
+              </EuiPageSideBar>
+            </Route>
+          ))}
+          <EuiPageBody>
+            <Switch>
+              <Route
+                path={buildUrl(ResourceType.roles, Action.edit) + '/:roleName/' + SubAction.mapuser}
+                render={(match) => (
+                  <RoleEditMappedUser
+                    buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
+                    {...{ ...props, ...decodeParams(match.match.params) }}
+                  />
+                )}
+              />
+              <Route
+                path={buildUrl(ResourceType.roles, Action.view) + '/:roleName/:prevAction?'}
+                render={(match) => (
+                  <RoleView
+                    buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
+                    {...{ ...props, ...decodeParams(match.match.params) }}
+                  />
+                )}
+              />
+              <Route
+                path={buildUrl(ResourceType.roles) + '/:action/:sourceRoleName?'}
+                render={(match) => (
+                  <RoleEdit
+                    buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.roles)}
+                    {...{ ...props, ...decodeParams(match.match.params) }}
+                  />
+                )}
+              />
+              <Route
+                path={ROUTE_MAP.roles.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.roles);
+                  return <RoleList {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.auth.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.auth);
+                  return <AuthView {...props} />;
+                }}
+              />
+              <Route
+                path={buildUrl(ResourceType.users) + '/:action/:sourceUserName?'}
+                render={(match) => (
+                  <InternalUserEdit
+                    buildBreadcrumbs={partial(setGlobalBreadcrumbs, ResourceType.users)}
+                    {...{ ...props, ...decodeParams(match.match.params) }}
+                  />
+                )}
+              />
+              <Route
+                path={ROUTE_MAP.users.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.users);
+                  return <UserList {...props} />;
+                }}
+              />
+              <Route
+                path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.auditLogging, 'General settings');
+                  return <AuditLoggingEditSettings setting={'general'} {...props} />;
+                }}
+              />
+              <Route
+                path={buildUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.auditLogging, 'Compliance settings');
+                  return <AuditLoggingEditSettings setting={'compliance'} {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.auditLogging.href + '/:fromType?'}
+                render={(match) => {
+                  setGlobalBreadcrumbs(ResourceType.auditLogging);
+                  return <AuditLogging {...{ ...props, ...match.match.params }} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.permissions.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.permissions);
+                  return <PermissionList {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.tenants.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.tenants);
+                  return <TenantList tabID={'Manage'} {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.tenantsConfigureTab.href}
+                render={() => {
+                  setGlobalBreadcrumbs(ResourceType.tenants);
+                  return <TenantList tabID={'Configure'} {...props} />;
+                }}
+              />
+              <Route
+                path={ROUTE_MAP.getStarted.href}
+                render={() => {
+                  setGlobalBreadcrumbs();
+                  return <GetStarted {...props} />;
+                }}
+              />
+              <Redirect exact from="/" to={LANDING_PAGE_URL} />
+            </Switch>
+          </EuiPageBody>
+          <CrossPageToast />
+        </EuiPage>
+      </Router>
+    </DataSourceContext.Provider>
   );
 }

--- a/public/apps/configuration/configuration-app.tsx
+++ b/public/apps/configuration/configuration-app.tsx
@@ -21,14 +21,22 @@ import { I18nProvider } from '@osd/i18n/react';
 import { AppMountParameters, CoreStart } from '../../../../../src/core/public';
 import { SecurityPluginStartDependencies, ClientConfigType } from '../../types';
 import { AppRouter } from './app-router';
+import { DataSourceManagementPluginSetup } from '../../../../../src/plugins/data_source_management/public';
 
 export function renderApp(
   coreStart: CoreStart,
-  navigation: SecurityPluginStartDependencies,
+  depsStart: SecurityPluginStartDependencies,
   params: AppMountParameters,
-  config: ClientConfigType
+  config: ClientConfigType,
+  dataSourceManagement?: DataSourceManagementPluginSetup
 ) {
-  const deps = { coreStart, navigation, params, config };
+  const deps = {
+    coreStart,
+    depsStart,
+    params,
+    config,
+    dataSourceManagement,
+  };
   ReactDOM.render(
     <I18nProvider>
       <AppRouter {...deps} />

--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   EuiButton,
   EuiFlexGroup,
@@ -35,15 +35,20 @@ import { ResourceType } from '../../../../../common';
 import { getAuditLogging, updateAuditLogging } from '../../utils/audit-logging-utils';
 import { useToastState } from '../../utils/toast-utils';
 import { setCrossPageToast } from '../../utils/storage-utils';
+import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
+import { DataSourceContext } from '../../app-router';
+import { getClusterInfo } from '../../../../utils/datasource-utils';
 
 interface AuditLoggingEditSettingProps extends AppDependencies {
   setting: 'general' | 'compliance';
 }
 
 export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
+  const dataSourceEnabled = !!props.depsStart.dataSource?.dataSourceEnabled;
   const [editConfig, setEditConfig] = React.useState<AuditLoggingSettings>({});
   const [toasts, addToast, removeToast] = useToastState();
   const [invalidSettings, setInvalidSettings] = React.useState<string[]>([]);
+  const { dataSource, setDataSource } = useContext(DataSourceContext)!;
 
   const handleChange = (path: string, val: boolean | string[] | SettingMapItem) => {
     setEditConfig((previousEditedConfig) => {
@@ -63,7 +68,7 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
   React.useEffect(() => {
     const fetchConfig = async () => {
       try {
-        const fetchedConfig = await getAuditLogging(props.coreStart.http);
+        const fetchedConfig = await getAuditLogging(props.coreStart.http, dataSource.id);
         setEditConfig(fetchedConfig);
       } catch (e) {
         console.log(e);
@@ -71,7 +76,7 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
     };
 
     fetchConfig();
-  }, [props.coreStart.http]);
+  }, [props.coreStart.http, dataSource.id]);
 
   const renderSaveAndCancel = () => {
     return (
@@ -106,7 +111,7 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
 
   const saveConfig = async (configToUpdate: AuditLoggingSettings) => {
     try {
-      await updateAuditLogging(props.coreStart.http, configToUpdate);
+      await updateAuditLogging(props.coreStart.http, configToUpdate, dataSource.id);
 
       const addSuccessToast = (text: string) => {
         const successToast: Toast = {
@@ -121,9 +126,11 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
       };
 
       if (props.setting === 'general') {
-        addSuccessToast('General settings saved');
+        addSuccessToast(`General settings saved ${getClusterInfo(dataSourceEnabled, dataSource)}`);
       } else {
-        addSuccessToast('Compliance settings saved');
+        addSuccessToast(
+          `Compliance settings saved ${getClusterInfo(dataSourceEnabled, dataSource)}`
+        );
       }
 
       window.location.href = buildHashUrl(ResourceType.auditLogging);
@@ -132,7 +139,11 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
         id: 'update-result',
         color: 'danger',
         iconType: 'alert',
-        title: 'Failed to update audit configuration due to ' + e?.message,
+        title:
+          `Failed to update audit configuration ${getClusterInfo(
+            dataSourceEnabled,
+            dataSource
+          )} due to ` + e?.message,
       };
 
       addToast(failureToast);
@@ -237,5 +248,15 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
     content = renderComplianceSetting();
   }
 
-  return <div className="panel-restrict-width">{content}</div>;
+  return (
+    <div className="panel-restrict-width">
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={true}
+        setDataSource={setDataSource}
+        selectedDataSource={dataSource}
+      />
+      {content}
+    </div>
+  );
 }

--- a/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
+++ b/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
@@ -241,6 +241,21 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
 <div
   className="panel-restrict-width"
 >
+  <Memo()
+    coreStart={
+      Object {
+        "http": 1,
+      }
+    }
+    dataSourcePickerReadOnly={false}
+    navigation={Object {}}
+    selectedDataSource={
+      Object {
+        "id": "test",
+      }
+    }
+    setDataSource={[MockFunction]}
+  />
   <EuiPanel>
     <EuiTitle>
       <h3>
@@ -321,7 +336,9 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
     </EuiForm>
   </EuiPanel>
   <EuiSpacer />
-  <EuiPanel>
+  <EuiPanel
+    data-test-subj="general-settings"
+  >
     <EuiFlexGroup>
       <EuiFlexItem>
         <EuiTitle>

--- a/public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
@@ -21,6 +21,10 @@ import { buildHashUrl } from '../../../utils/url-builder';
 import { ResourceType } from '../../../../../../common';
 
 jest.mock('../../../utils/audit-logging-utils');
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 
 // eslint-disable-next-line
 const mockAuditLoggingUtils = require('../../../utils/audit-logging-utils');
@@ -53,7 +57,7 @@ describe('Audit logs edit', () => {
     shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="general"
         params={{} as any}
         config={{} as any}
@@ -89,7 +93,7 @@ describe('Audit logs edit', () => {
     shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="compliance"
         params={{} as any}
         config={{} as any}
@@ -112,7 +116,7 @@ describe('Audit logs edit', () => {
     shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="compliance"
         params={{} as any}
         config={{} as any}
@@ -129,7 +133,7 @@ describe('Audit logs edit', () => {
     const component = shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="compliance"
         params={{} as any}
         config={{} as any}
@@ -143,7 +147,7 @@ describe('Audit logs edit', () => {
     const component = shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="compliance"
         params={{} as any}
         config={{} as any}
@@ -158,7 +162,7 @@ describe('Audit logs edit', () => {
     const component = shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{}}
         setting="general"
         params={{} as any}
         config={{} as any}

--- a/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
@@ -25,6 +25,10 @@ import {
 } from '../constants';
 
 jest.mock('../../../utils/audit-logging-utils');
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 
 // eslint-disable-next-line
 const mockAuditLoggingUtils = require('../../../utils/audit-logging-utils');

--- a/public/apps/configuration/panels/auth-view/auth-view.tsx
+++ b/public/apps/configuration/panels/auth-view/auth-view.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { EuiPageHeader, EuiSpacer, EuiTitle } from '@elastic/eui';
 import { isEmpty } from 'lodash';
 import { AuthenticationSequencePanel } from './authentication-sequence-panel';
@@ -23,17 +23,20 @@ import { AppDependencies } from '../../../types';
 import { ExternalLinkButton } from '../../utils/display-utils';
 import { getSecurityConfig } from '../../utils/auth-view-utils';
 import { InstructionView } from './instruction-view';
+import { DataSourceContext } from '../../app-router';
+import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
 
 export function AuthView(props: AppDependencies) {
   const [authentication, setAuthentication] = React.useState([]);
   const [authorization, setAuthorization] = React.useState([]);
   const [loading, setLoading] = useState(false);
+  const { dataSource, setDataSource } = useContext(DataSourceContext)!;
 
   React.useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const config = await getSecurityConfig(props.coreStart.http);
+        const config = await getSecurityConfig(props.coreStart.http, dataSource.id);
 
         setAuthentication(config.authc);
         setAuthorization(config.authz);
@@ -45,7 +48,7 @@ export function AuthView(props: AppDependencies) {
     };
 
     fetchData();
-  }, [props.coreStart.http]);
+  }, [props.coreStart.http, dataSource.id]);
 
   if (isEmpty(authentication)) {
     return <InstructionView config={props.config} />;
@@ -53,6 +56,12 @@ export function AuthView(props: AppDependencies) {
 
   return (
     <>
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={false}
+        setDataSource={setDataSource}
+        selectedDataSource={dataSource}
+      />
       <EuiPageHeader>
         <EuiTitle size="l">
           <h1>Authentication and authorization</h1>

--- a/public/apps/configuration/panels/auth-view/test/auth-view.test.tsx
+++ b/public/apps/configuration/panels/auth-view/test/auth-view.test.tsx
@@ -17,6 +17,11 @@ import { shallow } from 'enzyme';
 import React from 'react';
 import { AuthView } from '../auth-view';
 
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
+
 // eslint-disable-next-line
 const mockAuthViewUtils = require('../../../utils/auth-view-utils');
 

--- a/public/apps/configuration/panels/internal-user-edit/test/internal-user-edit.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/internal-user-edit.test.tsx
@@ -31,6 +31,10 @@ jest.mock('../../../utils/toast-utils', () => ({
   createUnknownErrorToast: jest.fn(),
   useToastState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()]),
 }));
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 
 describe('Internal user edit', () => {
   const sampleUsername = 'user1';
@@ -52,7 +56,7 @@ describe('Internal user edit', () => {
         sourceUserName={sampleUsername}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -73,13 +77,13 @@ describe('Internal user edit', () => {
         sourceUserName={sampleUsername}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
     );
 
-    expect(getUserDetail).toBeCalledWith(mockCoreStart.http, sampleUsername);
+    expect(getUserDetail).toBeCalledWith(mockCoreStart.http, sampleUsername, 'test');
   });
 
   it('should not submit if password is empty on creation', () => {
@@ -92,7 +96,7 @@ describe('Internal user edit', () => {
         sourceUserName={sampleUsername}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -112,7 +116,7 @@ describe('Internal user edit', () => {
         sourceUserName={sampleUsername}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -134,7 +138,7 @@ describe('Internal user edit', () => {
         sourceUserName={sampleUsername}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -34,7 +34,14 @@ import {
   Query,
 } from '@elastic/eui';
 import { difference } from 'lodash';
-import React, { Dispatch, ReactNode, SetStateAction, useCallback, useState } from 'react';
+import React, {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  useCallback,
+  useState,
+  useContext,
+} from 'react';
 import { AppDependencies } from '../../../types';
 import { Action, DataObject, ActionGroupItem, ExpandedRowMapInterface } from '../../types';
 import {
@@ -54,6 +61,8 @@ import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
 import { useContextMenuState } from '../../utils/context-menu';
 import { generateResourceName } from '../../utils/resource-utils';
 import { DocLinks } from '../../constants';
+import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
+import { DataSourceContext } from '../../app-router';
 
 export function renderBooleanToCheckMark(value: boolean): React.ReactNode {
   return value ? <EuiIcon type="check" /> : '';
@@ -77,7 +86,7 @@ export function toggleRowDetails(
   });
 }
 
-export function renderRowExpanstionArrow(
+export function renderRowExpansionArrow(
   itemIdToExpandedRowMap: ExpandedRowMapInterface,
   actionGroupDict: DataObject<ActionGroupItem>,
   setItemIdToExpandedRowMap: Dispatch<SetStateAction<ExpandedRowMapInterface>>
@@ -129,7 +138,7 @@ function getColumns(
       align: RIGHT_ALIGNMENT,
       width: '40px',
       isExpander: true,
-      render: renderRowExpanstionArrow(
+      render: renderRowExpansionArrow(
         itemIdToExpandedRowMap,
         actionGroupDict,
         setItemIdToExpandedRowMap
@@ -182,6 +191,9 @@ export function PermissionList(props: AppDependencies) {
   const [selection, setSelection] = React.useState<PermissionListingItem[]>([]);
   const [itemIdToExpandedRowMap, setItemIdToExpandedRowMap] = useState<ExpandedRowMapInterface>({});
 
+  const dataSourceEnabled = !!props.depsStart.dataSource?.dataSourceEnabled;
+  const { dataSource, setDataSource } = useContext(DataSourceContext)!;
+
   // Modal state
   const [editModal, setEditModal] = useState<ReactNode>(null);
 
@@ -194,7 +206,7 @@ export function PermissionList(props: AppDependencies) {
   const fetchData = useCallback(async () => {
     try {
       setLoading(true);
-      const actionGroups = await fetchActionGroups(props.coreStart.http);
+      const actionGroups = await fetchActionGroups(props.coreStart.http, dataSource.id);
       setActionGroupDict(actionGroups);
       setPermissionList(await mergeAllPermissions(actionGroups));
     } catch (e) {
@@ -203,16 +215,16 @@ export function PermissionList(props: AppDependencies) {
     } finally {
       setLoading(false);
     }
-  }, [props.coreStart.http]);
+  }, [props.coreStart.http, dataSource.id]);
 
   React.useEffect(() => {
     fetchData();
-  }, [props.coreStart.http, fetchData]);
+  }, [props.coreStart.http, fetchData, dataSource.id]);
 
   const handleDelete = async () => {
     const groupsToDelete: string[] = selection.map((r) => r.name);
     try {
-      await requestDeleteActionGroups(props.coreStart.http, groupsToDelete);
+      await requestDeleteActionGroups(props.coreStart.http, groupsToDelete, dataSource.id);
       setPermissionList(difference(permissionList, selection));
       setSelection([]);
     } catch (e) {
@@ -276,14 +288,23 @@ export function PermissionList(props: AppDependencies) {
         handleClose={() => setEditModal(null)}
         handleSave={async (groupName, allowedAction) => {
           try {
-            await updateActionGroup(props.coreStart.http, groupName, {
-              allowed_actions: allowedAction,
-            });
+            await updateActionGroup(
+              props.coreStart.http,
+              groupName,
+              { allowed_actions: allowedAction },
+              dataSource.id
+            );
             setEditModal(null);
             fetchData();
             addToast({
               id: 'saveSucceeded',
-              title: getSuccessToastMessage('Action group', action, groupName),
+              title: `${getSuccessToastMessage(
+                'Action group',
+                action,
+                groupName,
+                dataSourceEnabled,
+                dataSource
+              )}`,
               color: 'success',
             });
           } catch (e) {
@@ -328,6 +349,12 @@ export function PermissionList(props: AppDependencies) {
 
   return (
     <>
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={false}
+        setDataSource={setDataSource}
+        selectedDataSource={dataSource}
+      />
       <EuiPageHeader>
         <EuiTitle size="l">
           <h1>Permissions</h1>

--- a/public/apps/configuration/panels/permission-list/test/permission-list.test.tsx
+++ b/public/apps/configuration/panels/permission-list/test/permission-list.test.tsx
@@ -19,7 +19,7 @@ import {
   PermissionList,
   renderBooleanToCheckMark,
   toggleRowDetails,
-  renderRowExpanstionArrow,
+  renderRowExpansionArrow,
 } from '../permission-list';
 import { EuiInMemoryTable, EuiButtonIcon } from '@elastic/eui';
 import {
@@ -49,6 +49,11 @@ jest.mock('../../../utils/toast-utils', () => ({
   useToastState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()]),
 }));
 
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
+
 describe('Permission list page ', () => {
   const sampleActionGroup: PermissionListingItem = {
     name: 'group',
@@ -73,7 +78,7 @@ describe('Permission list page ', () => {
 
   describe('renderRowExpanstionArrow', () => {
     it('should render down arrow when collapsed', () => {
-      const renderFunc = renderRowExpanstionArrow({}, {}, jest.fn());
+      const renderFunc = renderRowExpansionArrow({}, {}, jest.fn());
       const Wrapper = () => <>{renderFunc(sampleActionGroup)}</>;
       const component = shallow(<Wrapper />);
 
@@ -81,7 +86,7 @@ describe('Permission list page ', () => {
     });
 
     it('should render up arrow when expanded', () => {
-      const renderFunc = renderRowExpanstionArrow(
+      const renderFunc = renderRowExpansionArrow(
         { [sampleActionGroup.name]: sampleActionGroup },
         {},
         jest.fn()
@@ -94,11 +99,14 @@ describe('Permission list page ', () => {
   });
 
   describe('PermissionList', () => {
+    const mockCoreStart = {
+      http: 1,
+    };
     it('render empty', () => {
       const component = shallow(
         <PermissionList
           coreStart={{} as any}
-          navigation={{} as any}
+          depsStart={{} as any}
           params={{} as any}
           config={{} as any}
         />
@@ -111,14 +119,14 @@ describe('Permission list page ', () => {
       jest.spyOn(React, 'useEffect').mockImplementationOnce((f) => f());
       shallow(
         <PermissionList
-          coreStart={{} as any}
-          navigation={{} as any}
+          coreStart={mockCoreStart as any}
+          depsStart={{} as any}
           params={{} as any}
           config={{} as any}
         />
       );
 
-      expect(fetchActionGroups).toBeCalled();
+      expect(fetchActionGroups).toBeCalledWith(mockCoreStart.http, 'test');
     });
 
     it('fetch data error', () => {
@@ -134,7 +142,7 @@ describe('Permission list page ', () => {
       shallow(
         <PermissionList
           coreStart={{} as any}
-          navigation={{} as any}
+          depsStart={{} as any}
           params={{} as any}
           config={{} as any}
         />
@@ -147,8 +155,8 @@ describe('Permission list page ', () => {
     it('submit change', () => {
       const component = shallow(
         <PermissionList
-          coreStart={{} as any}
-          navigation={{} as any}
+          coreStart={mockCoreStart as any}
+          depsStart={{} as any}
           params={{} as any}
           config={{} as any}
         />
@@ -157,7 +165,12 @@ describe('Permission list page ', () => {
       const submitFunc = component.find(PermissionEditModal).prop('handleSave');
       submitFunc('group1', []);
 
-      expect(updateActionGroup).toBeCalled();
+      expect(updateActionGroup).toBeCalledWith(
+        mockCoreStart.http,
+        'group1',
+        { allowed_actions: [] },
+        'test'
+      );
     });
 
     it('submit change error', () => {
@@ -170,7 +183,7 @@ describe('Permission list page ', () => {
       const component = shallow(
         <PermissionList
           coreStart={{} as any}
-          navigation={{} as any}
+          depsStart={{} as any}
           params={{} as any}
           config={{} as any}
         />
@@ -186,8 +199,8 @@ describe('Permission list page ', () => {
     it('delete action group', (done) => {
       shallow(
         <PermissionList
-          coreStart={{} as any}
-          navigation={{} as any}
+          coreStart={mockCoreStart as any}
+          depsStart={{} as any}
           params={{} as any}
           config={{} as any}
         />
@@ -197,7 +210,7 @@ describe('Permission list page ', () => {
       deleteFunc();
 
       process.nextTick(() => {
-        expect(requestDeleteActionGroups).toBeCalled();
+        expect(requestDeleteActionGroups).toBeCalledWith(mockCoreStart.http, [], 'test');
         done();
       });
     });
@@ -207,7 +220,7 @@ describe('Permission list page ', () => {
       const component = shallow(
         <PermissionList
           coreStart={{} as any}
-          navigation={{} as any}
+          depsStart={{} as any}
           params={{} as any}
           config={{} as any}
         />

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -23,7 +23,7 @@ import {
   EuiSuperSelect,
   EuiTextArea,
 } from '@elastic/eui';
-import React, { Dispatch, Fragment, SetStateAction } from 'react';
+import React, { Dispatch, Fragment, SetStateAction, useEffect } from 'react';
 import { isEmpty } from 'lodash';
 import { RoleIndexPermission } from '../../types';
 import { ResourceType } from '../../../../../common';
@@ -320,9 +320,11 @@ export function IndexPermissionPanel(props: {
 }) {
   const { state, optionUniverse, setState } = props;
   // Show one empty row if there is no data.
-  if (isEmpty(state)) {
-    setState([getEmptyIndexPermission()]);
-  }
+  useEffect(() => {
+    if (isEmpty(state)) {
+      setState([getEmptyIndexPermission()]);
+    }
+  }, [state, setState]);
   return (
     <PanelWithHeader
       headerText="Index permissions"

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -14,7 +14,7 @@
  */
 
 import { EuiButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiSuperSelect } from '@elastic/eui';
-import React, { Dispatch, Fragment, SetStateAction } from 'react';
+import React, { Dispatch, Fragment, SetStateAction, useEffect } from 'react';
 import { isEmpty } from 'lodash';
 import { RoleTenantPermission, TenantPermissionType, ComboBoxOptions } from '../../types';
 import {
@@ -129,9 +129,12 @@ export function TenantPanel(props: {
 }) {
   const { state, optionUniverse, setState } = props;
   // Show one empty row if there is no data.
-  if (isEmpty(state)) {
-    setState([getEmptyTenantPermission()]);
-  }
+
+  useEffect(() => {
+    if (isEmpty(state)) {
+      setState([getEmptyTenantPermission()]);
+    }
+  }, [state, setState]);
   return (
     <PanelWithHeader
       headerText="Tenant permissions"

--- a/public/apps/configuration/panels/role-edit/test/index-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/index-permission-panel.test.tsx
@@ -14,6 +14,7 @@
  */
 
 import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { RoleIndexPermission, ComboBoxOptions, FieldLevelSecurityMethod } from '../../../types';
 import { stringToComboBoxOption } from '../../../utils/combo-box-utils';
@@ -180,7 +181,7 @@ describe('Role edit - index permission panel', () => {
       const state: RoleIndexPermissionStateClass[] = [];
       const optionUniverse: ComboBoxOptions = [];
 
-      shallow(<IndexPermissionPanel {...{ state, optionUniverse, setState }} />);
+      render(<IndexPermissionPanel {...{ state, optionUniverse, setState }} />);
 
       expect(setState).toHaveBeenCalledTimes(1);
     });

--- a/public/apps/configuration/panels/role-edit/test/role-edit-filtering.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/role-edit-filtering.test.tsx
@@ -33,6 +33,7 @@ jest.mock('../../../utils/role-detail-utils', () => ({
   }),
   updateRole: jest.fn(),
 }));
+
 jest.mock('../../../utils/action-groups-utils');
 
 jest.mock('../cluster-permission-panel', () => ({
@@ -41,6 +42,11 @@ jest.mock('../cluster-permission-panel', () => ({
 
 jest.mock('../index-permission-panel', () => ({
   IndexPermissionPanel: jest.fn(() => null) as jest.Mock,
+}));
+
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
 }));
 
 describe('Role edit filtering', () => {
@@ -94,7 +100,7 @@ describe('Role edit filtering', () => {
         sourceRoleName={sampleSourceRole}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -150,7 +156,7 @@ describe('Role edit filtering', () => {
         sourceRoleName={sampleSourceRole}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />

--- a/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
@@ -38,6 +38,10 @@ jest.mock('../../../utils/action-groups-utils', () => ({
 }));
 jest.mock('../../../utils/tenant-utils');
 jest.mock('../../../utils/storage-utils');
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 
 describe('Role edit', () => {
   const sampleSourceRole = 'role';
@@ -59,7 +63,7 @@ describe('Role edit', () => {
         sourceRoleName={sampleSourceRole}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -85,7 +89,7 @@ describe('Role edit', () => {
         sourceRoleName={sampleSourceRole}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -108,7 +112,7 @@ describe('Role edit', () => {
         sourceRoleName={sampleSourceRole}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -116,11 +120,16 @@ describe('Role edit', () => {
     // click update
     component.find(EuiButton).last().simulate('click');
 
-    expect(updateRole).toBeCalledWith(mockCoreStart.http, '', {
-      cluster_permissions: [],
-      index_permissions: [],
-      tenant_permissions: [],
-    });
+    expect(updateRole).toBeCalledWith(
+      mockCoreStart.http,
+      '',
+      {
+        cluster_permissions: [],
+        index_permissions: [],
+        tenant_permissions: [],
+      },
+      'test'
+    );
 
     process.nextTick(() => {
       expect(setCrossPageToast).toHaveBeenCalled();

--- a/public/apps/configuration/panels/role-edit/test/tenant-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/tenant-panel.test.tsx
@@ -24,6 +24,7 @@ import {
 import { shallow } from 'enzyme';
 import React from 'react';
 import { EuiComboBox, EuiButton, EuiSuperSelect } from '@elastic/eui';
+import { render } from '@testing-library/react';
 
 jest.mock('../../../utils/array-state-utils');
 // eslint-disable-next-line
@@ -76,7 +77,7 @@ describe('Role edit - tenant panel', () => {
     const setState = jest.fn();
 
     it('render an empty row if data is empty', () => {
-      shallow(<TenantPanel state={[]} optionUniverse={optionUniverse} setState={setState} />);
+      render(<TenantPanel state={[]} optionUniverse={optionUniverse} setState={setState} />);
 
       expect(setState).toHaveBeenCalledWith([
         {

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import {
   EuiFlexGroup,
   EuiText,
@@ -54,6 +54,8 @@ import { showTableStatusMessage } from '../utils/loading-spinner-utils';
 import { useDeleteConfirmState } from '../utils/delete-confirm-modal-utils';
 import { useContextMenuState } from '../utils/context-menu';
 import { DocLinks } from '../constants';
+import { DataSourceContext } from '../app-router';
+import { SecurityPluginTopNavMenu } from '../top-nav-menu';
 
 const columns: Array<EuiBasicTableColumn<RoleListing>> = [
   {
@@ -105,13 +107,14 @@ export function RoleList(props: AppDependencies) {
   const [errorFlag, setErrorFlag] = React.useState(false);
   const [selection, setSelection] = React.useState<RoleListing[]>([]);
   const [loading, setLoading] = useState(false);
+  const { dataSource, setDataSource } = useContext(DataSourceContext)!;
 
   React.useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const rawRoleData = await fetchRole(props.coreStart.http);
-        const rawRoleMappingData = await fetchRoleMapping(props.coreStart.http);
+        const rawRoleData = await fetchRole(props.coreStart.http, dataSource.id);
+        const rawRoleMappingData = await fetchRoleMapping(props.coreStart.http, dataSource.id);
         const processedData = transformRoleData(rawRoleData, rawRoleMappingData);
         setRoleData(processedData);
       } catch (e) {
@@ -123,12 +126,12 @@ export function RoleList(props: AppDependencies) {
     };
 
     fetchData();
-  }, [props.coreStart.http]);
+  }, [props.coreStart.http, dataSource.id]);
 
   const handleDelete = async () => {
     const rolesToDelete: string[] = selection.map((r) => r.roleName);
     try {
-      await requestDeleteRoles(props.coreStart.http, rolesToDelete);
+      await requestDeleteRoles(props.coreStart.http, rolesToDelete, dataSource.id);
       // Refresh from server (calling fetchData) does not work here, the server still return the roles
       // that had been just deleted, probably because ES takes some time to sync to all nodes.
       // So here remove the selected roles from local memory directly.
@@ -250,6 +253,12 @@ export function RoleList(props: AppDependencies) {
 
   return (
     <>
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={false}
+        setDataSource={setDataSource}
+        selectedDataSource={dataSource}
+      />
       <EuiPageHeader>
         <EuiTitle size="l">
           <h1>Roles</h1>
@@ -278,7 +287,11 @@ export function RoleList(props: AppDependencies) {
             <EuiFlexGroup>
               <EuiFlexItem>{actionsMenu}</EuiFlexItem>
               <EuiFlexItem>
-                <EuiButton fill href={buildHashUrl(ResourceType.roles, Action.create)}>
+                <EuiButton
+                  fill
+                  href={buildHashUrl(ResourceType.roles, Action.create)}
+                  data-test-subj="create-role"
+                >
                   Create role
                 </EuiButton>
               </EuiFlexItem>

--- a/public/apps/configuration/panels/role-mapping/test/role-edit-mapped-user.test.tsx
+++ b/public/apps/configuration/panels/role-mapping/test/role-edit-mapped-user.test.tsx
@@ -26,6 +26,10 @@ jest.mock('../../../utils/role-mapping-utils');
 jest.mock('../../../utils/internal-user-list-utils', () => ({
   fetchUserNameList: jest.fn().mockReturnValue([]),
 }));
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 // eslint-disable-next-line
 const roleMappingUtils = require('../../../utils/role-mapping-utils');
 
@@ -52,7 +56,7 @@ describe('Role mapping edit', () => {
         roleName={sampleRole}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -77,7 +81,7 @@ describe('Role mapping edit', () => {
         roleName={sampleRole}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -98,7 +102,7 @@ describe('Role mapping edit', () => {
         roleName={sampleRole}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -106,11 +110,16 @@ describe('Role mapping edit', () => {
     // click update
     component.find('#map').last().simulate('click');
 
-    expect(updateRoleMapping).toBeCalledWith(mockCoreStart.http, sampleRole, {
-      users: [],
-      backend_roles: [],
-      hosts: [],
-    });
+    expect(updateRoleMapping).toBeCalledWith(
+      mockCoreStart.http,
+      sampleRole,
+      {
+        users: [],
+        backend_roles: [],
+        hosts: [],
+      },
+      'test'
+    );
   });
 
   it('submit update error', () => {
@@ -126,7 +135,7 @@ describe('Role mapping edit', () => {
         roleName={sampleRole}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -49,6 +49,7 @@ interface RoleViewTenantsPanelProps {
   coreStart: CoreStart;
   loading: boolean;
   isReserved: boolean;
+  dataSourceId: string;
 }
 
 export function TenantsPanel(props: RoleViewTenantsPanelProps) {
@@ -62,7 +63,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
   React.useEffect(() => {
     const fetchData = async () => {
       try {
-        const rawTenantData = await fetchTenants(props.coreStart.http);
+        const rawTenantData = await fetchTenants(props.coreStart.http, props.dataSourceId);
         const processedTenantData = transformTenantData(rawTenantData);
         setTenantPermissionDetail(
           transformRoleTenantPermissionData(props.tenantPermissions, processedTenantData)

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
@@ -2,6 +2,40 @@
 
 exports[`Role view basic rendering when permission tab is selected 1`] = `
 <Fragment>
+  <Memo()
+    buildBreadcrumbs={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "role",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+    config={Object {}}
+    coreStart={
+      Object {
+        "http": 1,
+      }
+    }
+    dataSourcePickerReadOnly={true}
+    depsStart={Object {}}
+    params={Object {}}
+    prevAction=""
+    roleName="role"
+    selectedDataSource={
+      Object {
+        "id": "test",
+      }
+    }
+    setDataSource={[MockFunction]}
+  />
   <EuiPageContentHeader>
     <EuiPageContentHeaderSection>
       <EuiTitle
@@ -80,6 +114,7 @@ exports[`Role view basic rendering when permission tab is selected 1`] = `
                 "http": 1,
               }
             }
+            dataSourceId="test"
             errorFlag={false}
             isReserved={false}
             loading={false}
@@ -129,6 +164,7 @@ exports[`Role view basic rendering when permission tab is selected 1`] = `
                   "http": 1,
                 }
               }
+              dataSourceId="test"
               errorFlag={false}
               isReserved={false}
               loading={false}
@@ -293,6 +329,40 @@ exports[`Role view basic rendering when permission tab is selected 1`] = `
 
 exports[`Role view renders when mapped user tab is selected 1`] = `
 <Fragment>
+  <Memo()
+    buildBreadcrumbs={
+      [MockFunction] {
+        "calls": Array [
+          Array [
+            "role",
+          ],
+        ],
+        "results": Array [
+          Object {
+            "type": "return",
+            "value": undefined,
+          },
+        ],
+      }
+    }
+    config={Object {}}
+    coreStart={
+      Object {
+        "http": 1,
+      }
+    }
+    dataSourcePickerReadOnly={true}
+    depsStart={Object {}}
+    params={Object {}}
+    prevAction="mapuser"
+    roleName="role"
+    selectedDataSource={
+      Object {
+        "id": "test",
+      }
+    }
+    setDataSource={[MockFunction]}
+  />
   <EuiPageContentHeader>
     <EuiPageContentHeaderSection>
       <EuiTitle
@@ -512,6 +582,7 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                   "http": 1,
                 }
               }
+              dataSourceId="test"
               errorFlag={false}
               isReserved={false}
               loading={false}

--- a/public/apps/configuration/panels/role-view/test/role-view.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/role-view.test.tsx
@@ -72,6 +72,10 @@ jest.mock('../../../utils/toast-utils', () => ({
   createUnknownErrorToast: jest.fn(),
   useToastState: jest.fn().mockReturnValue([[], jest.fn(), jest.fn()]),
 }));
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 
 describe('Role view', () => {
   const setState = jest.fn();
@@ -96,7 +100,7 @@ describe('Role view', () => {
         prevAction=""
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -119,7 +123,7 @@ describe('Role view', () => {
         prevAction={SubAction.mapuser}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -134,7 +138,7 @@ describe('Role view', () => {
         prevAction={SubAction.mapuser}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -155,7 +159,7 @@ describe('Role view', () => {
         prevAction={SubAction.mapuser}
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -174,7 +178,7 @@ describe('Role view', () => {
         prevAction=""
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -203,7 +207,7 @@ describe('Role view', () => {
         prevAction=""
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -219,7 +223,7 @@ describe('Role view', () => {
         prevAction=""
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -245,7 +249,7 @@ describe('Role view', () => {
         prevAction=""
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -267,7 +271,7 @@ describe('Role view', () => {
         prevAction=""
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />
@@ -287,7 +291,7 @@ describe('Role view', () => {
         prevAction=""
         buildBreadcrumbs={buildBreadcrumbs}
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={{} as any}
       />

--- a/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
+++ b/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
@@ -49,6 +49,7 @@ import {
   useToastState,
 } from '../../utils/toast-utils';
 import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
+import { LOCAL_CLUSTER_ID } from '../../../../../common';
 
 export function ConfigureTab1(props: AppDependencies) {
   const [isMultiTenancyEnabled, setIsMultiTenancyEnabled] = useState(false);
@@ -191,7 +192,7 @@ export function ConfigureTab1(props: AppDependencies) {
           default_tenant: (await getDashboardsInfo(props.coreStart.http)).default_tenant,
         });
 
-        const rawTenantData = await fetchTenants(props.coreStart.http);
+        const rawTenantData = await fetchTenants(props.coreStart.http, LOCAL_CLUSTER_ID);
         const processedTenantData = transformTenantData(rawTenantData);
         setTenantData(processedTenantData);
       } catch (e) {

--- a/public/apps/configuration/panels/tenant-list/manage_tab.tsx
+++ b/public/apps/configuration/panels/tenant-list/manage_tab.tsx
@@ -42,7 +42,7 @@ import { flow } from 'lodash';
 import { getCurrentUser } from '../../../../utils/auth-info-utils';
 import { AppDependencies } from '../../../types';
 import { Action, Tenant } from '../../types';
-import { ResourceType } from '../../../../../common';
+import { LOCAL_CLUSTER_ID, ResourceType } from '../../../../../common';
 import { ExternalLink, renderCustomization, tableItemsUIProps } from '../../utils/display-utils';
 import {
   fetchTenants,
@@ -68,7 +68,7 @@ import { useContextMenuState } from '../../utils/context-menu';
 import { generateResourceName } from '../../utils/resource-utils';
 import { DocLinks } from '../../constants';
 import { TenantList } from './tenant-list';
-import { getBreadcrumbs } from '../../app-router';
+import { LocalCluster, getBreadcrumbs } from '../../app-router';
 import { buildUrl } from '../../utils/url-builder';
 import { CrossPageToast } from '../../cross-page-toast';
 import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
@@ -90,13 +90,14 @@ export function ManageTab(props: AppDependencies) {
   const [isMultiTenancyEnabled, setIsMultiTenancyEnabled] = useState(false);
   const [isPrivateTenantEnabled, setIsPrivateTenantEnabled] = useState(false);
   const [dashboardsDefaultTenant, setDashboardsDefaultTenant] = useState('');
+  const dataSourceEnabled = !!props.depsStart.dataSource?.dataSourceEnabled;
 
   const { http } = props.coreStart;
 
   const fetchData = useCallback(async () => {
     try {
       setLoading(true);
-      const rawTenantData = await fetchTenants(http);
+      const rawTenantData = await fetchTenants(http, LOCAL_CLUSTER_ID);
       const processedTenantData = transformTenantData(rawTenantData);
       const activeTenant = await fetchCurrentTenant(http);
       const currentUser = await getCurrentUser(http);
@@ -465,7 +466,13 @@ export function ManageTab(props: AppDependencies) {
             fetchData();
             addToast({
               id: 'saveSucceeded',
-              title: getSuccessToastMessage('Tenant', action, tenantName),
+              title: getSuccessToastMessage(
+                'Tenant',
+                action,
+                tenantName,
+                dataSourceEnabled,
+                LocalCluster
+              ),
               color: 'success',
             });
           } catch (e) {

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -31,6 +31,8 @@ import { ExternalLink } from '../../utils/display-utils';
 import { DocLinks } from '../../constants';
 import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
 import { TenantInstructionView } from './tenant-instruction-view';
+import { LocalCluster } from '../../app-router';
+import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
 
 interface TenantListProps extends AppDependencies {
   tabID: string;
@@ -133,6 +135,12 @@ export function TenantList(props: TenantListProps) {
 
   return (
     <>
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={true}
+        setDataSource={() => {}}
+        selectedDataSource={LocalCluster}
+      />
       <EuiPageHeader>
         <EuiTitle size="l">
           <h1>Dashboards multi-tenancy</h1>

--- a/public/apps/configuration/panels/tenant-list/test/tenant-list.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/test/tenant-list.test.tsx
@@ -98,7 +98,7 @@ describe('Tenant list', () => {
     const component = shallow(
       <ManageTab
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={config as any}
       />
@@ -126,7 +126,7 @@ describe('Tenant list', () => {
     const component = shallow(
       <ManageTab
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={config1 as any}
       />
@@ -145,7 +145,7 @@ describe('Tenant list', () => {
     shallow(
       <ManageTab
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={config as any}
       />
@@ -175,7 +175,7 @@ describe('Tenant list', () => {
     shallow(
       <ManageTab
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={config as any}
       />
@@ -195,7 +195,7 @@ describe('Tenant list', () => {
     shallow(
       <ManageTab
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={config as any}
       />
@@ -220,7 +220,7 @@ describe('Tenant list', () => {
     shallow(
       <ManageTab
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={config as any}
       />
@@ -239,7 +239,7 @@ describe('Tenant list', () => {
     const component = shallow(
       <ManageTab
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={config as any}
       />
@@ -261,7 +261,7 @@ describe('Tenant list', () => {
     const component = shallow(
       <ManageTab
         coreStart={mockCoreStart as any}
-        navigation={{} as any}
+        depsStart={{} as any}
         params={{} as any}
         config={config as any}
       />
@@ -299,7 +299,7 @@ describe('Tenant list', () => {
       const component = shallow(
         <ManageTab
           coreStart={mockCoreStart as any}
-          navigation={{} as any}
+          depsStart={{} as any}
           params={{} as any}
           config={config as any}
         />
@@ -315,7 +315,7 @@ describe('Tenant list', () => {
       const component = shallow(
         <ManageTab
           coreStart={mockCoreStart as any}
-          navigation={{} as any}
+          depsStart={{} as any}
           params={{} as any}
           config={config as any}
         />
@@ -335,7 +335,7 @@ describe('Tenant list', () => {
       const component = shallow(
         <ManageTab
           coreStart={mockCoreStart as any}
-          navigation={{} as any}
+          depsStart={{} as any}
           params={{} as any}
           config={config as any}
         />
@@ -364,7 +364,7 @@ describe('Tenant list', () => {
       component = shallow(
         <ManageTab
           coreStart={mockCoreStart as any}
-          navigation={{} as any}
+          depsStart={{} as any}
           params={{} as any}
           config={config as any}
         />

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -5,6 +5,29 @@ exports[`Get started (landing page) renders when backend configuration is disabl
   <div
     className="panel-restrict-width"
   >
+    <Memo()
+      config={
+        Object {
+          "ui": Object {
+            "backend_configurable": false,
+          },
+        }
+      }
+      coreStart={
+        Object {
+          "http": 1,
+        }
+      }
+      dataSourcePickerReadOnly={false}
+      depsStart={Object {}}
+      params={Object {}}
+      selectedDataSource={
+        Object {
+          "id": "test",
+        }
+      }
+      setDataSource={[MockFunction]}
+    />
     <EuiPageHeader>
       <EuiTitle
         size="l"
@@ -258,6 +281,29 @@ exports[`Get started (landing page) renders when backend configuration is enable
   <div
     className="panel-restrict-width"
   >
+    <Memo()
+      config={
+        Object {
+          "ui": Object {
+            "backend_configurable": true,
+          },
+        }
+      }
+      coreStart={
+        Object {
+          "http": 1,
+        }
+      }
+      dataSourcePickerReadOnly={false}
+      depsStart={Object {}}
+      params={Object {}}
+      selectedDataSource={
+        Object {
+          "id": "test",
+        }
+      }
+      setDataSource={[MockFunction]}
+    />
     <EuiPageHeader>
       <EuiTitle
         size="l"

--- a/public/apps/configuration/panels/test/__snapshots__/role-list.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/role-list.test.tsx.snap
@@ -17,6 +17,7 @@ exports[`Role list Render columns render Customization column 1`] = `
   >
     <EuiText
       className="table-items"
+      data-test-subj="filter-reserved"
     >
       Reserved
     </EuiText>

--- a/public/apps/configuration/panels/test/role-list.test.tsx
+++ b/public/apps/configuration/panels/test/role-list.test.tsx
@@ -36,6 +36,11 @@ jest.mock('../../utils/context-menu', () => ({
 jest.mock('../../utils/delete-confirm-modal-utils', () => ({
   useDeleteConfirmState: jest.fn().mockReturnValue([jest.fn(), '']),
 }));
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
+
 // eslint-disable-next-line
 const mockRoleListUtils = require('../../utils/role-list-utils');
 

--- a/public/apps/configuration/panels/test/user-list.test.tsx
+++ b/public/apps/configuration/panels/test/user-list.test.tsx
@@ -37,6 +37,10 @@ jest.mock('../../utils/context-menu', () => ({
     .fn()
     .mockImplementation((buttonText, buttonProps, children) => [children, jest.fn()]),
 }));
+jest.mock('react', () => ({
+  ...jest.requireActual('react'),
+  useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
+}));
 
 import { getAuthInfo } from '../../../../utils/auth-info-utils';
 import { buildHashUrl } from '../../utils/url-builder';

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -111,7 +111,11 @@ export function UserList(props: AppDependencies) {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const userDataPromise = getUserList(props.coreStart.http, dataSource.id);
+        const userDataPromise = getUserList(
+          props.coreStart.http,
+          ResourceType.users,
+          dataSource.id
+        );
         setCurrentUsername((await getAuthInfo(props.coreStart.http)).user_name);
         setUserData(await userDataPromise);
       } catch (e) {

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -31,7 +31,7 @@ import {
   Query,
 } from '@elastic/eui';
 import { Dictionary, difference, isEmpty, map } from 'lodash';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { getAuthInfo } from '../../../utils/auth-info-utils';
 import { AppDependencies } from '../../types';
 import { API_ENDPOINT_INTERNALUSERS, DocLinks } from '../constants';
@@ -48,6 +48,8 @@ import {
 } from '../utils/internal-user-list-utils';
 import { showTableStatusMessage } from '../utils/loading-spinner-utils';
 import { buildHashUrl } from '../utils/url-builder';
+import { DataSourceContext } from '../app-router';
+import { SecurityPluginTopNavMenu } from '../top-nav-menu';
 
 export function dictView(items: Dictionary<string>) {
   if (isEmpty(items)) {
@@ -103,12 +105,13 @@ export function UserList(props: AppDependencies) {
   const [currentUsername, setCurrentUsername] = useState('');
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState<Query | null>(null);
+  const { dataSource, setDataSource } = useContext(DataSourceContext)!;
 
   React.useEffect(() => {
     const fetchData = async () => {
       try {
         setLoading(true);
-        const userDataPromise = getUserList(props.coreStart.http);
+        const userDataPromise = getUserList(props.coreStart.http, dataSource.id);
         setCurrentUsername((await getAuthInfo(props.coreStart.http)).user_name);
         setUserData(await userDataPromise);
       } catch (e) {
@@ -120,12 +123,12 @@ export function UserList(props: AppDependencies) {
     };
 
     fetchData();
-  }, [props.coreStart.http]);
+  }, [props.coreStart.http, dataSource.id]);
 
   const handleDelete = async () => {
     const usersToDelete: string[] = selection.map((r) => r.username);
     try {
-      await requestDeleteUsers(props.coreStart.http, usersToDelete);
+      await requestDeleteUsers(props.coreStart.http, usersToDelete, dataSource.id);
       // Refresh from server (calling fetchData) does not work here, the server still return the users
       // that had been just deleted, probably because ES takes some time to sync to all nodes.
       // So here remove the selected users from local memory directly.
@@ -194,6 +197,12 @@ export function UserList(props: AppDependencies) {
 
   return (
     <>
+      <SecurityPluginTopNavMenu
+        {...props}
+        dataSourcePickerReadOnly={false}
+        setDataSource={setDataSource}
+        selectedDataSource={dataSource}
+      />
       <EuiPageHeader>
         <EuiTitle size="l">
           <h1>Internal users</h1>

--- a/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
+++ b/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
@@ -39,10 +39,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
                   "name": "Internal users",
                 },
                 Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
-                },
-                Object {
                   "href": "/permissions",
                   "name": "Permissions",
                 },
@@ -87,10 +83,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
                 Object {
                   "href": "/users",
                   "name": "Internal users",
-                },
-                Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
                 },
                 Object {
                   "href": "/permissions",
@@ -139,10 +131,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
                   "name": "Internal users",
                 },
                 Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
-                },
-                Object {
                   "href": "/permissions",
                   "name": "Permissions",
                 },
@@ -187,60 +175,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
                 Object {
                   "href": "/users",
                   "name": "Internal users",
-                },
-                Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
-                },
-                Object {
-                  "href": "/permissions",
-                  "name": "Permissions",
-                },
-                Object {
-                  "href": "/tenants",
-                  "name": "Tenants",
-                },
-                Object {
-                  "href": "/auditLogging",
-                  "name": "Audit logs",
-                },
-                Object {
-                  "href": "/tenantsConfigureTab",
-                  "name": "",
-                },
-              ]
-            }
-          />
-        </EuiPageSideBar>
-      </Route>
-      <Route
-        exact={true}
-        key="/serviceAccounts"
-        path="/serviceAccounts"
-      >
-        <EuiPageSideBar>
-          <NavPanel
-            items={
-              Array [
-                Object {
-                  "href": "/getstarted",
-                  "name": "Get Started",
-                },
-                Object {
-                  "href": "/auth",
-                  "name": "Authentication",
-                },
-                Object {
-                  "href": "/roles",
-                  "name": "Roles",
-                },
-                Object {
-                  "href": "/users",
-                  "name": "Internal users",
-                },
-                Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
                 },
                 Object {
                   "href": "/permissions",
@@ -289,10 +223,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
                   "name": "Internal users",
                 },
                 Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
-                },
-                Object {
                   "href": "/permissions",
                   "name": "Permissions",
                 },
@@ -337,10 +267,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
                 Object {
                   "href": "/users",
                   "name": "Internal users",
-                },
-                Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
                 },
                 Object {
                   "href": "/permissions",
@@ -389,10 +315,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
                   "name": "Internal users",
                 },
                 Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
-                },
-                Object {
                   "href": "/permissions",
                   "name": "Permissions",
                 },
@@ -437,10 +359,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
                 Object {
                   "href": "/users",
                   "name": "Internal users",
-                },
-                Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
                 },
                 Object {
                   "href": "/permissions",
@@ -489,10 +407,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
                   "name": "Internal users",
                 },
                 Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
-                },
-                Object {
                   "href": "/permissions",
                   "name": "Permissions",
                 },
@@ -537,10 +451,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
                 Object {
                   "href": "/users",
                   "name": "Internal users",
-                },
-                Object {
-                  "href": "/serviceAccounts",
-                  "name": "Service Accounts",
                 },
                 Object {
                   "href": "/permissions",
@@ -591,10 +501,6 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
           />
           <Route
             path="/users"
-            render={[Function]}
-          />
-          <Route
-            path="/serviceAccounts"
             render={[Function]}
           />
           <Route

--- a/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
+++ b/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
@@ -1,0 +1,639 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enabled 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "dataSource": Object {},
+      "setDataSource": [Function],
+    }
+  }
+>
+  <HashRouter
+    basename=""
+  >
+    <EuiPage>
+      <Route
+        exact={true}
+        key="/getstarted"
+        path="/getstarted"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/auth"
+        path="/auth"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/roles"
+        path="/roles"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/users"
+        path="/users"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/serviceAccounts"
+        path="/serviceAccounts"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/permissions"
+        path="/permissions"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/tenants"
+        path="/tenants"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/auditLogging"
+        path="/auditLogging"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/tenantsConfigureTab"
+        path="/tenantsConfigureTab"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/auditLogging/edit/generalSettings"
+        path="/auditLogging/edit/generalSettings"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <Route
+        exact={true}
+        key="/auditLogging/edit/complianceSettings"
+        path="/auditLogging/edit/complianceSettings"
+      >
+        <EuiPageSideBar>
+          <NavPanel
+            items={
+              Array [
+                Object {
+                  "href": "/getstarted",
+                  "name": "Get Started",
+                },
+                Object {
+                  "href": "/auth",
+                  "name": "Authentication",
+                },
+                Object {
+                  "href": "/roles",
+                  "name": "Roles",
+                },
+                Object {
+                  "href": "/users",
+                  "name": "Internal users",
+                },
+                Object {
+                  "href": "/serviceAccounts",
+                  "name": "Service Accounts",
+                },
+                Object {
+                  "href": "/permissions",
+                  "name": "Permissions",
+                },
+                Object {
+                  "href": "/tenants",
+                  "name": "Tenants",
+                },
+                Object {
+                  "href": "/auditLogging",
+                  "name": "Audit logs",
+                },
+                Object {
+                  "href": "/tenantsConfigureTab",
+                  "name": "",
+                },
+              ]
+            }
+          />
+        </EuiPageSideBar>
+      </Route>
+      <EuiPageBody>
+        <Switch>
+          <Route
+            path="/roles/edit/:roleName/mapuser"
+            render={[Function]}
+          />
+          <Route
+            path="/roles/view/:roleName/:prevAction?"
+            render={[Function]}
+          />
+          <Route
+            path="/roles/:action/:sourceRoleName?"
+            render={[Function]}
+          />
+          <Route
+            path="/roles"
+            render={[Function]}
+          />
+          <Route
+            path="/auth"
+            render={[Function]}
+          />
+          <Route
+            path="/users/:action/:sourceUserName?"
+            render={[Function]}
+          />
+          <Route
+            path="/users"
+            render={[Function]}
+          />
+          <Route
+            path="/serviceAccounts"
+            render={[Function]}
+          />
+          <Route
+            path="/auditLogging/edit/generalSettings"
+            render={[Function]}
+          />
+          <Route
+            path="/auditLogging/edit/complianceSettings"
+            render={[Function]}
+          />
+          <Route
+            path="/auditLogging/:fromType?"
+            render={[Function]}
+          />
+          <Route
+            path="/permissions"
+            render={[Function]}
+          />
+          <Route
+            path="/tenants"
+            render={[Function]}
+          />
+          <Route
+            path="/tenantsConfigureTab"
+            render={[Function]}
+          />
+          <Route
+            path="/getstarted"
+            render={[Function]}
+          />
+          <Redirect
+            exact={true}
+            from="/"
+            to="/getstarted"
+          />
+        </Switch>
+      </EuiPageBody>
+      <CrossPageToast />
+    </EuiPage>
+  </HashRouter>
+</ContextProvider>
+`;

--- a/public/apps/configuration/test/app-router.test.tsx
+++ b/public/apps/configuration/test/app-router.test.tsx
@@ -1,0 +1,50 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { shallow } from 'enzyme';
+import { AppRouter } from '../app-router';
+
+describe('SecurityPluginTopNavMenu', () => {
+  const coreStartMock = {
+    savedObjects: {
+      client: jest.fn(),
+    },
+    notifications: jest.fn(),
+    chrome: {
+      setBreadcrumbs: jest.fn(),
+    },
+  };
+
+  const dataSourceMenuMock = jest.fn(() => <div>Mock DataSourceMenu</div>);
+
+  const dataSourceManagementMock = {
+    ui: {
+      DataSourceMenu: dataSourceMenuMock,
+    },
+  };
+
+  it('renders DataSourceMenu when dataSource is enabled', () => {
+    const securityPluginStartDepsMock = {
+      dataSource: {
+        dataSourceEnabled: true,
+      },
+    };
+
+    const wrapper = shallow(<AppRouter coreStart={coreStartMock} params={{ appBasePath: '' }} />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/public/apps/configuration/test/top-nav-menu.test.tsx
+++ b/public/apps/configuration/test/top-nav-menu.test.tsx
@@ -1,0 +1,79 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { render } from 'enzyme';
+import { SecurityPluginTopNavMenu } from '../top-nav-menu';
+
+describe('SecurityPluginTopNavMenu', () => {
+  const coreStartMock = {
+    savedObjects: {
+      client: jest.fn(),
+    },
+    notifications: jest.fn(),
+  };
+
+  const dataSourceMenuMock = jest.fn(() => <div>Mock DataSourceMenu</div>);
+
+  const dataSourceManagementMock = {
+    ui: {
+      getDataSourceMenu: jest.fn().mockReturnValue(dataSourceMenuMock),
+    },
+  };
+
+  it('renders DataSourceMenu when dataSource is enabled', () => {
+    const securityPluginStartDepsMock = {
+      dataSource: {
+        dataSourceEnabled: true,
+      },
+    };
+
+    const wrapper = render(
+      <SecurityPluginTopNavMenu
+        coreStart={coreStartMock}
+        depsStart={securityPluginStartDepsMock}
+        dataSourcePickerReadOnly={false}
+        dataSourceManagement={dataSourceManagementMock}
+        selectedDataSource={{}}
+        params={{}}
+      />
+    );
+
+    expect(dataSourceMenuMock).toBeCalled();
+    expect(wrapper.html()).not.toBe('');
+  });
+
+  it('renders null when dataSource is disabled', () => {
+    const securityPluginStartDepsMock = {
+      dataSource: {
+        dataSourceEnabled: false,
+      },
+    };
+
+    const wrapper = render(
+      <SecurityPluginTopNavMenu
+        coreStart={coreStartMock}
+        depsStart={securityPluginStartDepsMock}
+        dataSourcePickerReadOnly={false}
+        dataSourceManagement={dataSourceManagementMock}
+        setHeaderActionMenu={() => {}}
+        params={{}}
+      />
+    );
+
+    expect(dataSourceMenuMock).not.toBeCalled();
+    expect(wrapper.html()).toBe('');
+  });
+});

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -1,0 +1,67 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import React from 'react';
+import { DataSourceSelectableConfig } from 'src/plugins/data_source_management/public';
+import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
+import { AppDependencies } from '../types';
+import { setDataSourceInUrl } from '../../utils/datasource-utils';
+
+export interface TopNavMenuProps extends AppDependencies {
+  dataSourcePickerReadOnly: boolean;
+  setDataSource: React.Dispatch<React.SetStateAction<DataSourceOption>>;
+  selectedDataSource: DataSourceOption;
+}
+
+export const SecurityPluginTopNavMenu = React.memo(
+  (props: TopNavMenuProps) => {
+    const {
+      coreStart,
+      depsStart,
+      params,
+      dataSourceManagement,
+      setDataSource,
+      selectedDataSource,
+      dataSourcePickerReadOnly,
+    } = props;
+    const { setHeaderActionMenu } = params;
+    const DataSourceMenu = dataSourceManagement?.ui.getDataSourceMenu<DataSourceSelectableConfig>();
+
+    const dataSourceEnabled = !!depsStart.dataSource?.dataSourceEnabled;
+
+    const wrapSetDataSourceWithUpdateUrl = (dataSources: DataSourceOption[]) => {
+      setDataSourceInUrl(dataSources[0]);
+      setDataSource(dataSources[0]);
+    };
+
+    return dataSourceEnabled ? (
+      <DataSourceMenu
+        setMenuMountPoint={setHeaderActionMenu}
+        componentType={dataSourcePickerReadOnly ? 'DataSourceView' : 'DataSourceSelectable'}
+        componentConfig={{
+          savedObjects: coreStart.savedObjects.client,
+          notifications: coreStart.notifications,
+          activeOption:
+            selectedDataSource.id || selectedDataSource.label ? [selectedDataSource] : undefined,
+          onSelectedDataSources: wrapSetDataSourceWithUpdateUrl,
+          fullWidth: true,
+        }}
+      />
+    ) : null;
+  },
+  (prevProps, newProps) =>
+    prevProps.selectedDataSource.id === newProps.selectedDataSource.id &&
+    prevProps.dataSourcePickerReadOnly === newProps.dataSourcePickerReadOnly
+);

--- a/public/apps/configuration/utils/audit-logging-utils.tsx
+++ b/public/apps/configuration/utils/audit-logging-utils.tsx
@@ -16,13 +16,27 @@
 import { HttpStart } from 'opensearch-dashboards/public';
 import { AuditLoggingSettings } from '../panels/audit-logging/types';
 import { API_ENDPOINT_AUDITLOGGING, API_ENDPOINT_AUDITLOGGING_UPDATE } from '../constants';
-import { httpGet, httpPost } from './request-utils';
+import { createRequestContextWithDataSourceId } from './request-utils';
 
-export async function updateAuditLogging(http: HttpStart, updateObject: AuditLoggingSettings) {
-  return await httpPost(http, API_ENDPOINT_AUDITLOGGING_UPDATE, updateObject);
+export async function updateAuditLogging(
+  http: HttpStart,
+  updateObject: AuditLoggingSettings,
+  dataSourceId: string
+) {
+  return await createRequestContextWithDataSourceId(dataSourceId).httpPost({
+    http,
+    url: API_ENDPOINT_AUDITLOGGING_UPDATE,
+    body: updateObject,
+  });
 }
 
-export async function getAuditLogging(http: HttpStart): Promise<AuditLoggingSettings> {
-  const rawConfiguration = await httpGet<any>(http, API_ENDPOINT_AUDITLOGGING);
+export async function getAuditLogging(
+  http: HttpStart,
+  dataSourceId: string
+): Promise<AuditLoggingSettings> {
+  const rawConfiguration = await createRequestContextWithDataSourceId(dataSourceId).httpGet<any>({
+    http,
+    url: API_ENDPOINT_AUDITLOGGING,
+  });
   return rawConfiguration?.config;
 }

--- a/public/apps/configuration/utils/auth-view-utils.tsx
+++ b/public/apps/configuration/utils/auth-view-utils.tsx
@@ -15,9 +15,12 @@
 
 import { HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_SECURITYCONFIG } from '../constants';
-import { httpGet } from './request-utils';
+import { createRequestContextWithDataSourceId } from './request-utils';
 
-export async function getSecurityConfig(http: HttpStart) {
-  const rawSecurityConfig = await httpGet<any>(http, API_ENDPOINT_SECURITYCONFIG);
+export async function getSecurityConfig(http: HttpStart, dataSourceId: string) {
+  const rawSecurityConfig = await createRequestContextWithDataSourceId(dataSourceId).httpGet<any>({
+    http,
+    url: API_ENDPOINT_SECURITYCONFIG,
+  });
   return rawSecurityConfig.data.config.dynamic;
 }

--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -70,7 +70,12 @@ export function renderCustomization(reserved: boolean, props: UIProps) {
         <EuiIcon type={reserved ? 'lock' : 'pencil'} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
-        <EuiText className={props.cssClassName}>{reserved ? 'Reserved' : 'Custom'}</EuiText>
+        <EuiText
+          className={props.cssClassName}
+          data-test-subj={reserved ? 'filter-reserved' : 'filter-custom'}
+        >
+          {reserved ? 'Reserved' : 'Custom'}
+        </EuiText>
       </EuiFlexItem>
     </EuiFlexGroup>
   );

--- a/public/apps/configuration/utils/internal-user-detail-utils.tsx
+++ b/public/apps/configuration/utils/internal-user-detail-utils.tsx
@@ -16,17 +16,29 @@
 import { HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_INTERNALUSERS } from '../constants';
 import { InternalUser, InternalUserUpdate } from '../types';
-import { httpGet, httpPost } from './request-utils';
+import { createRequestContextWithDataSourceId } from './request-utils';
 import { getResourceUrl } from './resource-utils';
 
-export async function getUserDetail(http: HttpStart, username: string): Promise<InternalUser> {
-  return await httpGet<InternalUser>(http, getResourceUrl(API_ENDPOINT_INTERNALUSERS, username));
+export async function getUserDetail(
+  http: HttpStart,
+  username: string,
+  dataSourceId: string
+): Promise<InternalUser> {
+  return await createRequestContextWithDataSourceId(dataSourceId).httpGet<InternalUser>({
+    http,
+    url: getResourceUrl(API_ENDPOINT_INTERNALUSERS, username),
+  });
 }
 
 export async function updateUser(
   http: HttpStart,
   username: string,
-  updateObject: InternalUserUpdate
+  updateObject: InternalUserUpdate,
+  dataSourceId: string
 ): Promise<InternalUser> {
-  return await httpPost(http, getResourceUrl(API_ENDPOINT_INTERNALUSERS, username), updateObject);
+  return await createRequestContextWithDataSourceId(dataSourceId).httpPost({
+    http,
+    url: getResourceUrl(API_ENDPOINT_INTERNALUSERS, username),
+    body: updateObject,
+  });
 }

--- a/public/apps/configuration/utils/role-detail-utils.tsx
+++ b/public/apps/configuration/utils/role-detail-utils.tsx
@@ -16,13 +16,29 @@
 import { HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_ROLES } from '../constants';
 import { RoleDetail, RoleUpdate } from '../types';
-import { httpGet, httpPost } from './request-utils';
+import { createRequestContextWithDataSourceId } from './request-utils';
 import { getResourceUrl } from './resource-utils';
 
-export async function getRoleDetail(http: HttpStart, roleName: string): Promise<RoleDetail> {
-  return await httpGet<RoleDetail>(http, getResourceUrl(API_ENDPOINT_ROLES, roleName));
+export async function getRoleDetail(
+  http: HttpStart,
+  roleName: string,
+  dataSourceId: string
+): Promise<RoleDetail> {
+  return await createRequestContextWithDataSourceId(dataSourceId).httpGet<RoleDetail>({
+    http,
+    url: getResourceUrl(API_ENDPOINT_ROLES, roleName),
+  });
 }
 
-export async function updateRole(http: HttpStart, roleName: string, updateObject: RoleUpdate) {
-  return await httpPost(http, getResourceUrl(API_ENDPOINT_ROLES, roleName), updateObject);
+export async function updateRole(
+  http: HttpStart,
+  roleName: string,
+  updateObject: RoleUpdate,
+  dataSourceId: string
+) {
+  return await createRequestContextWithDataSourceId(dataSourceId).httpPost({
+    http,
+    url: getResourceUrl(API_ENDPOINT_ROLES, roleName),
+    body: updateObject,
+  });
 }

--- a/public/apps/configuration/utils/role-list-utils.tsx
+++ b/public/apps/configuration/utils/role-list-utils.tsx
@@ -16,7 +16,7 @@
 import { map, chain } from 'lodash';
 import { HttpStart } from '../../../../../../src/core/public';
 import { API_ENDPOINT_ROLES, API_ENDPOINT_ROLESMAPPING } from '../constants';
-import { httpDelete, httpDeleteWithIgnores, httpGet } from './request-utils';
+import { createRequestContextWithDataSourceId } from './request-utils';
 import { getResourceUrl } from './resource-utils';
 
 export interface RoleListing {
@@ -92,19 +92,32 @@ export function buildSearchFilterOptions(roleList: any[], attrName: string): Arr
 }
 
 // Submit request to delete given roles. No error handling in this function.
-export async function requestDeleteRoles(http: HttpStart, roles: string[]) {
+export async function requestDeleteRoles(http: HttpStart, roles: string[], dataSourceId: string) {
   for (const role of roles) {
-    await httpDelete(http, getResourceUrl(API_ENDPOINT_ROLES, role));
-    await httpDeleteWithIgnores(http, getResourceUrl(API_ENDPOINT_ROLESMAPPING, role), [404]);
+    await createRequestContextWithDataSourceId(dataSourceId).httpDelete({
+      http,
+      url: getResourceUrl(API_ENDPOINT_ROLES, role),
+    });
+    await createRequestContextWithDataSourceId(dataSourceId).httpDeleteWithIgnores({
+      http,
+      url: getResourceUrl(API_ENDPOINT_ROLESMAPPING, role),
+      ignores: [404],
+    });
   }
 }
 
 // TODO: have a type definition for it
-export function fetchRole(http: HttpStart): Promise<any> {
-  return httpGet<any>(http, API_ENDPOINT_ROLES);
+export function fetchRole(http: HttpStart, dataSourceId: string): Promise<any> {
+  return createRequestContextWithDataSourceId(dataSourceId).httpGet<any>({
+    http,
+    url: API_ENDPOINT_ROLES,
+  });
 }
 
 // TODO: have a type definition for it
-export function fetchRoleMapping(http: HttpStart): Promise<any> {
-  return httpGet<any>(http, API_ENDPOINT_ROLESMAPPING);
+export function fetchRoleMapping(http: HttpStart, dataSourceId: string): Promise<any> {
+  return createRequestContextWithDataSourceId(dataSourceId).httpGet<any>({
+    http,
+    url: API_ENDPOINT_ROLESMAPPING,
+  });
 }

--- a/public/apps/configuration/utils/role-mapping-utils.tsx
+++ b/public/apps/configuration/utils/role-mapping-utils.tsx
@@ -17,7 +17,7 @@ import { map } from 'lodash';
 import { HttpStart } from '../../../../../../src/core/public';
 import { API_ENDPOINT_ROLESMAPPING } from '../constants';
 import { RoleMappingDetail } from '../types';
-import { httpGetWithIgnores, httpPost } from './request-utils';
+import { createRequestContextWithDataSourceId } from './request-utils';
 import { getResourceUrl } from './resource-utils';
 
 export interface MappedUsersListing {
@@ -30,12 +30,12 @@ export enum UserType {
   external = 'Backend role',
 }
 
-export async function getRoleMappingData(http: HttpStart, roleName: string) {
-  return httpGetWithIgnores<RoleMappingDetail>(
+export async function getRoleMappingData(http: HttpStart, roleName: string, dataSourceId: string) {
+  return createRequestContextWithDataSourceId(dataSourceId).httpGetWithIgnores<RoleMappingDetail>({
     http,
-    getResourceUrl(API_ENDPOINT_ROLESMAPPING, roleName),
-    [404]
-  );
+    url: getResourceUrl(API_ENDPOINT_ROLESMAPPING, roleName),
+    ignores: [404],
+  });
 }
 
 export function transformRoleMappingData(rawData: RoleMappingDetail): MappedUsersListing[] {
@@ -55,7 +55,12 @@ export function transformRoleMappingData(rawData: RoleMappingDetail): MappedUser
 export async function updateRoleMapping(
   http: HttpStart,
   roleName: string,
-  updateObject: RoleMappingDetail
+  updateObject: RoleMappingDetail,
+  dataSourceId: string
 ) {
-  return await httpPost(http, getResourceUrl(API_ENDPOINT_ROLESMAPPING, roleName), updateObject);
+  return await createRequestContextWithDataSourceId(dataSourceId).httpPost({
+    http,
+    url: getResourceUrl(API_ENDPOINT_ROLESMAPPING, roleName),
+    body: updateObject,
+  });
 }

--- a/public/apps/configuration/utils/tenancy-config_util.tsx
+++ b/public/apps/configuration/utils/tenancy-config_util.tsx
@@ -15,14 +15,13 @@
 
 import { HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_TENANCY_CONFIGS } from '../constants';
-import { httpGet, httpPost } from './request-utils';
 import { TenancyConfigSettings } from '../panels/tenancy-config/types';
-
-export async function updateTenancyConfig(http: HttpStart, updateObject: TenancyConfigSettings) {
-  return await httpPost(http, API_ENDPOINT_TENANCY_CONFIGS, updateObject);
-}
+import { createLocalClusterRequestContext } from './request-utils';
 
 export async function getTenancyConfig(http: HttpStart): Promise<TenancyConfigSettings> {
-  const rawConfiguration = await httpGet<any>(http, API_ENDPOINT_TENANCY_CONFIGS);
+  const rawConfiguration = await createLocalClusterRequestContext().httpGet<any>({
+    http,
+    url: API_ENDPOINT_TENANCY_CONFIGS,
+  });
   return rawConfiguration;
 }

--- a/public/apps/configuration/utils/test/__snapshots__/display-utils.test.tsx.snap
+++ b/public/apps/configuration/utils/test/__snapshots__/display-utils.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Display utils Render Customization column when reserved = False 1`] = `
   >
     <EuiText
       className="table-items"
+      data-test-subj="filter-custom"
     >
       Custom
     </EuiText>
@@ -39,6 +40,7 @@ exports[`Display utils Render Customization column when reserved = True 1`] = `
   >
     <EuiText
       className="table-items"
+      data-test-subj="filter-reserved"
     >
       Reserved
     </EuiText>

--- a/public/apps/configuration/utils/test/internal-user-list-utils.test.tsx
+++ b/public/apps/configuration/utils/test/internal-user-list-utils.test.tsx
@@ -13,7 +13,16 @@
  *   permissions and limitations under the License.
  */
 
-import { transformUserData } from '../internal-user-list-utils';
+import { fetchUserNameList, getUserList, transformUserData } from '../internal-user-list-utils';
+// Import RequestContext
+
+const mockedHttpGet = jest.fn().mockResolvedValue({ data: {} });
+
+jest.mock('../../utils/request-utils', () => ({
+  createRequestContextWithDataSourceId: jest.fn(() => ({
+    httpGet: mockedHttpGet,
+  })),
+}));
 
 describe('Internal user list utils', () => {
   const userList = {
@@ -31,5 +40,57 @@ describe('Internal user list utils', () => {
       },
     ];
     expect(result).toEqual(expectedUserList);
+  });
+
+  it('getUserList calls httpGet with the correct parameters for internal users', async () => {
+    const httpMock = {}; // Mock HttpStart object
+    const userType = 'internalaccounts';
+
+    const test = await getUserList(httpMock, userType, 'test');
+
+    expect(mockedHttpGet).toHaveBeenCalledWith({
+      http: httpMock,
+      url: '/api/v1/configuration/internalaccounts',
+    });
+    expect(test).toEqual([]);
+  });
+
+  it('getUserList calls httpGet with the correct parameters for service accounts', async () => {
+    const httpMock = {};
+    const userType = 'serviceAccounts';
+
+    const test = await getUserList(httpMock, userType, 'test');
+
+    expect(mockedHttpGet).toHaveBeenCalledWith({
+      http: httpMock,
+      url: '/api/v1/configuration/serviceaccounts',
+    });
+    expect(test).toEqual([]);
+  });
+
+  it('fetchUserNameList calls httpGet with the correct parameters for service accounts', async () => {
+    const httpMock = {};
+    const userType = 'serviceAccounts';
+
+    const test = await fetchUserNameList(httpMock, userType, '');
+
+    expect(mockedHttpGet).toHaveBeenCalledWith({
+      http: httpMock,
+      url: '/api/v1/configuration/serviceaccounts',
+    });
+    expect(test).toEqual([]);
+  });
+
+  it('fetchUserNameList calls httpGet with the correct parameters for internal users', async () => {
+    const httpMock = {};
+    const userType = 'internalaccounts';
+
+    const test = await fetchUserNameList(httpMock, userType, '');
+
+    expect(mockedHttpGet).toHaveBeenCalledWith({
+      http: httpMock,
+      url: '/api/v1/configuration/internalaccounts',
+    });
+    expect(test).toEqual([]);
   });
 });

--- a/public/apps/configuration/utils/test/internal-user-list-utils.test.tsx
+++ b/public/apps/configuration/utils/test/internal-user-list-utils.test.tsx
@@ -50,33 +50,7 @@ describe('Internal user list utils', () => {
 
     expect(mockedHttpGet).toHaveBeenCalledWith({
       http: httpMock,
-      url: '/api/v1/configuration/internalaccounts',
-    });
-    expect(test).toEqual([]);
-  });
-
-  it('getUserList calls httpGet with the correct parameters for service accounts', async () => {
-    const httpMock = {};
-    const userType = 'serviceAccounts';
-
-    const test = await getUserList(httpMock, userType, 'test');
-
-    expect(mockedHttpGet).toHaveBeenCalledWith({
-      http: httpMock,
-      url: '/api/v1/configuration/serviceaccounts',
-    });
-    expect(test).toEqual([]);
-  });
-
-  it('fetchUserNameList calls httpGet with the correct parameters for service accounts', async () => {
-    const httpMock = {};
-    const userType = 'serviceAccounts';
-
-    const test = await fetchUserNameList(httpMock, userType, '');
-
-    expect(mockedHttpGet).toHaveBeenCalledWith({
-      http: httpMock,
-      url: '/api/v1/configuration/serviceaccounts',
+      url: '/api/v1/configuration/internalusers',
     });
     expect(test).toEqual([]);
   });
@@ -89,7 +63,7 @@ describe('Internal user list utils', () => {
 
     expect(mockedHttpGet).toHaveBeenCalledWith({
       http: httpMock,
-      url: '/api/v1/configuration/internalaccounts',
+      url: '/api/v1/configuration/internalusers',
     });
     expect(test).toEqual([]);
   });

--- a/public/apps/configuration/utils/test/request-utils.test.ts
+++ b/public/apps/configuration/utils/test/request-utils.test.ts
@@ -1,0 +1,48 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+import * as requestUtils from '../request-utils';
+import { HttpStart } from 'opensearch-dashboards/public';
+
+describe('RequestContext', () => {
+  let httpMock: HttpStart;
+
+  beforeEach(() => {
+    // Mocking HttpStart
+    httpMock = {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should error if no dataSourceId is passed', () => {
+    expect(() => createRequestContextWithDataSourceId()).toThrowError();
+  });
+
+  it('should have the correct query based on the passed dataSourceId', () => {
+    const context = requestUtils.createRequestContextWithDataSourceId('test');
+    expect(context.query).toEqual({ dataSourceId: 'test' });
+  });
+
+  it('should have the correct query based on local cluster context', () => {
+    const context = requestUtils.createLocalClusterRequestContext();
+    expect(context.query).toEqual({ dataSourceId: '' });
+  });
+});

--- a/public/apps/configuration/utils/test/toast-utils.test.tsx
+++ b/public/apps/configuration/utils/test/toast-utils.test.tsx
@@ -101,21 +101,30 @@ describe('Toast utils', () => {
 
   describe('getSuccessToastMessage', () => {
     it('should return successful create message', () => {
-      const result = getSuccessToastMessage('User', 'create', 'user1');
+      const result = getSuccessToastMessage('User', 'create', 'user1', false, { id: '' });
 
-      expect(result).toEqual('User "user1" successfully created');
+      expect(result).toEqual('User "user1" successfully created ');
     });
 
     it('should return successful update message', () => {
-      const result = getSuccessToastMessage('Role', 'edit', 'role1');
+      const result = getSuccessToastMessage('Role', 'edit', 'role1', false, { id: '' });
 
-      expect(result).toEqual('Role "role1" successfully updated');
+      expect(result).toEqual('Role "role1" successfully updated ');
     });
 
     it('should return empty message for unknown action', () => {
-      const result = getSuccessToastMessage('User', '', 'user1');
+      const result = getSuccessToastMessage('User', '', 'user1', false, { id: '' });
 
       expect(result).toEqual('');
+    });
+
+    it('should return successful update message for remote cluster', () => {
+      const result = getSuccessToastMessage('Role', 'edit', 'role1', true, {
+        id: '',
+        label: 'blah',
+      });
+
+      expect(result).toEqual('Role "role1" successfully updated for blah');
     });
   });
 });

--- a/public/apps/configuration/utils/toast-utils.tsx
+++ b/public/apps/configuration/utils/toast-utils.tsx
@@ -15,6 +15,8 @@
 
 import { Toast } from '@elastic/eui/src/components/toast/global_toast_list';
 import { useState, useCallback } from 'react';
+import { getClusterInfo } from '../../../utils/datasource-utils';
+import { DataSourceOption } from '../../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
 
 export function createErrorToast(id: string, title: string, text: string): Toast {
   return {
@@ -66,14 +68,22 @@ export function useToastState(): [Toast[], (toAdd: Toast) => void, (toDelete: To
 export function getSuccessToastMessage(
   resourceType: string,
   action: string,
-  userName: string
+  userName: string,
+  dataSourceEnabled: boolean,
+  dataSource: DataSourceOption
 ): string {
   switch (action) {
     case 'create':
     case 'duplicate':
-      return `${resourceType} "${userName}" successfully created`;
+      return `${resourceType} "${userName}" successfully created ${getClusterInfo(
+        dataSourceEnabled,
+        dataSource
+      )}`;
     case 'edit':
-      return `${resourceType} "${userName}" successfully updated`;
+      return `${resourceType} "${userName}" successfully updated ${getClusterInfo(
+        dataSourceEnabled,
+        dataSource
+      )}`;
     default:
       return '';
   }

--- a/public/apps/types.ts
+++ b/public/apps/types.ts
@@ -13,15 +13,17 @@
  *   permissions and limitations under the License.
  */
 
+import { DataSourceManagementPluginSetup } from '../../../../src/plugins/data_source_management/public';
 import { AppMountParameters, CoreStart } from '../../../../src/core/public';
 import { SecurityPluginStartDependencies, ClientConfigType, DashboardsInfo } from '../types';
 
 export interface AppDependencies {
   coreStart: CoreStart;
-  navigation: SecurityPluginStartDependencies;
+  depsStart: SecurityPluginStartDependencies;
   params: AppMountParameters;
   config: ClientConfigType;
   dashboardsInfo: DashboardsInfo;
+  dataSourceManagement: DataSourceManagementPluginSetup;
 }
 
 export interface BreadcrumbsPageDependencies extends AppDependencies {

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -112,7 +112,13 @@ export class SecurityPlugin
           excludeFromDisabledTransportCategories(config.disabledTransportCategories.exclude);
           excludeFromDisabledRestCategories(config.disabledRestCategories.exclude);
 
-          return renderApp(coreStart, depsStart as SecurityPluginStartDependencies, params, config);
+          return renderApp(
+            coreStart,
+            depsStart as SecurityPluginStartDependencies,
+            params,
+            config,
+            deps.dataSourceManagement
+          );
         },
         category: DEFAULT_APP_CATEGORIES.management,
       });

--- a/public/types.ts
+++ b/public/types.ts
@@ -19,6 +19,8 @@ import {
   SavedObjectsManagementPluginStart,
 } from '../../../src/plugins/saved_objects_management/public';
 import { ManagementOverViewPluginSetup } from '../../../src/plugins/management_overview/public';
+import { DataSourcePluginStart } from '../../../src/plugins/data_source/public/types';
+import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SecurityPluginSetup {}
@@ -28,11 +30,18 @@ export interface SecurityPluginStart {}
 export interface SecurityPluginSetupDependencies {
   savedObjectsManagement: SavedObjectsManagementPluginSetup;
   managementOverview?: ManagementOverViewPluginSetup;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
+}
+
+export interface Cluster {
+  id: string;
+  label: string;
 }
 
 export interface SecurityPluginStartDependencies {
   navigation: NavigationPublicPluginStart;
   savedObjectsManagement: SavedObjectsManagementPluginStart;
+  dataSource?: DataSourcePluginStart;
 }
 
 export interface AuthInfo {

--- a/public/utils/auth-info-utils.tsx
+++ b/public/utils/auth-info-utils.tsx
@@ -15,11 +15,14 @@
 
 import { HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_AUTHINFO } from '../../common';
-import { httpGet } from '../apps/configuration/utils/request-utils';
 import { AuthInfo } from '../types';
+import { createLocalClusterRequestContext } from '../apps/configuration/utils/request-utils';
 
 export async function getAuthInfo(http: HttpStart) {
-  return await httpGet<AuthInfo>(http, API_ENDPOINT_AUTHINFO);
+  return await createLocalClusterRequestContext().httpGet<AuthInfo>({
+    http,
+    url: API_ENDPOINT_AUTHINFO,
+  });
 }
 
 export async function getCurrentUser(http: HttpStart) {

--- a/public/utils/dashboards-info-utils.tsx
+++ b/public/utils/dashboards-info-utils.tsx
@@ -15,13 +15,20 @@
 
 import { HttpStart } from 'opensearch-dashboards/public';
 import { API_ENDPOINT_DASHBOARDSINFO } from '../../common';
-import { httpGet, httpGetWithIgnores } from '../apps/configuration/utils/request-utils';
 import { DashboardsInfo } from '../types';
+import { createLocalClusterRequestContext } from '../apps/configuration/utils/request-utils';
 
 export async function getDashboardsInfo(http: HttpStart) {
-  return await httpGet<DashboardsInfo>(http, API_ENDPOINT_DASHBOARDSINFO);
+  return await createLocalClusterRequestContext().httpGet<DashboardsInfo>({
+    http,
+    url: API_ENDPOINT_DASHBOARDSINFO,
+  });
 }
 
 export async function getDashboardsInfoSafe(http: HttpStart): Promise<DashboardsInfo | undefined> {
-  return httpGetWithIgnores<DashboardsInfo>(http, API_ENDPOINT_DASHBOARDSINFO, [401]);
+  return createLocalClusterRequestContext().httpGetWithIgnores<DashboardsInfo>({
+    http,
+    url: API_ENDPOINT_DASHBOARDSINFO,
+    ignores: [401],
+  });
 }

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -1,0 +1,41 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
+
+export function createDataSourceQuery(dataSourceId: string) {
+  return { dataSourceId };
+}
+
+const DATASOURCEURLKEY = 'dataSource';
+
+export function getClusterInfo(dataSourceEnabled: boolean, cluster: DataSourceOption) {
+  if (dataSourceEnabled) {
+    return `for ${cluster.label || 'Local cluster'}`;
+  }
+  return '';
+}
+
+export function getDataSourceFromUrl(): DataSourceOption {
+  const urlParams = new URLSearchParams(window.location.search);
+  const dataSourceParam = (urlParams && urlParams.get(DATASOURCEURLKEY)) || '{}';
+  return JSON.parse(dataSourceParam);
+}
+
+export function setDataSourceInUrl(dataSource: DataSourceOption) {
+  const url = new URL(window.location.href);
+  url.searchParams.set(DATASOURCEURLKEY, JSON.stringify(dataSource));
+  window.history.replaceState({}, '', url.toString());
+}

--- a/public/utils/login-utils.tsx
+++ b/public/utils/login-utils.tsx
@@ -14,15 +14,19 @@
  */
 
 import { HttpStart } from 'opensearch-dashboards/public';
-import { httpPost } from '../apps/configuration/utils/request-utils';
+import { createLocalClusterRequestContext } from '../apps/configuration/utils/request-utils';
 
 export async function validateCurrentPassword(
   http: HttpStart,
   userName: string,
   currentPassword: string
 ): Promise<void> {
-  await httpPost(http, '/auth/login', {
-    username: userName,
-    password: currentPassword,
+  await createLocalClusterRequestContext().httpPost({
+    http,
+    url: '/auth/login',
+    body: {
+      username: userName,
+      password: currentPassword,
+    },
   });
 }

--- a/public/utils/logout-utils.tsx
+++ b/public/utils/logout-utils.tsx
@@ -19,7 +19,7 @@ import {
   IHttpInterceptController,
 } from '../../../../src/core/public';
 import { API_ENDPOINT_AUTHTYPE, CUSTOM_ERROR_PAGE_URI, LOGIN_PAGE_URI } from '../../common';
-import { httpGet } from '../apps/configuration/utils/request-utils';
+import { createLocalClusterRequestContext } from '../apps/configuration/utils/request-utils';
 import { setShouldShowTenantPopup } from './storage-utils';
 
 export function interceptError(logoutUrl: string, thisWindow: Window): any {
@@ -47,5 +47,8 @@ export function interceptError(logoutUrl: string, thisWindow: Window): any {
 }
 
 export async function fetchCurrentAuthType(http: HttpStart): Promise<any> {
-  return await httpGet(http, API_ENDPOINT_AUTHTYPE);
+  return await createLocalClusterRequestContext().httpGet({
+    http,
+    url: API_ENDPOINT_AUTHTYPE,
+  });
 }

--- a/public/utils/test/datasource-utils.test.ts
+++ b/public/utils/test/datasource-utils.test.ts
@@ -1,0 +1,81 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import {
+  createDataSourceQuery,
+  getClusterInfo,
+  getDataSourceFromUrl,
+  setDataSourceInUrl,
+} from '../datasource-utils';
+
+describe('Tests datasource utils', () => {
+  it('Tests the GetClusterDescription helper function', () => {
+    expect(getClusterInfo(false, { id: 'blah', label: 'blah' })).toBe('');
+    expect(getClusterInfo(true, { id: '', label: '' })).toBe('for Local cluster');
+    expect(getClusterInfo(true, { id: 'test', label: 'test' })).toBe('for test');
+  });
+
+  it('Tests the create DataSource query helper function', () => {
+    expect(createDataSourceQuery('test')).toStrictEqual({ dataSourceId: 'test' });
+  });
+
+  it('Tests getting the datasource from the url', () => {
+    const mockSearchNoDataSourceId = '?foo=bar&baz=qux';
+    Object.defineProperty(window, 'location', {
+      value: { search: mockSearchNoDataSourceId },
+      writable: true,
+    });
+    expect(getDataSourceFromUrl()).toEqual({});
+    const mockSearchDataSourceIdNotfirst =
+      '?foo=bar&baz=qux&dataSource=%7B"id"%3A"94ffa650-f11a-11ee-a585-793f7b098e1a"%2C"label"%3A"9202"%7D';
+    Object.defineProperty(window, 'location', {
+      value: { search: mockSearchDataSourceIdNotfirst },
+      writable: true,
+    });
+    expect(getDataSourceFromUrl()).toEqual({
+      id: '94ffa650-f11a-11ee-a585-793f7b098e1a',
+      label: '9202',
+    });
+    const mockSearchDataSourceIdFirst =
+      '?dataSource=%7B"id"%3A"94ffa650-f11a-11ee-a585-793f7b098e1a"%2C"label"%3A"9202"%7D';
+    Object.defineProperty(window, 'location', {
+      value: { search: mockSearchDataSourceIdFirst },
+      writable: true,
+    });
+    expect(getDataSourceFromUrl()).toEqual({
+      id: '94ffa650-f11a-11ee-a585-793f7b098e1a',
+      label: '9202',
+    });
+  });
+
+  it('Tests setting the datasource in the url', () => {
+    const replaceState = jest.fn();
+    const mockUrl = 'http://localhost:5601/app/security-dashboards-plugin#/auth';
+    Object.defineProperty(window, 'location', {
+      value: { href: mockUrl },
+      writable: true,
+    });
+    Object.defineProperty(window, 'history', {
+      value: { replaceState },
+      writable: true,
+    });
+    setDataSourceInUrl({ id: '', label: 'Local cluster' });
+    expect(replaceState).toBeCalledWith(
+      {},
+      '',
+      'http://localhost:5601/app/security-dashboards-plugin?dataSource=%7B%22id%22%3A%22%22%2C%22label%22%3A%22Local+cluster%22%7D#/auth'
+    );
+  });
+});

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -19,11 +19,13 @@ import {
   ResponseError,
   IOpenSearchDashboardsResponse,
   OpenSearchDashboardsResponseFactory,
+  RequestHandlerContext,
+  OpenSearchDashboardsRequest,
 } from 'opensearch-dashboards/server';
 import { API_PREFIX, CONFIGURATION_API_PREFIX, isValidResourceName } from '../../common';
 
 // TODO: consider to extract entity CRUD operations and put it into a client class
-export function defineRoutes(router: IRouter) {
+export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
   const internalUserSchema = schema.object({
     description: schema.maybe(schema.string()),
     password: schema.maybe(schema.string()),
@@ -238,6 +240,9 @@ export function defineRoutes(router: IRouter) {
         params: schema.object({
           resourceName: schema.string(),
         }),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (
@@ -245,12 +250,14 @@ export function defineRoutes(router: IRouter) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.listResource', {
-          resourceName: request.params.resourceName,
-        });
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.listResource',
+          { resourceName: request.params.resourceName }
+        );
         return response.ok({
           body: {
             total: Object.keys(esResp).length,
@@ -343,6 +350,9 @@ export function defineRoutes(router: IRouter) {
           resourceName: schema.string(),
           id: schema.string(),
         }),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (
@@ -350,13 +360,17 @@ export function defineRoutes(router: IRouter) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.getResource', {
-          resourceName: request.params.resourceName,
-          id: request.params.id,
-        });
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.getResource',
+          {
+            resourceName: request.params.resourceName,
+            id: request.params.id,
+          }
+        );
         return response.ok({ body: esResp[request.params.id] });
       } catch (error) {
         return errorResponse(response, error);
@@ -377,6 +391,9 @@ export function defineRoutes(router: IRouter) {
             minLength: 1,
           }),
         }),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (
@@ -384,13 +401,17 @@ export function defineRoutes(router: IRouter) {
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.deleteResource', {
-          resourceName: request.params.resourceName,
-          id: request.params.id,
-        });
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.deleteResource',
+          {
+            resourceName: request.params.resourceName,
+            id: request.params.id,
+          }
+        );
         return response.ok({
           body: {
             message: esResp.message,
@@ -420,6 +441,9 @@ export function defineRoutes(router: IRouter) {
           resourceName: schema.string(),
         }),
         body: schema.any(),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (
@@ -432,13 +456,17 @@ export function defineRoutes(router: IRouter) {
       } catch (error) {
         return response.badRequest({ body: error });
       }
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.saveResourceWithoutId', {
-          resourceName: request.params.resourceName,
-          body: request.body,
-        });
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.saveResourceWithoutId',
+          {
+            resourceName: request.params.resourceName,
+            body: request.body,
+          }
+        );
         return response.ok({
           body: {
             message: esResp.message,
@@ -464,6 +492,9 @@ export function defineRoutes(router: IRouter) {
           }),
         }),
         body: schema.any(),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (
@@ -476,14 +507,18 @@ export function defineRoutes(router: IRouter) {
       } catch (error) {
         return response.badRequest({ body: error });
       }
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.saveResource', {
-          resourceName: request.params.resourceName,
-          id: request.params.id,
-          body: request.body,
-        });
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.saveResource',
+          {
+            resourceName: request.params.resourceName,
+            id: request.params.id,
+            body: request.body,
+          }
+        );
         return response.ok({
           body: {
             message: esResp.message,
@@ -625,18 +660,24 @@ export function defineRoutes(router: IRouter) {
   router.get(
     {
       path: `${API_PREFIX}/configuration/audit`,
-      validate: false,
+      validate: {
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
     },
     async (
       context,
       request,
       response
     ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      const client = context.security_plugin.esClient.asScoped(request);
-
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.getAudit');
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.getAudit'
+        );
 
         return response.ok({
           body: esResp,
@@ -710,15 +751,22 @@ export function defineRoutes(router: IRouter) {
       path: `${API_PREFIX}/configuration/audit/config`,
       validate: {
         body: schema.any(),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
       },
     },
     async (context, request, response) => {
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResp;
       try {
-        esResp = await client.callAsCurrentUser('opensearch_security.saveAudit', {
-          body: request.body,
-        });
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.saveAudit',
+          {
+            body: request.body,
+          }
+        );
         return response.ok({
           body: {
             message: esResp.message,
@@ -738,16 +786,23 @@ export function defineRoutes(router: IRouter) {
   router.delete(
     {
       path: `${API_PREFIX}/configuration/cache`,
-      validate: false,
+      validate: {
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
     },
     async (context, request, response) => {
-      const client = context.security_plugin.esClient.asScoped(request);
-      let esResponse;
       try {
-        esResponse = await client.callAsCurrentUser('opensearch_security.clearCache');
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.clearCache'
+        );
         return response.ok({
           body: {
-            message: esResponse.message,
+            message: esResp.message,
           },
         });
       } catch (error) {
@@ -875,6 +930,27 @@ export function defineRoutes(router: IRouter) {
     }
   );
 }
+
+/**
+ * A helper function to wrap API calls with the appropriate client. If the multiple datasources feature is disabled, it will use
+ * the existing client provided by the security plugin. Otherwise, it will use the one provided by the datasource plugin based on the id
+ * that we extract via the UI.
+ */
+const wrapRouteWithDataSource = async (
+  dataSourceEnabled: boolean,
+  context: RequestHandlerContext,
+  request: OpenSearchDashboardsRequest<unknown, any, any>,
+  endpoint: string,
+  body?: Record<string, string>
+) => {
+  if (!dataSourceEnabled || !request.query?.dataSourceId) {
+    const client = context.security_plugin.esClient.asScoped(request);
+    return await client.callAsCurrentUser(endpoint, body);
+  } else {
+    const client = context.dataSource.opensearch.legacy.getClient(request.query?.dataSourceId);
+    return await client.callAPI(endpoint, body);
+  }
+};
 
 function parseEsErrorResponse(error: any) {
   if (error.response) {

--- a/test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js
@@ -1,0 +1,27 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+describe('Multi-datasources enabled', () => {
+  it('Sanity checks the cluster selector is not visible when multi datasources is disabled', () => {
+    localStorage.setItem('opendistro::security::tenant::saved', '""');
+    localStorage.setItem('home:newThemeModal:show', 'false');
+
+    cy.visit('http://localhost:5601/app/security-dashboards-plugin#/getstarted', {
+      failOnStatusCode: false,
+    });
+
+    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').should('not.exist');
+  });
+});

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -162,15 +162,6 @@ describe('Multi-datasources enabled', () => {
     cy.get('[data-test-subj="dataSourceViewButton"]').should('contain', 'Local cluster');
   });
 
-  it('Checks Service Accounts Tab', () => {
-    // Datasource is locked to local cluster for service accounts tab
-    cy.visit(
-      `http://localhost:5601/app/security-dashboards-plugin${localDataSourceUrl}#/serviceAccounts`
-    );
-
-    cy.get('[data-test-subj="dataSourceViewButton"]').should('contain', 'Local cluster');
-  });
-
   it('Checks Audit Logs Tab', () => {
     cy.request({
       method: 'POST',

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -1,0 +1,240 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+const createDataSource = () => {
+  return cy.request({
+    method: 'POST',
+    url: `${Cypress.config('baseUrl')}/api/saved_objects/data-source`,
+    headers: {
+      'osd-xsrf': true,
+    },
+    body: {
+      attributes: {
+        title: Cypress.env('externalDataSourceLabel'),
+        endpoint: Cypress.env('externalDataSourceEndpoint'),
+        auth: {
+          type: 'username_password',
+          credentials: {
+            username: Cypress.env('externalDataSourceAdminUserName'),
+            password: Cypress.env('externalDataSourceAdminPassword'),
+          },
+        },
+      },
+    },
+  });
+};
+
+const deleteAllDataSources = () => {
+  cy.request(
+    'GET',
+    `${Cypress.config(
+      'baseUrl'
+    )}/api/saved_objects/_find?fields=id&fields=description&fields=title&per_page=10000&type=data-source`
+  ).then((resp) => {
+    if (resp && resp.body && resp.body.saved_objects) {
+      resp.body.saved_objects.map(({ id }) => {
+        cy.request({
+          method: 'DELETE',
+          url: `${Cypress.config('baseUrl')}/api/saved_objects/data-source/${id}`,
+          body: { force: false },
+          headers: {
+            'osd-xsrf': true,
+          },
+        });
+      });
+    }
+  });
+};
+
+const createUrlParam = (label, id) => {
+  const dataSourceObj = { label, id };
+  return `?dataSource=${JSON.stringify(dataSourceObj).toString()}`;
+};
+
+let externalDataSourceId;
+let externalDataSourceUrl;
+let localDataSourceUrl;
+
+describe('Multi-datasources enabled', () => {
+  beforeEach(() => {
+    localStorage.setItem('opendistro::security::tenant::saved', '""');
+    localStorage.setItem('home:newThemeModal:show', 'false');
+    createDataSource().then((resp) => {
+      if (resp && resp.body) {
+        externalDataSourceId = resp.body.id;
+      }
+      externalDataSourceUrl = createUrlParam(
+        Cypress.env('externalDataSourceLabel'),
+        externalDataSourceId
+      );
+      localDataSourceUrl = createUrlParam('Local cluster', '');
+    });
+  });
+
+  afterEach(() => {
+    cy.clearCookies();
+    cy.clearAllLocalStorage();
+    cy.clearAllSessionStorage();
+    deleteAllDataSources();
+  });
+
+  it('Checks Get Started Tab', () => {
+    // Remote cluster purge cache
+    cy.visit(
+      `http://localhost:5601/app/security-dashboards-plugin${externalDataSourceUrl}#/getstarted`
+    );
+
+    cy.contains('h1', 'Get started');
+    cy.get('[data-test-subj="dataSourceSelectableButton"]').should('contain', '9202');
+
+    cy.get('[data-test-subj="purge-cache"]').click();
+    cy.get('[class="euiToast euiToast--success euiGlobalToastListItem"]')
+      .get('.euiToastHeader__title')
+      .should('contain', 'successful for 9202');
+  });
+
+  it('Checks Auth Tab', () => {
+    cy.visit(`http://localhost:5601/app/security-dashboards-plugin${externalDataSourceUrl}#/auth`);
+
+    cy.get('.panel-header-count').first().invoke('text').should('contain', '(1)');
+  });
+
+  it('Checks Users Tab', () => {
+    cy.request({
+      method: 'POST',
+      url: `http://localhost:5601/api/v1/configuration/internalusers/9202-user?dataSourceId=${externalDataSourceId}`,
+      headers: {
+        'osd-xsrf': true,
+      },
+      body: {
+        backend_roles: [''],
+        attributes: {},
+        password: 'myStrongPassword12345678!',
+      },
+    }).then(() => {
+      cy.visit(
+        `http://localhost:5601/app/security-dashboards-plugin${externalDataSourceUrl}#/users`
+      );
+
+      cy.get('[data-test-subj="tableHeaderCell_username_0"]').click();
+      cy.get('[data-test-subj="checkboxSelectRow-9202-user"]').should('exist');
+    });
+  });
+
+  it('Checks Permissions Tab', () => {
+    cy.request({
+      method: 'POST',
+      url: `http://localhost:5601/api/v1/configuration/actiongroups/9202-permission?dataSourceId=${externalDataSourceId}`,
+      headers: {
+        'osd-xsrf': true,
+      },
+      body: {
+        allowed_actions: [],
+      },
+    }).then(() => {
+      cy.visit(
+        `http://localhost:5601/app/security-dashboards-plugin${externalDataSourceUrl}#/permissions`
+      );
+
+      // Permission exists on the remote data source
+      cy.get('[data-test-subj="tableHeaderCell_name_0"]').click();
+      cy.get('[data-test-subj="checkboxSelectRow-9202-permission"]').should('exist');
+    });
+  });
+
+  it('Checks Tenancy Tab', () => {
+    // Datasource is locked to local cluster for tenancy tab
+    cy.visit(`http://localhost:5601/app/security-dashboards-plugin${localDataSourceUrl}#/tenants`);
+
+    cy.contains('h1', 'Dashboards multi-tenancy');
+    cy.get('[data-test-subj="dataSourceViewButton"]').should('contain', 'Local cluster');
+  });
+
+  it('Checks Service Accounts Tab', () => {
+    // Datasource is locked to local cluster for service accounts tab
+    cy.visit(
+      `http://localhost:5601/app/security-dashboards-plugin${localDataSourceUrl}#/serviceAccounts`
+    );
+
+    cy.get('[data-test-subj="dataSourceViewButton"]').should('contain', 'Local cluster');
+  });
+
+  it('Checks Audit Logs Tab', () => {
+    cy.request({
+      method: 'POST',
+      url: `http://localhost:5601/api/v1/configuration/audit/config?dataSourceId=${externalDataSourceId}`,
+      headers: {
+        'osd-xsrf': true,
+      },
+      body: {
+        compliance: {
+          enabled: true,
+          write_log_diffs: false,
+          read_watched_fields: {},
+          read_ignore_users: ['kibanaserver'],
+          write_watched_indices: [],
+          write_ignore_users: ['kibanaserver'],
+          internal_config: false,
+          read_metadata_only: false,
+          write_metadata_only: false,
+          external_config: false,
+        },
+        enabled: false,
+        audit: {
+          ignore_users: ['kibanaserver'],
+          ignore_requests: [],
+          disabled_rest_categories: ['AUTHENTICATED', 'GRANTED_PRIVILEGES'],
+          disabled_transport_categories: ['AUTHENTICATED', 'GRANTED_PRIVILEGES'],
+          log_request_body: true,
+          resolve_indices: true,
+          resolve_bulk_requests: false,
+          enable_transport: true,
+          enable_rest: true,
+          exclude_sensitive_headers: true,
+        },
+      },
+    }).then(() => {
+      cy.visit(
+        `http://localhost:5601/app/security-dashboards-plugin${externalDataSourceUrl}#/auditLogging`
+      );
+      cy.get('[class="euiSwitch__label"]').should('contain', 'Disabled');
+    });
+  });
+
+  it('Checks Roles Tab', () => {
+    cy.request({
+      method: 'POST',
+      url: `http://localhost:5601/api/v1/configuration/roles/9202-role?dataSourceId=${externalDataSourceId}`,
+      headers: {
+        'osd-xsrf': true,
+      },
+      body: {
+        cluster_permissions: [],
+        index_permissions: [],
+        tenant_permissions: [],
+      },
+    }).then(() => {
+      cy.visit(
+        `http://localhost:5601/app/security-dashboards-plugin${externalDataSourceUrl}#/roles`
+      );
+
+      cy.get('[data-test-subj="dataSourceSelectableButton"]').should('contain', '9202');
+      cy.get('[data-test-subj="tableHeaderCell_roleName_0"]').click();
+      cy.get('[data-test-subj="checkboxSelectRow-9202-role"]').should('exist');
+
+      // role exists on the remote
+    });
+  });
+});

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -91,6 +91,20 @@ Cypress.Commands.add('loginWithSamlMultiauth', () => {
   cy.get('button[id=btn-sign-in]').should('be.visible').click();
 });
 
+if (Cypress.env('LOGIN_AS_ADMIN')) {
+  // Define custom cy.visit() only if LOGIN_AS_ADMIN is true
+  Cypress.Commands.overwrite('visit', (orig, url, options = {}) => {
+    if (Cypress.env('LOGIN_AS_ADMIN')) {
+      options.auth = ADMIN_AUTH;
+      options.failOnStatusCode = false;
+      options.qs = {
+        security_tenant: 'private',
+      };
+    }
+    orig(url, options);
+  });
+}
+
 Cypress.Commands.add('shortenUrl', (data, tenant) => {
   cy.request({
     url: `http://localhost:5601${DASHBOARDS_API.SHORTEN_URL}`,

--- a/test/helper/entity_operation.ts
+++ b/test/helper/entity_operation.ts
@@ -33,3 +33,48 @@ export async function getEntityAsAdmin(root: Root, entityType: string, entityId:
     .get(root, `/api/v1/configuration/${entityType}/${entityId}`)
     .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
 }
+
+export async function createOrUpdateEntityAsAdminWithDataSource(
+  root: Root,
+  entityType: string,
+  entityId: string,
+  body: any,
+  dataSourceId: string
+) {
+  return await osdTestServer.request
+    .post(root, `/api/v1/configuration/${entityType}/${entityId}?dataSourceId=${dataSourceId}`)
+    .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS)
+    .send(body);
+}
+
+export async function getEntityAsAdminWithDataSource(
+  root: Root,
+  entityType: string,
+  entityId: string,
+  dataSourceId: string
+) {
+  return await osdTestServer.request
+    .get(root, `/api/v1/configuration/${entityType}/${entityId}?dataSourceId=${dataSourceId}`)
+    .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
+}
+
+export async function getAllEntitiesAsAdminWithDataSource(
+  root: Root,
+  entityType: string,
+  dataSourceId: string
+) {
+  return await osdTestServer.request
+    .get(root, `/api/v1/configuration/${entityType}?dataSourceId=${dataSourceId}`)
+    .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
+}
+
+export async function deleteEntityAsAdminWithDataSource(
+  root: Root,
+  entityType: string,
+  entityId: string,
+  dataSourceId: string
+) {
+  return await osdTestServer.request
+    .delete(root, `/api/v1/configuration/${entityType}/${entityId}?dataSourceId=${dataSourceId}`)
+    .set(AUTHORIZATION_HEADER_NAME, ADMIN_CREDENTIALS);
+}

--- a/test/jest_integration/constants.ts
+++ b/test/jest_integration/constants.ts
@@ -1,0 +1,74 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+export const testAuditLogDisabledSettings = {
+  enabled: false,
+  audit: {
+    enable_rest: false,
+    disabled_rest_categories: ['FAILED_LOGIN', 'AUTHENTICATED'],
+    enable_transport: true,
+    disabled_transport_categories: ['GRANTED_PRIVILEGES'],
+    resolve_bulk_requests: true,
+    log_request_body: false,
+    resolve_indices: true,
+    exclude_sensitive_headers: true,
+    ignore_users: ['admin'],
+    ignore_requests: ['SearchRequest', 'indices:data/read/*'],
+  },
+  compliance: {
+    enabled: true,
+    internal_config: false,
+    external_config: false,
+    read_metadata_only: false,
+    read_watched_fields: {
+      indexName1: ['field1', 'fields-*'],
+    },
+    read_ignore_users: ['opensearchdashboardsserver', 'operator/*'],
+    write_metadata_only: false,
+    write_log_diffs: false,
+    write_watched_indices: ['indexName2', 'indexPatterns-*'],
+    write_ignore_users: ['admin'],
+  },
+};
+
+export const testAuditLogEnabledSettings = {
+  enabled: true,
+  audit: {
+    enable_rest: false,
+    disabled_rest_categories: ['FAILED_LOGIN', 'AUTHENTICATED'],
+    enable_transport: true,
+    disabled_transport_categories: ['GRANTED_PRIVILEGES'],
+    resolve_bulk_requests: true,
+    log_request_body: false,
+    resolve_indices: true,
+    exclude_sensitive_headers: true,
+    ignore_users: ['admin'],
+    ignore_requests: ['SearchRequest', 'indices:data/read/*'],
+  },
+  compliance: {
+    enabled: true,
+    internal_config: false,
+    external_config: false,
+    read_metadata_only: false,
+    read_watched_fields: {
+      indexName1: ['field1', 'fields-*'],
+    },
+    read_ignore_users: ['opensearchdashboardsserver', 'operator/*'],
+    write_metadata_only: false,
+    write_log_diffs: false,
+    write_watched_indices: ['indexName2', 'indexPatterns-*'],
+    write_ignore_users: ['admin'],
+  },
+};


### PR DESCRIPTION
(cherry picked from commit 154a3ba08828b36a8dae684651f25c8d72f584be)

### Description
This PR is the manual backport of: https://github.com/opensearch-project/security-dashboards-plugin/pull/1888. This PR added multiple datasources feature in the security dashboards plugin. This means that users can use the security dashboards plugin to perform operations on security backend plugins of different clusters. 

### Category
New Feature
### Why these changes are required?
Backport of: https://github.com/opensearch-project/security-dashboards-plugin/pull/1888

### What is the old behavior before changes and new behavior after changes?
Old behavior: doesn't support multiple datasources
New behavior: supports multiple datasources

### Issues Resolved
Backport: https://github.com/opensearch-project/security-dashboards-plugin/pull/1888
### Testing
New unit, integration, e2e tests
### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).