### PR TITLE
Make login screen input feels consistent

### DIFF
--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -17,7 +17,6 @@ import React, { useState } from 'react';
 import {
   EuiText,
   EuiFieldText,
-  EuiIcon,
   EuiSpacer,
   EuiButton,
   EuiImage,
@@ -194,7 +193,7 @@ export function LoginPage(props: LoginPageDeps) {
                 data-test-subj="user-name"
                 aria-label="username_input"
                 placeholder="Username"
-                prepend={<EuiIcon type="user" />}
+                icon="user"
                 onChange={(e) => setUsername(e.target.value)}
                 value={username}
                 isInvalid={usernameValidationFailed}

--- a/public/apps/login/test/__snapshots__/login-page.test.tsx.snap
+++ b/public/apps/login/test/__snapshots__/login-page.test.tsx.snap
@@ -44,14 +44,10 @@ exports[`Login page renders renders with config value for multiauth 1`] = `
       <EuiFieldText
         aria-label="username_input"
         data-test-subj="user-name"
+        icon="user"
         isInvalid={false}
         onChange={[Function]}
         placeholder="Username"
-        prepend={
-          <EuiIcon
-            type="user"
-          />
-        }
         value=""
       />
     </EuiFormRow>
@@ -195,14 +191,10 @@ exports[`Login page renders renders with config value for multiauth with anonymo
       <EuiFieldText
         aria-label="username_input"
         data-test-subj="user-name"
+        icon="user"
         isInvalid={false}
         onChange={[Function]}
         placeholder="Username"
-        prepend={
-          <EuiIcon
-            type="user"
-          />
-        }
         value=""
       />
     </EuiFormRow>
@@ -364,14 +356,10 @@ exports[`Login page renders renders with config value with anonymous auth enable
       <EuiFieldText
         aria-label="username_input"
         data-test-subj="user-name"
+        icon="user"
         isInvalid={false}
         onChange={[Function]}
         placeholder="Username"
-        prepend={
-          <EuiIcon
-            type="user"
-          />
-        }
         value=""
       />
     </EuiFormRow>
@@ -483,14 +471,10 @@ exports[`Login page renders renders with config value with anonymous auth enable
       <EuiFieldText
         aria-label="username_input"
         data-test-subj="user-name"
+        icon="user"
         isInvalid={false}
         onChange={[Function]}
         placeholder="Username"
-        prepend={
-          <EuiIcon
-            type="user"
-          />
-        }
         value=""
       />
     </EuiFormRow>
@@ -602,14 +586,10 @@ exports[`Login page renders renders with config value: string 1`] = `
       <EuiFieldText
         aria-label="username_input"
         data-test-subj="user-name"
+        icon="user"
         isInvalid={false}
         onChange={[Function]}
         placeholder="Username"
-        prepend={
-          <EuiIcon
-            type="user"
-          />
-        }
         value=""
       />
     </EuiFormRow>
@@ -703,14 +683,10 @@ exports[`Login page renders renders with config value: string array 1`] = `
       <EuiFieldText
         aria-label="username_input"
         data-test-subj="user-name"
+        icon="user"
         isInvalid={false}
         onChange={[Function]}
         placeholder="Username"
-        prepend={
-          <EuiIcon
-            type="user"
-          />
-        }
         value=""
       />
     </EuiFormRow>
@@ -804,14 +780,10 @@ exports[`Login page renders renders with default value: string 1`] = `
       <EuiFieldText
         aria-label="username_input"
         data-test-subj="user-name"
+        icon="user"
         isInvalid={false}
         onChange={[Function]}
         placeholder="Username"
-        prepend={
-          <EuiIcon
-            type="user"
-          />
-        }
         value=""
       />
     </EuiFormRow>
@@ -905,14 +877,10 @@ exports[`Login page renders renders with default value: string array 1`] = `
       <EuiFieldText
         aria-label="username_input"
         data-test-subj="user-name"
+        icon="user"
         isInvalid={false}
         onChange={[Function]}
         placeholder="Username"
-        prepend={
-          <EuiIcon
-            type="user"
-          />
-        }
         value=""
       />
     </EuiFormRow>


### PR DESCRIPTION
### Description

Ran this by @kgcreative.

Turns 

<img width="334" alt="Screenshot 2024-06-10 at 1 49 08 PM" src="https://github.com/opensearch-project/security-dashboards-plugin/assets/3527403/fa94ae87-a92d-405d-9234-20597af94606">

Into

<img width="361" alt="Screenshot 2024-06-10 at 1 28 37 PM" src="https://github.com/opensearch-project/security-dashboards-plugin/assets/3527403/1d25bf1d-56b4-4577-8c9e-076fe76047f7">


### Category
Bug fix

### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?
Prior to #1980, we had

<img width="334" alt="Screenshot 2024-06-10 at 1 50 55 PM" src="https://github.com/opensearch-project/security-dashboards-plugin/assets/3527403/3d335fc4-9ff9-4185-8b60-e29d7fd0851b">

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).