### PR TITLE
[Backport 2.x] Move myself (peternied) to emeritus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/security
+* @cliu123 @cwperks @DarshitChanpura @derek-ho @RyanL1997 @scrawfor99

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,9 +1,24 @@
-# OpenSearch Security Maintainers
+## Overview
 
-## Maintainers
+This document contains a list of maintainers in this repo. See [opensearch-project/.github/RESPONSIBILITIES.md](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#maintainer-responsibilities) that explains what the role of maintainer means, what maintainers do in this and other repos, and how they should be doing it. If you're interested in contributing, and becoming a maintainer, see [CONTRIBUTING](CONTRIBUTING.md).
+
+## Current Maintainers
+
 | Maintainer       | GitHub ID                                             | Affiliation |
 | ---------------- | ----------------------------------------------------- | ----------- |
 | Chang Liu        | [cliu123](https://github.com/cliu123)                 | Amazon      |
 | Darshit Chanpura | [DarshitChanpura](https://github.com/DarshitChanpura) | Amazon      |
-| Dave Lago        | [davidlago](https://github.com/davidlago)             | Amazon      |
-| Peter Nied       | [peternied](https://github.com/peternied)             | Amazon      |
+| Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
+| Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
+| Stephen Crawford | [scrawfor99](https://github.com/scrawfor99)           | Amazon      |
+| Derek Ho         | [derek-ho](https://github.com/derek-ho)               | Amazon      |
+
+## Emeritus
+
+| Maintainer    | GitHub ID                                           | Affiliation |
+| ------------- | --------------------------------------------------- | ----------- |
+| Yan Zeng      | [zengyan-amazon](https://github.com/zengyan-amazon) | Amazon      |
+| Bandini Bhopi | [bandinib-amzn](https://github.com/bandinib-amzn)   | Amazon      |
+| Tianle Huang  | [tianleh](https://github.com/tianleh)               | Amazon      |
+| Dave Lago     | [davidlago](https://github.com/davidlago)           | Contributor |
+| Peter Nied    | [peternied](https://github.com/peternied)           | Amazon      |


### PR DESCRIPTION
### Description
Move myself (peternied) to emeritus, and update the codeowners and maintainers with what is current in `main`.

### Issues Resolved
- Related https://github.com/opensearch-project/security-dashboards-plugin/pull/1913

### Check List
- [ ] New functionality includes testing~
- [X] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).