### PR TITLE
Fix 2.15 integration test failures due to backport

### DIFF
--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -260,7 +260,7 @@ export function AuditLogging(props: AuditLoggingProps) {
       />
       <EuiPageHeader>
         <EuiTitle size="l">
-          <h1>Audit Logging</h1>
+          <h3>Audit logging</h3>
         </EuiTitle>
       </EuiPageHeader>
       <EuiSpacer />

--- a/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
+++ b/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
@@ -260,9 +260,9 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
     <EuiTitle
       size="l"
     >
-      <h1>
-        Audit Logging
-      </h1>
+      <h3>
+        Audit logging
+      </h3>
     </EuiTitle>
   </EuiPageHeader>
   <EuiSpacer />
@@ -670,9 +670,9 @@ exports[`Audit logs should load access error component 1`] = `
     <EuiTitle
       size="l"
     >
-      <h1>
-        Audit Logging
-      </h1>
+      <h3>
+        Audit logging
+      </h3>
     </EuiTitle>
   </EuiPageHeader>
   <EuiSpacer />

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -256,7 +256,7 @@ export function UserList(props: AppDependencies) {
                     href={buildHashUrl(ResourceType.users, Action.create)}
                     data-test-subj="create-user"
                   >
-                    Create user account
+                    Create internal user
                   </EuiButton>
                 </EuiFlexItem>
               </EuiFlexGroup>


### PR DESCRIPTION
### Description
A recent backport brought some failures for integration tests for 2.15 release. This PR reverts the necessary changes to make integration tests pass again. 

### Category
Bug Fix
### Why these changes are required?
Changes from backport #1984 

### What is the old behavior before changes and new behavior after changes?
Integration tests now pass again, see screenshots

### Issues Resolved
Fix: #1999 
### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).