### PR TITLE
Remove username block on custom tenants 

### DIFF
--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -121,7 +121,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
   };
   const customTenantOptions = tenants
     .filter((tenant) => {
-      return tenant !== GLOBAL_TENANT_KEY_NAME && tenant !== username;
+      return tenant !== GLOBAL_TENANT_KEY_NAME;
     })
     .sort()
     .map((option: string) => ({

--- a/public/apps/account/test/__snapshots__/tenant-switch-panel.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/tenant-switch-panel.test.tsx.snap
@@ -74,6 +74,9 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
             Object {
               "label": "tenant1",
             },
+            Object {
+              "label": "user1",
+            },
           ]
         }
         placeholder="Select a custom tenant"
@@ -188,6 +191,9 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
           Array [
             Object {
               "label": "tenant1",
+            },
+            Object {
+              "label": "user1",
             },
           ]
         }
@@ -304,6 +310,9 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
             Object {
               "label": "tenant1",
             },
+            Object {
+              "label": "user1",
+            },
           ]
         }
         placeholder="Select a custom tenant"
@@ -419,6 +428,9 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
             Object {
               "label": "tenant1",
             },
+            Object {
+              "label": "user1",
+            },
           ]
         }
         placeholder="Select a custom tenant"
@@ -533,6 +545,9 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
           Array [
             Object {
               "label": "tenant1",
+            },
+            Object {
+              "label": "user1",
             },
           ]
         }

--- a/public/apps/account/test/tenant-switch-panel.test.tsx
+++ b/public/apps/account/test/tenant-switch-panel.test.tsx
@@ -156,6 +156,7 @@ describe('Account menu -tenant switch panel', () => {
         data: {
           tenants: {
             ['tenant1']: true,
+            ['user1']: true,
           },
           user_name: 'user1',
           roles: ['role1', 'role2'],


### PR DESCRIPTION
### Description
This PR resolves: https://github.com/opensearch-project/security-dashboards-plugin/issues/1244

Since its creation the tenant-switch-panel has enforced that 

```  
const customTenantOptions = tenants
    .filter((tenant) => {
      return tenant !== GLOBAL_TENANT_KEY_NAME && tenant !== username;
    })

...
```

This has been the same case the creation of the tenancy feature https://github.com/opensearch-project/security-dashboards-plugin/pull/374 and serves an unclear purpose. In order to resolve this issue, I am removing the `!== username` part of the evaluation. I have also contacted the original author to see if there was any reason for the original enforcement.

Existing tests should serve to validate this change. 



### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]
Existing tests should validate the tenancy behavior 

### Check List
- [ ] ~New functionality includes testing~
- [ ] ~New functionality has been documented~
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).