### PR TITLE
Fix the bug of capabilities request not supporting carrying authinfo

### DIFF
--- a/server/auth/types/authentication_type.test.ts
+++ b/server/auth/types/authentication_type.test.ts
@@ -111,3 +111,57 @@ describe('test tenant header', () => {
     expect(result.requestHeaders.securitytenant).toEqual('dummy_tenant');
   });
 });
+
+describe('test capabilities request authinfo', () => {
+  const config = {
+    auth: {
+      unauthenticated_routes: [] as string[],
+    },
+    session: {
+      keepalive: false,
+    },
+  } as SecurityPluginConfigType;
+  const sessionStorageFactory = {
+    asScoped: jest.fn(() => {
+      return {
+        clear: jest.fn(),
+        get: jest.fn().mockResolvedValue({}),
+      };
+    }),
+  };
+  const router = jest.fn();
+  const esClient = {
+    asScoped: jest.fn().mockImplementation(() => {
+      return {
+        callAsCurrentUser: jest.fn().mockImplementation(() => {
+          return { username: 'capabolities-username' };
+        }),
+      };
+    }),
+  };
+  const coreSetup = jest.fn();
+  const logger = {
+    error: jest.fn(),
+  };
+
+  const dummyAuthType = new DummyAuthType(
+    config,
+    sessionStorageFactory,
+    router,
+    esClient,
+    coreSetup,
+    logger
+  );
+
+  it(`Capabilities API includes authinfo`, async () => {
+    const request = httpServerMock.createOpenSearchDashboardsRequest({
+      path: '/api/core/capabilities',
+    });
+    const response = jest.fn();
+    const toolkit = {
+      authenticated: jest.fn((value) => value),
+    };
+    const result = await dummyAuthType.authHandler(request, response, toolkit);
+    expect(result.state.authInfo.username).toEqual('capabolities-username');
+  });
+});

--- a/server/auth/types/authentication_type.test.ts
+++ b/server/auth/types/authentication_type.test.ts
@@ -134,7 +134,7 @@ describe('test capabilities request authinfo', () => {
     asScoped: jest.fn().mockImplementation(() => {
       return {
         callAsCurrentUser: jest.fn().mockImplementation(() => {
-          return { username: 'capabolities-username' };
+          return { username: 'capabilities-username' };
         }),
       };
     }),
@@ -162,6 +162,6 @@ describe('test capabilities request authinfo', () => {
       authenticated: jest.fn((value) => value),
     };
     const result = await dummyAuthType.authHandler(request, response, toolkit);
-    expect(result.state.authInfo.username).toEqual('capabolities-username');
+    expect(result.state.authInfo.username).toEqual('capabilities-username');
   });
 });

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -151,7 +151,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
           return toolkit.notHandled();
         }
 
-        // Before users login, skip auth capabilities request.
+        // allow optional authentication
         if (this.authOptional(request)) {
           return toolkit.authenticated();
         }
@@ -244,7 +244,6 @@ export abstract class AuthenticationType implements IAuthenticationType {
     if (!pathname) {
       return false;
     }
-    // allow requests to ignored routes
     if (AuthenticationType.ROUTES_AUTH_OPTIONAL.includes(pathname!)) {
       return true;
     }

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -244,10 +244,7 @@ export abstract class AuthenticationType implements IAuthenticationType {
     if (!pathname) {
       return false;
     }
-    if (AuthenticationType.ROUTES_AUTH_OPTIONAL.includes(pathname!)) {
-      return true;
-    }
-    return false;
+    return AuthenticationType.ROUTES_AUTH_OPTIONAL.includes(pathname!);
   }
 
   async resolveTenant(


### PR DESCRIPTION
### Description
Fix the issue of capabilities API not supporting carrying authinfo。

### Category
Bug fix

### Why these changes are required?
When user call `core.capabilities.registerSwitcher` to store certain state which is about authinfo, the request need carry the auth information.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).