### PR TITLE
[Backport 2.16] [MDS] Adds datasource filter for version decoupling (#2051)

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -15,5 +15,7 @@
     "dataSourceManagement"
   ],
   "server": true,
-  "ui": true
+  "ui": true,
+  "supportedOSDataSourceVersions": ">=1.0.0",
+  "requiredOSDataSourcePlugins": ["opensearch-security"]
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "@hapi/wreck": "^17.1.0",
     "html-entities": "1.3.1",
     "proxy-agent": "^6.4.0",
-    "zxcvbn": "^4.4.2"
+    "zxcvbn": "^4.4.2",
+    "semver": "^7.5.3"
   },
   "resolutions": {
     "selenium-webdriver": "4.10.0",

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -20,6 +20,7 @@ import { AppDependencies } from '../types';
 import {
   setDataSourceInUrl,
   setDataSource as setDataSourceInSubscription,
+  isDataSourceCompatible,
 } from '../../utils/datasource-utils';
 
 export interface TopNavMenuProps extends AppDependencies {
@@ -63,6 +64,7 @@ export const SecurityPluginTopNavMenu = React.memo(
               : undefined,
           onSelectedDataSources: wrapSetDataSourceWithUpdateUrl,
           fullWidth: true,
+          dataSourceFilter: isDataSourceCompatible,
         }}
       />
     ) : null;

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -12,9 +12,12 @@
  *   express or implied. See the License for the specific language governing
  *   permissions and limitations under the License.
  */
-
+import semver from 'semver';
 import { BehaviorSubject } from 'rxjs';
 import { DataSourceOption } from 'src/plugins/data_source_management/public/components/data_source_menu/types';
+import pluginManifest from '../../opensearch_dashboards.json';
+import type { SavedObject } from '../../../../src/core/public';
+import type { DataSourceAttributes } from '../../../../src/plugins/data_source/common/data_sources';
 
 const DATASOURCEURLKEY = 'dataSource';
 
@@ -55,3 +58,26 @@ export const dataSource$ = new BehaviorSubject<DataSourceOption>(
 export function setDataSource(dataSource: DataSourceOption) {
   dataSource$.next(dataSource);
 }
+
+export const isDataSourceCompatible = (dataSource: SavedObject<DataSourceAttributes>) => {
+  if (
+    'requiredOSDataSourcePlugins' in pluginManifest &&
+    !pluginManifest.requiredOSDataSourcePlugins.every((plugin) =>
+      dataSource.attributes.installedPlugins?.includes(plugin)
+    )
+  ) {
+    return false;
+  }
+
+  // filter out data sources which is NOT in the support range of plugin
+  if (
+    'supportedOSDataSourceVersions' in pluginManifest &&
+    !semver.satisfies(
+      dataSource.attributes.dataSourceVersion,
+      pluginManifest.supportedOSDataSourceVersions
+    )
+  ) {
+    return false;
+  }
+  return true;
+};

--- a/public/utils/test/datasource-utils.test.ts
+++ b/public/utils/test/datasource-utils.test.ts
@@ -13,7 +13,12 @@
  *   permissions and limitations under the License.
  */
 
-import { getClusterInfo, getDataSourceFromUrl, setDataSourceInUrl } from '../datasource-utils';
+import {
+  getClusterInfo,
+  getDataSourceFromUrl,
+  setDataSourceInUrl,
+  isDataSourceCompatible,
+} from '../datasource-utils';
 
 describe('Tests datasource utils', () => {
   it('Tests the GetClusterDescription helper function', () => {
@@ -77,5 +82,131 @@ describe('Tests datasource utils', () => {
       writable: true,
     });
     expect(getDataSourceFromUrl()).toEqual({});
+  });
+
+  describe('isDataSourceCompatible', () => {
+    it('should return true for compatible data sources', () => {
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: ['opensearch-security'],
+            dataSourceVersion: '2.9.0',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(true);
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: ['opensearch-security'],
+            dataSourceVersion: '2.11.0',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(true);
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: ['opensearch-security'],
+            dataSourceVersion: '2.13.0',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(true);
+    });
+
+    it('should return false for un-compatible data sources', () => {
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: [],
+            dataSourceVersion: '2.13.0',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(false);
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: ['opensearch-ml'],
+            dataSourceVersion: '2.13.0',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(false);
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            title: '',
+            endpoint: '',
+            dataSourceVersion: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(false);
+      expect(
+        isDataSourceCompatible({
+          attributes: {
+            installedPlugins: ['opensearch-security'],
+            dataSourceVersion: '1.0.0-beta1',
+            title: '',
+            endpoint: '',
+            auth: {
+              type: '',
+              credentials: undefined,
+            },
+          },
+          id: '',
+          type: '',
+          references: [],
+        })
+      ).toBe(false);
+    });
   });
 });

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -24,6 +24,8 @@ const createDataSource = () => {
       attributes: {
         title: Cypress.env('externalDataSourceLabel'),
         endpoint: Cypress.env('externalDataSourceEndpoint'),
+        installedPlugins: ['opensearch-security'],
+        dataSourceVersion: '2.15.0',
         auth: {
           type: 'username_password',
           credentials: {


### PR DESCRIPTION
### Description
Manually backports #2051 via commit e9609acc76e7db541eb3701bd53369555a98517c
- manual backport required because of conflicts in yarn.lock (no changes were made in yarn.lock as it is too close to release)


### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).