### PR TITLE
Move myself (peternied) to emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cliu123 @cwperks @DarshitChanpura @derek-ho @peternied @RyanL1997 @scrawfor99
+* @cliu123 @cwperks @DarshitChanpura @derek-ho @RyanL1997 @scrawfor99

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,7 +8,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | ---------------- | ----------------------------------------------------- | ----------- |
 | Chang Liu        | [cliu123](https://github.com/cliu123)                 | Amazon      |
 | Darshit Chanpura | [DarshitChanpura](https://github.com/DarshitChanpura) | Amazon      |
-| Peter Nied       | [peternied](https://github.com/peternied)             | Amazon      |
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
 | Stephen Crawford | [scrawfor99](https://github.com/scrawfor99)           | Amazon      |
@@ -22,3 +21,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Bandini Bhopi | [bandinib-amzn](https://github.com/bandinib-amzn)   | Amazon      |
 | Tianle Huang  | [tianleh](https://github.com/tianleh)               | Amazon      |
 | Dave Lago     | [davidlago](https://github.com/davidlago)           | Contributor |
+| Peter Nied    | [peternied](https://github.com/peternied)           | Amazon      |


### PR DESCRIPTION
### Description
Move myself (peternied) to emeritus

### Check List
- [ ] ~New functionality includes testing~
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).