### PR TITLE
Fix issue setting nextUrl on click of logout button

### DIFF
--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -43,9 +43,9 @@ export async function logout(http: HttpStart, logoutUrl?: string): Promise<void>
   setShouldShowTenantPopup(null);
   // Clear everything in the sessionStorage since they can contain sensitive information
   sessionStorage.clear();
-  // When no basepath is set, we can take '/' as the basepath.
-  const basePath = http.basePath.serverBasePath ? http.basePath.serverBasePath : '/';
-  const nextUrl = encodeURIComponent(basePath);
+  const nextUrl = encodeURIComponent(
+    window.location.pathname + window.location.search + window.location.hash
+  );
   window.location.href =
     logoutUrl || `${http.basePath.serverBasePath}/app/login?nextUrl=${nextUrl}`;
 }
@@ -54,7 +54,10 @@ export async function externalLogout(http: HttpStart, logoutEndpoint: string): P
   // This will ensure tenancy is picked up from local storage in the next login.
   setShouldShowTenantPopup(null);
   sessionStorage.clear();
-  window.location.href = `${http.basePath.serverBasePath}${logoutEndpoint}`;
+  const nextUrl = encodeURIComponent(
+    window.location.pathname + window.location.search + window.location.hash
+  );
+  window.location.href = `${http.basePath.serverBasePath}${logoutEndpoint}?nextUrl=${nextUrl}`;
 }
 
 export async function updateNewPassword(

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -263,7 +263,12 @@ export class OpenIdAuthRoutes {
         const token = tokenFromExtraStorage.length
           ? tokenFromExtraStorage.split(' ')[1]
           : cookie?.credentials.authHeaderValue.split(' ')[1]; // get auth token
-        const nextUrl = getBaseRedirectUrl(this.config, this.core, request);
+        let nextUrl = getBaseRedirectUrl(this.config, this.core, request);
+        if (request.url.searchParams.has('nextUrl')) {
+          nextUrl = `${nextUrl}/app/login?nextUrl=${encodeURIComponent(
+            request.url.searchParams.get('nextUrl') || ''
+          )}`;
+        }
 
         const logoutQueryParams = {
           post_logout_redirect_uri: `${nextUrl}`,


### PR DESCRIPTION
### Description

Opening up a Draft PR that shows a fixes an issue on logout for multiple authentication types (basic + OIDC). When a user clicks the logout button, they will logout of the respective IdP and then land back on the OSD login screen. When the user is on the login page, the url is supposed to contain a `nextUrl` param which contains the page that the user was most recently visiting in OSD when they explicitly click the logout button.

### Category

Bug fix

### Issues Resolved

Discovered while investigating: https://github.com/opensearch-project/security-dashboards-plugin/issues/1823

### Testing

This will stay in draft until unit and functional tests are added

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).