### PR TITLE
Change JDK to 21 for main branch

### DIFF
--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -36,7 +36,7 @@ runs:
         download-location: ${{ env.PLUGIN_NAME }}
     
     - name: Run Opensearch with A Single Plugin
-      uses: derek-ho/start-opensearch@v5
+      uses: derek-ho/start-opensearch@v6
       with:
         opensearch-version: ${{ env.OPENSEARCH_VERSION }}
         plugins: "file:$(pwd)/opensearch-security.zip"

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -22,7 +22,7 @@ runs:
     - name: Set up JDK
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 21
 
     - name: Set env
       run: |
@@ -41,13 +41,14 @@ runs:
         download-location: ${{ env.PLUGIN_NAME }}
     
     - name: Run Opensearch with A Single Plugin
-      uses: derek-ho/start-opensearch@v2
+      uses: derek-ho/start-opensearch@v5
       with:
         opensearch-version: ${{ env.OPENSEARCH_VERSION }}
         plugins: "file:$(pwd)/opensearch-security.zip"
         security-enabled: true
         admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
         security_config_file: ${{ inputs.security_config_file }}
+        jdk-version: 21
 
     # OSD bootstrap
     - name: Run Dashboard with Security Dashboards Plugin

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -19,11 +19,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set up JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: 21
-
     - name: Set env
       run: |
         opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")

--- a/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
@@ -67,7 +67,7 @@ jobs:
           download-location: ${{env.PLUGIN_NAME}}
       
       - name: Run Opensearch with A Single Plugin
-        uses: derek-ho/start-opensearch@v5
+        uses: derek-ho/start-opensearch@v6
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/opensearch-security.zip"

--- a/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
@@ -67,7 +67,7 @@ jobs:
           download-location: ${{env.PLUGIN_NAME}}
       
       - name: Run Opensearch with A Single Plugin
-        uses: derek-ho/start-opensearch@v4
+        uses: derek-ho/start-opensearch@v5
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/opensearch-security.zip"
@@ -75,6 +75,7 @@ jobs:
           admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
           security_config_file: config_custom.yml
           port: 9202
+          jdk-version: 21
 
       - name: Check OpenSearch is running
           # Verify that the server is operational

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -22,11 +22,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Set up JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
       - name: Checkout Branch
         uses: actions/checkout@v3
 
@@ -47,12 +42,13 @@ jobs:
           download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@v2
+        uses: derek-ho/start-opensearch@v5
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"
           security-enabled: true
           admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
+          jdk-version: 21
 
       # Configure the Dashboard
       - name: Configure OpenSearch Dashboards with tenancy disabled

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -42,7 +42,7 @@ jobs:
           download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@v5
+        uses: derek-ho/start-opensearch@v6
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -22,11 +22,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:       
-      - name: Set up JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
       - name: Checkout Branch
         uses: actions/checkout@v3
 
@@ -47,12 +42,13 @@ jobs:
           download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@v2
+        uses: derek-ho/start-opensearch@v5
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"
           security-enabled: true
           admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
+          jdk-version: 21
 
       # Configure the Dashboard
       - name: Configure OpenSearch Dashboards for cypress

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -42,7 +42,7 @@ jobs:
           download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@v5
+        uses: derek-ho/start-opensearch@v6
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,7 +46,7 @@ jobs:
           plugin-version: ${{ env.PLUGIN_VERSION }}
       
       - name: Run Opensearch with A Single Plugin Remote Cluster
-        uses: derek-ho/start-opensearch@windows-fix
+        uses: derek-ho/start-opensearch@v6
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/opensearch-security-${{ env.OPENSEARCH_VERSION }}.zip"
@@ -62,7 +62,7 @@ jobs:
         shell: bash
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@windows-fix
+        uses: derek-ho/start-opensearch@v6
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,11 +20,6 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
-        
-      - name: Set up JDK
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
 
       - name: Set env
         run: |
@@ -51,7 +46,7 @@ jobs:
           plugin-version: ${{ env.PLUGIN_VERSION }}
       
       - name: Run Opensearch with A Single Plugin Remote Cluster
-        uses: derek-ho/start-opensearch@v4
+        uses: derek-ho/start-opensearch@v5
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/opensearch-security-${{ env.OPENSEARCH_VERSION }}.zip"
@@ -59,6 +54,7 @@ jobs:
           admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
           security_config_file: ${{ inputs.security_config_file }}
           port: 9202
+          jdk-version: 21
 
       - name: Check OpenSearch remote is running
         run: |
@@ -66,12 +62,13 @@ jobs:
         shell: bash
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@v2
+        uses: derek-ho/start-opensearch@v5
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"
           security-enabled: true
           admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
+          jdk-version: 21
 
       # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
       - name: Remove unnecessary files Linux

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -46,7 +46,7 @@ jobs:
           plugin-version: ${{ env.PLUGIN_VERSION }}
       
       - name: Run Opensearch with A Single Plugin Remote Cluster
-        uses: derek-ho/start-opensearch@v5
+        uses: derek-ho/start-opensearch@windows-fix
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/opensearch-security-${{ env.OPENSEARCH_VERSION }}.zip"
@@ -62,7 +62,7 @@ jobs:
         shell: bash
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@v5
+        uses: derek-ho/start-opensearch@windows-fix
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -39,12 +39,13 @@ jobs:
           download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@v2
+        uses: derek-ho/start-opensearch@v5
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"
           security-enabled: true
           admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
+          jdk-version: 21
 
       # Configure the Dashboard
       - name: Configure OpenSearch Dashboards

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -39,7 +39,7 @@ jobs:
           download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@v5
+        uses: derek-ho/start-opensearch@v6
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"


### PR DESCRIPTION
### Description
Bump JDK version to 21. Remove unnecessary steps in the CI. 
### Category
Maintenance
### Why these changes are required?
Fix: https://github.com/opensearch-project/security-dashboards-plugin/issues/2009

### What is the old behavior before changes and new behavior after changes?
Fix: https://github.com/opensearch-project/security-dashboards-plugin/issues/2009

### Issues Resolved
Fix: https://github.com/opensearch-project/security-dashboards-plugin/issues/2009
### Testing
Existing tests pass
### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).