### PR TITLE
Remove MDS selector for tenancy tab

### DIFF
--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -31,8 +31,6 @@ import { ExternalLink } from '../../utils/display-utils';
 import { DocLinks } from '../../constants';
 import { getDashboardsInfo } from '../../../../utils/dashboards-info-utils';
 import { TenantInstructionView } from './tenant-instruction-view';
-import { LocalCluster } from '../../app-router';
-import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
 
 interface TenantListProps extends AppDependencies {
   tabID: string;
@@ -135,12 +133,6 @@ export function TenantList(props: TenantListProps) {
 
   return (
     <>
-      <SecurityPluginTopNavMenu
-        {...props}
-        dataSourcePickerReadOnly={true}
-        setDataSource={() => {}}
-        selectedDataSource={LocalCluster}
-      />
       <EuiPageHeader>
         <EuiTitle size="l">
           <h1>Dashboards multi-tenancy</h1>

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -159,7 +159,7 @@ describe('Multi-datasources enabled', () => {
     cy.visit(`http://localhost:5601/app/security-dashboards-plugin${localDataSourceUrl}#/tenants`);
 
     cy.contains('h1', 'Dashboards multi-tenancy');
-    cy.get('[data-test-subj="dataSourceViewButton"]').should('contain', 'Local cluster');
+    cy.get('[data-test-subj="dataSourceSelectableButton"]').should('not.exist');
   });
 
   it('Checks Service Accounts Tab', () => {


### PR DESCRIPTION
### Description
For MDS, tenancy tab is always locked to local cluster. When disabling/removing local cluster, this causes an edge case where local cluster does not exist in the picker, but is still locked to on the page. This PR removes the picker for the tenancy tab altogether, since tenancy is a dashboards concept and does not really apply in MDS world. 

### Category
Maintenace
### Why these changes are required?
Fix: #1933 

### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
Fix: #1933 
### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).