### PR TITLE
Fix URL duplication issue

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -165,7 +165,7 @@ export function AppRouter(props: AppDependencies) {
 
   return (
     <DataSourceContext.Provider value={{ dataSource, setDataSource }}>
-      <Router basename={props.params.appBasePath}>
+      <Router>
         <EuiPage>
           {allNavPanelUrls(multitenancyEnabled).map((route) => (
             // Create different routes to update the 'selected' nav item .

--- a/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
+++ b/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
@@ -12,9 +12,7 @@ exports[`SecurityPluginTopNavMenu renders DataSourceMenu when dataSource is enab
     }
   }
 >
-  <HashRouter
-    basename=""
-  >
+  <HashRouter>
     <EuiPage>
       <Route
         exact={true}


### PR DESCRIPTION
### Description
This PR fixes a duplication issue where upon first navigation to the security dashboards plugin, the /app/security-dashboards-plugin#/ segment would appear twice. 

### Category
Bug Fix
### Why these changes are required?
Bug Fix

### What is the old behavior before changes and new behavior after changes?
See video here: https://github.com/opensearch-project/security-dashboards-plugin/pull/2004#issuecomment-2166445743

### Issues Resolved
Fix: #1967 
### Testing
Manual testing
### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).