### PR TITLE
Introduce `opensearch_security.configuration.admin_pages_enabled` setting to be able to disable security admin pages

### DIFF
--- a/public/types.ts
+++ b/public/types.ts
@@ -112,6 +112,10 @@ export interface ClientConfigType {
     anonymous_auth_enabled: boolean;
     logout_url: string;
   };
+  configuration: {
+    enabled: boolean;
+    admin_pages_enabled: boolean;
+  };
   clusterPermissions: {
     include: string[];
   };

--- a/server/backend/opensearch_security_configuration_plugin.ts
+++ b/server/backend/opensearch_security_configuration_plugin.ts
@@ -21,41 +21,12 @@ export default function (Client: any, config: any, components: any) {
     Client.prototype.opensearch_security = components.clientAction.namespaceFactory();
   }
 
-  Client.prototype.opensearch_security.prototype.restapiinfo = ca({
-    url: {
-      fmt: '/_plugins/_security/api/permissionsinfo',
-    },
-  });
-
   /**
    * list all field mappings for all indices.
    */
   Client.prototype.opensearch_security.prototype.indices = ca({
     url: {
       fmt: '/_all/_mapping/field/*',
-    },
-  });
-
-  /**
-   * Returns a Security resource configuration.
-   *
-   * Sample response:
-   *
-   * {
-   *   "user": {
-   *     "hash": "#123123"
-   *   }
-   * }
-   */
-  Client.prototype.opensearch_security.prototype.listResource = ca({
-    url: {
-      fmt: '/_plugins/_security/api/<%=resourceName%>',
-      req: {
-        resourceName: {
-          type: 'string',
-          required: true,
-        },
-      },
     },
   });
 
@@ -94,30 +65,6 @@ export default function (Client: any, config: any, components: any) {
           required: true,
         },
         id: {
-          type: 'string',
-          required: true,
-        },
-      },
-    },
-  });
-
-  /**
-   * Updates a resource.
-   * Resource identification is expected to computed from headers. Eg: auth headers.
-   *
-   * Sample response:
-   * {
-   *   "status": "OK",
-   *   "message": "Username updated."
-   * }
-   */
-  Client.prototype.opensearch_security.prototype.saveResourceWithoutId = ca({
-    method: 'PUT',
-    needBody: true,
-    url: {
-      fmt: '/_plugins/_security/api/<%=resourceName%>',
-      req: {
-        resourceName: {
           type: 'string',
           required: true,
         },

--- a/server/backend/opensearch_security_plugin.ts
+++ b/server/backend/opensearch_security_plugin.ts
@@ -21,6 +21,59 @@ export default function (Client: any, config: any, components: any) {
     Client.prototype.opensearch_security = components.clientAction.namespaceFactory();
   }
 
+  Client.prototype.opensearch_security.prototype.restapiinfo = ca({
+    url: {
+      fmt: '/_plugins/_security/api/permissionsinfo',
+    },
+  });
+
+  /**
+   * Updates a resource.
+   * Resource identification is expected to computed from headers. Eg: auth headers.
+   *
+   * Sample response:
+   * {
+   *   "status": "OK",
+   *   "message": "Username updated."
+   * }
+   */
+  Client.prototype.opensearch_security.prototype.saveResourceWithoutId = ca({
+    method: 'PUT',
+    needBody: true,
+    url: {
+      fmt: '/_plugins/_security/api/<%=resourceName%>',
+      req: {
+        resourceName: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+  });
+
+  /**
+   * Returns a Security resource configuration.
+   *
+   * Sample response:
+   *
+   * {
+   *   "user": {
+   *     "hash": "#123123"
+   *   }
+   * }
+   */
+  Client.prototype.opensearch_security.prototype.listResource = ca({
+    url: {
+      fmt: '/_plugins/_security/api/<%=resourceName%>',
+      req: {
+        resourceName: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+  });
+
   /**
    * Gets auth info.
    */
@@ -48,7 +101,7 @@ export default function (Client: any, config: any, components: any) {
    *   "opensearch_dashboards_server_user": "kibanaserver"
    * }
    */
-  Client.prototype.opensearch_security.prototype.multitenancyinfo = ca({
+  Client.prototype.opensearch_security.prototype.xx = ca({
     url: {
       fmt: '/_plugins/_security/dashboardsinfo',
     },

--- a/server/index.ts
+++ b/server/index.ts
@@ -158,6 +158,7 @@ export const configSchema = schema.object({
   }),
   configuration: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
+    admin_pages_enabled: schema.boolean({ defaultValue: true }),
   }),
   accountinfo: schema.object({
     enabled: schema.boolean({ defaultValue: false }),
@@ -299,6 +300,7 @@ export const config: PluginConfigDescriptor<SecurityPluginConfigType> = {
     ui: true,
     multitenancy: true,
     readonly_mode: true,
+    configuration: true,
     clusterPermissions: true,
     indexPermissions: true,
     disabledTransportCategories: true,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -25,72 +25,72 @@ import {
 import { API_PREFIX, CONFIGURATION_API_PREFIX, isValidResourceName } from '../../common';
 import { ResourceType } from '../../common';
 
+const internalUserSchema = schema.object({
+  description: schema.maybe(schema.string()),
+  password: schema.maybe(schema.string()),
+  backend_roles: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  attributes: schema.any({ defaultValue: {} }),
+});
+
+const actionGroupSchema = schema.object({
+  description: schema.maybe(schema.string()),
+  allowed_actions: schema.arrayOf(schema.string()),
+  // type field is not supported in legacy implementation, comment it out for now.
+  // type: schema.oneOf([
+  //   schema.literal('cluster'),
+  //   schema.literal('index'),
+  //   schema.literal('opensearch_dashboards'),
+  // ]),
+});
+
+const roleMappingSchema = schema.object({
+  description: schema.maybe(schema.string()),
+  backend_roles: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  hosts: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  users: schema.arrayOf(schema.string(), { defaultValue: [] }),
+});
+
+const roleSchema = schema.object({
+  description: schema.maybe(schema.string()),
+  cluster_permissions: schema.arrayOf(schema.string(), { defaultValue: [] }),
+  tenant_permissions: schema.arrayOf(schema.any(), { defaultValue: [] }),
+  index_permissions: schema.arrayOf(schema.any(), { defaultValue: [] }),
+});
+
+const tenantSchema = schema.object({
+  description: schema.string(),
+});
+
+const accountSchema = schema.object({
+  password: schema.string(),
+  current_password: schema.string(),
+});
+
+const schemaMap: any = {
+  internalusers: internalUserSchema,
+  actiongroups: actionGroupSchema,
+  rolesmapping: roleMappingSchema,
+  roles: roleSchema,
+  tenants: tenantSchema,
+  account: accountSchema,
+};
+
+function validateRequestBody(resourceName: string, requestBody: any): any {
+  const inputSchema = schemaMap[resourceName];
+  if (!inputSchema) {
+    throw new Error(`Unknown resource ${resourceName}`);
+  }
+  inputSchema.validate(requestBody); // throws error if validation fail
+}
+
+function validateEntityId(resourceName: string) {
+  if (!isValidResourceName(resourceName)) {
+    return 'Invalid entity name or id.';
+  }
+}
+
 // TODO: consider to extract entity CRUD operations and put it into a client class
 export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
-  const internalUserSchema = schema.object({
-    description: schema.maybe(schema.string()),
-    password: schema.maybe(schema.string()),
-    backend_roles: schema.arrayOf(schema.string(), { defaultValue: [] }),
-    attributes: schema.any({ defaultValue: {} }),
-  });
-
-  const actionGroupSchema = schema.object({
-    description: schema.maybe(schema.string()),
-    allowed_actions: schema.arrayOf(schema.string()),
-    // type field is not supported in legacy implementation, comment it out for now.
-    // type: schema.oneOf([
-    //   schema.literal('cluster'),
-    //   schema.literal('index'),
-    //   schema.literal('opensearch_dashboards'),
-    // ]),
-  });
-
-  const roleMappingSchema = schema.object({
-    description: schema.maybe(schema.string()),
-    backend_roles: schema.arrayOf(schema.string(), { defaultValue: [] }),
-    hosts: schema.arrayOf(schema.string(), { defaultValue: [] }),
-    users: schema.arrayOf(schema.string(), { defaultValue: [] }),
-  });
-
-  const roleSchema = schema.object({
-    description: schema.maybe(schema.string()),
-    cluster_permissions: schema.arrayOf(schema.string(), { defaultValue: [] }),
-    tenant_permissions: schema.arrayOf(schema.any(), { defaultValue: [] }),
-    index_permissions: schema.arrayOf(schema.any(), { defaultValue: [] }),
-  });
-
-  const tenantSchema = schema.object({
-    description: schema.string(),
-  });
-
-  const accountSchema = schema.object({
-    password: schema.string(),
-    current_password: schema.string(),
-  });
-
-  const schemaMap: any = {
-    internalusers: internalUserSchema,
-    actiongroups: actionGroupSchema,
-    rolesmapping: roleMappingSchema,
-    roles: roleSchema,
-    tenants: tenantSchema,
-    account: accountSchema,
-  };
-
-  function validateRequestBody(resourceName: string, requestBody: any): any {
-    const inputSchema = schemaMap[resourceName];
-    if (!inputSchema) {
-      throw new Error(`Unknown resource ${resourceName}`);
-    }
-    inputSchema.validate(requestBody); // throws error if validation fail
-  }
-
-  function validateEntityId(resourceName: string) {
-    if (!isValidResourceName(resourceName)) {
-      return 'Invalid entity name or id.';
-    }
-  }
-
   /**
    * Lists resources by resource name.
    *
@@ -393,51 +393,6 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
   );
 
   /**
-   * Deletes an entity by id.
-   */
-  router.delete(
-    {
-      path: `${API_PREFIX}/${CONFIGURATION_API_PREFIX}/{resourceName}/{id}`,
-      validate: {
-        params: schema.object({
-          resourceName: schema.string(),
-          id: schema.string({
-            minLength: 1,
-          }),
-        }),
-        query: schema.object({
-          dataSourceId: schema.maybe(schema.string()),
-        }),
-      },
-    },
-    async (
-      context,
-      request,
-      response
-    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      try {
-        const esResp = await wrapRouteWithDataSource(
-          dataSourceEnabled,
-          context,
-          request,
-          'opensearch_security.deleteResource',
-          {
-            resourceName: request.params.resourceName,
-            id: request.params.id,
-          }
-        );
-        return response.ok({
-          body: {
-            message: esResp.message,
-          },
-        });
-      } catch (error) {
-        return errorResponse(response, error);
-      }
-    }
-  );
-
-  /**
    * Update object with out Id. Resource identification is expected to computed from headers. Eg: auth headers
    *
    * Request sample:
@@ -478,58 +433,6 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
           'opensearch_security.saveResourceWithoutId',
           {
             resourceName: request.params.resourceName,
-            body: request.body,
-          }
-        );
-        return response.ok({
-          body: {
-            message: esResp.message,
-          },
-        });
-      } catch (error) {
-        return errorResponse(response, error);
-      }
-    }
-  );
-
-  /**
-   * Update entity by Id.
-   */
-  router.post(
-    {
-      path: `${API_PREFIX}/${CONFIGURATION_API_PREFIX}/{resourceName}/{id}`,
-      validate: {
-        params: schema.object({
-          resourceName: schema.string(),
-          id: schema.string({
-            validate: validateEntityId,
-          }),
-        }),
-        body: schema.any(),
-        query: schema.object({
-          dataSourceId: schema.maybe(schema.string()),
-        }),
-      },
-    },
-    async (
-      context,
-      request,
-      response
-    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
-      try {
-        validateRequestBody(request.params.resourceName, request.body);
-      } catch (error) {
-        return response.badRequest({ body: error });
-      }
-      try {
-        const esResp = await wrapRouteWithDataSource(
-          dataSourceEnabled,
-          context,
-          request,
-          'opensearch_security.saveResource',
-          {
-            resourceName: request.params.resourceName,
-            id: request.params.id,
             body: request.body,
           }
         );
@@ -609,6 +512,136 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
 
         return response.ok({
           body: esResp,
+        });
+      } catch (error) {
+        return errorResponse(response, error);
+      }
+    }
+  );
+
+  /**
+   * Gets permission info of current user.
+   *
+   * Sample response:
+   * {
+   *   "user": "User [name=admin, roles=[], requestedTenant=__user__]",
+   *   "user_name": "admin",
+   *   "has_api_access": true,
+   *   "disabled_endpoints": {}
+   * }
+   */
+  router.get(
+    {
+      path: `${API_PREFIX}/restapiinfo`,
+      validate: false,
+    },
+    async (context, request, response) => {
+      const client = context.security_plugin.esClient.asScoped(request);
+      try {
+        const esResponse = await client.callAsCurrentUser('opensearch_security.restapiinfo');
+        return response.ok({
+          body: esResponse,
+        });
+      } catch (error) {
+        return response.badRequest({
+          body: error,
+        });
+      }
+    }
+  );
+}
+
+export function defineSecurityConfigurationRoutes(router: IRouter, dataSourceEnabled: boolean) {
+  /**
+   * Deletes an entity by id.
+   */
+  router.delete(
+    {
+      path: `${API_PREFIX}/${CONFIGURATION_API_PREFIX}/{resourceName}/{id}`,
+      validate: {
+        params: schema.object({
+          resourceName: schema.string(),
+          id: schema.string({
+            minLength: 1,
+          }),
+        }),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (
+      context,
+      request,
+      response
+    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
+      try {
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.deleteResource',
+          {
+            resourceName: request.params.resourceName,
+            id: request.params.id,
+          }
+        );
+        return response.ok({
+          body: {
+            message: esResp.message,
+          },
+        });
+      } catch (error) {
+        return errorResponse(response, error);
+      }
+    }
+  );
+
+  /**
+   * Update entity by Id.
+   */
+  router.post(
+    {
+      path: `${API_PREFIX}/${CONFIGURATION_API_PREFIX}/{resourceName}/{id}`,
+      validate: {
+        params: schema.object({
+          resourceName: schema.string(),
+          id: schema.string({
+            validate: validateEntityId,
+          }),
+        }),
+        body: schema.any(),
+        query: schema.object({
+          dataSourceId: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    async (
+      context,
+      request,
+      response
+    ): Promise<IOpenSearchDashboardsResponse<any | ResponseError>> => {
+      try {
+        validateRequestBody(request.params.resourceName, request.body);
+      } catch (error) {
+        return response.badRequest({ body: error });
+      }
+      try {
+        const esResp = await wrapRouteWithDataSource(
+          dataSourceEnabled,
+          context,
+          request,
+          'opensearch_security.saveResource',
+          {
+            resourceName: request.params.resourceName,
+            id: request.params.id,
+            body: request.body,
+          }
+        );
+        return response.ok({
+          body: {
+            message: esResp.message,
+          },
         });
       } catch (error) {
         return errorResponse(response, error);
@@ -821,37 +854,6 @@ export function defineRoutes(router: IRouter, dataSourceEnabled: boolean) {
         });
       } catch (error) {
         return errorResponse(response, error);
-      }
-    }
-  );
-
-  /**
-   * Gets permission info of current user.
-   *
-   * Sample response:
-   * {
-   *   "user": "User [name=admin, roles=[], requestedTenant=__user__]",
-   *   "user_name": "admin",
-   *   "has_api_access": true,
-   *   "disabled_endpoints": {}
-   * }
-   */
-  router.get(
-    {
-      path: `${API_PREFIX}/restapiinfo`,
-      validate: false,
-    },
-    async (context, request, response) => {
-      const client = context.security_plugin.esClient.asScoped(request);
-      try {
-        const esResponse = await client.callAsCurrentUser('opensearch_security.restapiinfo');
-        return response.ok({
-          body: esResponse,
-        });
-      } catch (error) {
-        return response.badRequest({
-          body: error,
-        });
       }
     }
   );


### PR DESCRIPTION
### Description

Introduces an `opensearch_dashboards.yml` setting to be able to disable Security from the menu for all users. The setting is `opensearch_security.configuration.admin_pages_enabled`, is true by default and needs to be explicitly disabled.

Currently, the behavior is to display Security in the main menu only for a Security admin user. To determine whether a user is a Security admin, security-dashboards-plugin runs an API request and determines if the logged in user is mapped to one of the `plugins.security.restapi.roles_enabled` roles.

### Category

Enhancement

### Issues Resolved

- https://github.com/opensearch-project/security-dashboards-plugin/issues/1961

### Testing

Manual testing to ensure disabling the Security screens doesn't cause any other issues. The user still needs to be able to reset their password, view their user info and switch tenants.

Marking this as Draft until functional tests are added.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).