### PR TITLE
Add fix for data source disabled plugin should work

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -33,6 +33,6 @@ jobs:
         working-directory: ${{ steps.install-dashboards.outputs.plugin-directory }}
 
       - name: Uploads coverage
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -155,8 +155,9 @@ export const LocalCluster = { label: 'Local cluster', id: '' };
 export const DataSourceContext = createContext<DataSourceContextType | null>(null);
 
 export function AppRouter(props: AppDependencies) {
+  const dataSourceEnabled = !!props.depsStart.dataSource?.dataSourceEnabled;
   const setGlobalBreadcrumbs = flow(getBreadcrumbs, props.coreStart.chrome.setBreadcrumbs);
-  const dataSourceFromUrl = getDataSourceFromUrl();
+  const dataSourceFromUrl = dataSourceEnabled ? getDataSourceFromUrl() : LocalCluster;
 
   const [dataSource, setDataSource] = useState<DataSourceOption>(dataSourceFromUrl);
 

--- a/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
+++ b/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
@@ -4,7 +4,10 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
 <ContextProvider
   value={
     Object {
-      "dataSource": Object {},
+      "dataSource": Object {
+        "id": "",
+        "label": "Local cluster",
+      },
       "setDataSource": [Function],
     }
   }

--- a/public/apps/configuration/test/app-router.test.tsx
+++ b/public/apps/configuration/test/app-router.test.tsx
@@ -43,7 +43,9 @@ describe('SecurityPluginTopNavMenu', () => {
       },
     };
 
-    const wrapper = shallow(<AppRouter coreStart={coreStartMock} params={{ appBasePath: '' }} />);
+    const wrapper = shallow(
+      <AppRouter coreStart={coreStartMock} depsStart={{}} params={{ appBasePath: '' }} />
+    );
 
     expect(wrapper).toMatchSnapshot();
   });

--- a/public/apps/configuration/test/app-router.test.tsx
+++ b/public/apps/configuration/test/app-router.test.tsx
@@ -16,6 +16,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { AppRouter } from '../app-router';
+import { getDataSourceFromUrl } from '../../../utils/datasource-utils';
+
+jest.mock('../../../utils/datasource-utils', () => ({
+  getDataSourceFromUrl: jest.fn(),
+}));
 
 describe('SecurityPluginTopNavMenu', () => {
   const coreStartMock = {
@@ -48,5 +53,41 @@ describe('SecurityPluginTopNavMenu', () => {
     );
 
     expect(wrapper).toMatchSnapshot();
+  });
+
+  it('getDataSourceFromUrl not called when MDS is disabled', () => {
+    const securityPluginStartDepsMock = {
+      dataSource: {
+        dataSourceEnabled: false,
+      },
+    };
+
+    shallow(
+      <AppRouter
+        coreStart={coreStartMock}
+        depsStart={securityPluginStartDepsMock}
+        params={{ appBasePath: '' }}
+      />
+    );
+
+    expect(getDataSourceFromUrl).not.toHaveBeenCalled();
+  });
+
+  it('getDataSourceFromUrl called when MDS is enabled', () => {
+    const securityPluginStartDepsMock = {
+      dataSource: {
+        dataSourceEnabled: true,
+      },
+    };
+
+    shallow(
+      <AppRouter
+        coreStart={coreStartMock}
+        depsStart={securityPluginStartDepsMock}
+        params={{ appBasePath: '' }}
+      />
+    );
+
+    expect(getDataSourceFromUrl).toHaveBeenCalled();
   });
 });

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -14,6 +14,7 @@
  */
 
 import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
+import { LocalCluster } from '../apps/configuration/app-router';
 
 export function createDataSourceQuery(dataSourceId: string) {
   return { dataSourceId };
@@ -30,7 +31,8 @@ export function getClusterInfo(dataSourceEnabled: boolean, cluster: DataSourceOp
 
 export function getDataSourceFromUrl(): DataSourceOption {
   const urlParams = new URLSearchParams(window.location.search);
-  const dataSourceParam = (urlParams && urlParams.get(DATASOURCEURLKEY)) || '{}';
+  const dataSourceParam =
+    (urlParams && urlParams.get(DATASOURCEURLKEY)) || JSON.stringify(LocalCluster);
   return JSON.parse(dataSourceParam);
 }
 

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -14,7 +14,6 @@
  */
 
 import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
-import { LocalCluster } from '../apps/configuration/app-router';
 
 const DATASOURCEURLKEY = 'dataSource';
 
@@ -27,8 +26,7 @@ export function getClusterInfo(dataSourceEnabled: boolean, cluster: DataSourceOp
 
 export function getDataSourceFromUrl(): DataSourceOption {
   const urlParams = new URLSearchParams(window.location.search);
-  const dataSourceParam =
-    (urlParams && urlParams.get(DATASOURCEURLKEY)) || JSON.stringify(LocalCluster);
+  const dataSourceParam = (urlParams && urlParams.get(DATASOURCEURLKEY)) || '{}';
   return JSON.parse(dataSourceParam);
 }
 

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -16,10 +16,6 @@
 import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
 import { LocalCluster } from '../apps/configuration/app-router';
 
-export function createDataSourceQuery(dataSourceId: string) {
-  return { dataSourceId };
-}
-
 const DATASOURCEURLKEY = 'dataSource';
 
 export function getClusterInfo(dataSourceEnabled: boolean, cluster: DataSourceOption) {

--- a/public/utils/test/datasource-utils.test.ts
+++ b/public/utils/test/datasource-utils.test.ts
@@ -28,7 +28,7 @@ describe('Tests datasource utils', () => {
       value: { search: mockSearchNoDataSourceId },
       writable: true,
     });
-    expect(getDataSourceFromUrl()).toEqual({ id: '', label: 'Local cluster' });
+    expect(getDataSourceFromUrl()).toEqual({});
     const mockSearchDataSourceIdNotfirst =
       '?foo=bar&baz=qux&dataSource=%7B"id"%3A"94ffa650-f11a-11ee-a585-793f7b098e1a"%2C"label"%3A"9202"%7D';
     Object.defineProperty(window, 'location', {

--- a/public/utils/test/datasource-utils.test.ts
+++ b/public/utils/test/datasource-utils.test.ts
@@ -13,22 +13,13 @@
  *   permissions and limitations under the License.
  */
 
-import {
-  createDataSourceQuery,
-  getClusterInfo,
-  getDataSourceFromUrl,
-  setDataSourceInUrl,
-} from '../datasource-utils';
+import { getClusterInfo, getDataSourceFromUrl, setDataSourceInUrl } from '../datasource-utils';
 
 describe('Tests datasource utils', () => {
   it('Tests the GetClusterDescription helper function', () => {
     expect(getClusterInfo(false, { id: 'blah', label: 'blah' })).toBe('');
     expect(getClusterInfo(true, { id: '', label: '' })).toBe('for Local cluster');
     expect(getClusterInfo(true, { id: 'test', label: 'test' })).toBe('for test');
-  });
-
-  it('Tests the create DataSource query helper function', () => {
-    expect(createDataSourceQuery('test')).toStrictEqual({ dataSourceId: 'test' });
   });
 
   it('Tests getting the datasource from the url', () => {

--- a/public/utils/test/datasource-utils.test.ts
+++ b/public/utils/test/datasource-utils.test.ts
@@ -37,7 +37,7 @@ describe('Tests datasource utils', () => {
       value: { search: mockSearchNoDataSourceId },
       writable: true,
     });
-    expect(getDataSourceFromUrl()).toEqual({});
+    expect(getDataSourceFromUrl()).toEqual({ id: '', label: 'Local cluster' });
     const mockSearchDataSourceIdNotfirst =
       '?foo=bar&baz=qux&dataSource=%7B"id"%3A"94ffa650-f11a-11ee-a585-793f7b098e1a"%2C"label"%3A"9202"%7D';
     Object.defineProperty(window, 'location', {

--- a/test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-describe('Multi-datasources enabled', () => {
+describe('Multi-datasources disabled', () => {
   beforeEach(() => {
     localStorage.setItem('opendistro::security::tenant::saved', '""');
     localStorage.setItem('home:newThemeModal:show', 'false');

--- a/test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js
@@ -14,14 +14,27 @@
  */
 
 describe('Multi-datasources enabled', () => {
-  it('Sanity checks the cluster selector is not visible when multi datasources is disabled', () => {
+  beforeEach(() => {
     localStorage.setItem('opendistro::security::tenant::saved', '""');
     localStorage.setItem('home:newThemeModal:show', 'false');
+  });
 
-    cy.visit('http://localhost:5601/app/security-dashboards-plugin#/getstarted', {
-      failOnStatusCode: false,
-    });
+  afterEach(() => {
+    cy.clearCookies();
+    cy.clearAllLocalStorage();
+    cy.clearAllSessionStorage();
+  });
 
-    cy.get('[data-test-subj="dataSourceSelectableContextMenuHeaderLink"]').should('not.exist');
+  it('Checks Get Started Tab', () => {
+    // Remote cluster purge cache
+    cy.visit(`http://localhost:5601/app/security-dashboards-plugin#/getstarted`);
+
+    cy.contains('h1', 'Get started');
+    cy.get('[data-test-subj="dataSourceSelectableButton"]').should('not.exist');
+
+    cy.get('[data-test-subj="purge-cache"]').click();
+    cy.get('[class="euiToast euiToast--success euiGlobalToastListItem"]')
+      .get('.euiToastHeader__title')
+      .should('contain', 'Cache purge successful');
   });
 });


### PR DESCRIPTION
### Description
While testing the plugin when MDS is turned off, I noticed a few pages were not working. This was because after the refactor done in #1888, we started enforcing datasourceId as a mandator parameter to all APIs. I noticed that a reason why this may have not been caught is because the existing cypress tests for MDS turned off did not do any check that the API call went through, only that a component did not show up. This fixes the code to work when MDS is turned off, and also adds a cypress test to assert this behavior on a tab that broke but was fixed with this PR. 

### Category
Bug Fix
### Why these changes are required?
Bug introduced by #1888 in which MDS turned off breaks a few Security dashboard plugin features

### What is the old behavior before changes and new behavior after changes?
When MDS is turned off the security dashboards plugin still functions

### Issues Resolved
Fix:  #1918 , Fix: #1917 
### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).