### PR TITLE
Use the `getRedirectUrl` from OSD to generate nextUrl

### DIFF
--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -131,7 +131,7 @@ export class OpenIdAuthentication extends AuthenticationType {
     const path = getRedirectUrl({
       request,
       basePath: this.coreSetup.http.basePath.serverBasePath,
-      nextUrl: request.url.pathname || '/app/opensearch-dashboards'
+      nextUrl: request.url.pathname || '/app/opensearch-dashboards',
     });
     return escape(path);
   }

--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -46,6 +46,7 @@ import {
   getExtraAuthStorageValue,
   setExtraAuthStorage,
 } from '../../../session/cookie_splitter';
+import { getRedirectUrl } from '../../../../../../src/core/server/http';
 
 export interface OpenIdAuthConfig {
   authorizationEndpoint?: string;
@@ -127,9 +128,11 @@ export class OpenIdAuthentication extends AuthenticationType {
   }
 
   private generateNextUrl(request: OpenSearchDashboardsRequest): string {
-    const path =
-      this.coreSetup.http.basePath.serverBasePath +
-      (request.url.pathname || '/app/opensearch-dashboards');
+    const path = getRedirectUrl({
+      request,
+      basePath: this.coreSetup.http.basePath.serverBasePath,
+      nextUrl: request.url.pathname || '/app/opensearch-dashboards'
+    });
     return escape(path);
   }
 

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -41,6 +41,7 @@ import {
   getExtraAuthStorageValue,
   ExtraAuthStorageOptions,
 } from '../../../session/cookie_splitter';
+import { getRedirectUrl } from '../../../../../../src/core/server/http';
 
 export class SamlAuthentication extends AuthenticationType {
   public static readonly AUTH_HEADER_NAME = 'authorization';
@@ -59,9 +60,11 @@ export class SamlAuthentication extends AuthenticationType {
   }
 
   private generateNextUrl(request: OpenSearchDashboardsRequest): string {
-    let path =
-      this.coreSetup.http.basePath.serverBasePath +
-      (request.url.pathname || '/app/opensearch-dashboards');
+    let path = getRedirectUrl({
+      request,
+      basePath: this.coreSetup.http.basePath.serverBasePath,
+      nextUrl: request.url.pathname || '/app/opensearch-dashboards'
+    });
     if (request.url.search) {
       path += request.url.search;
     }

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -63,7 +63,7 @@ export class SamlAuthentication extends AuthenticationType {
     let path = getRedirectUrl({
       request,
       basePath: this.coreSetup.http.basePath.serverBasePath,
-      nextUrl: request.url.pathname || '/app/opensearch-dashboards'
+      nextUrl: request.url.pathname || '/app/opensearch-dashboards',
     });
     if (request.url.search) {
       path += request.url.search;

--- a/server/utils/next_url.test.ts
+++ b/server/utils/next_url.test.ts
@@ -18,14 +18,16 @@ import {
   validateNextUrl,
   INVALID_NEXT_URL_PARAMETER_MESSAGE,
 } from './next_url';
+import { httpServerMock } from '../../../../src/core/server/mocks';
 
 describe('test composeNextUrlQueryParam', () => {
+  httpServerMock.createOpenSearchDashboardsRequest();
   test('no base, no path', () => {
     expect(
       composeNextUrlQueryParam(
-        {
-          url: 'http://localhost:123',
-        },
+        httpServerMock.createOpenSearchDashboardsRequest({
+          path: ''
+        }),
         ''
       )
     ).toEqual('');
@@ -34,9 +36,9 @@ describe('test composeNextUrlQueryParam', () => {
   test('no base, path', () => {
     expect(
       composeNextUrlQueryParam(
-        {
-          url: 'http://localhost:123/alpha/major/foxtrot',
-        },
+        httpServerMock.createOpenSearchDashboardsRequest({
+          path: '/alpha/major/foxtrot'
+        }),
         ''
       )
     ).toEqual('nextUrl=%2Falpha%2Fmajor%2Ffoxtrot');
@@ -45,9 +47,9 @@ describe('test composeNextUrlQueryParam', () => {
   test('base, no path', () => {
     expect(
       composeNextUrlQueryParam(
-        {
-          url: 'http://localhost:123',
-        },
+        httpServerMock.createOpenSearchDashboardsRequest({
+          path: ''
+        }),
         'xyz'
       )
     ).toEqual('');
@@ -56,9 +58,9 @@ describe('test composeNextUrlQueryParam', () => {
   test('base, path', () => {
     expect(
       composeNextUrlQueryParam(
-        {
-          url: 'http://localhost:123/alpha/major/foxtrot',
-        },
+        httpServerMock.createOpenSearchDashboardsRequest({
+          path: '/alpha/major/foxtrot'
+        }),
         'xyz'
       )
     ).toEqual('nextUrl=xyz%2Falpha%2Fmajor%2Ffoxtrot');

--- a/server/utils/next_url.test.ts
+++ b/server/utils/next_url.test.ts
@@ -26,7 +26,7 @@ describe('test composeNextUrlQueryParam', () => {
     expect(
       composeNextUrlQueryParam(
         httpServerMock.createOpenSearchDashboardsRequest({
-          path: ''
+          path: '',
         }),
         ''
       )
@@ -37,7 +37,7 @@ describe('test composeNextUrlQueryParam', () => {
     expect(
       composeNextUrlQueryParam(
         httpServerMock.createOpenSearchDashboardsRequest({
-          path: '/alpha/major/foxtrot'
+          path: '/alpha/major/foxtrot',
         }),
         ''
       )
@@ -48,7 +48,7 @@ describe('test composeNextUrlQueryParam', () => {
     expect(
       composeNextUrlQueryParam(
         httpServerMock.createOpenSearchDashboardsRequest({
-          path: ''
+          path: '',
         }),
         'xyz'
       )
@@ -59,7 +59,7 @@ describe('test composeNextUrlQueryParam', () => {
     expect(
       composeNextUrlQueryParam(
         httpServerMock.createOpenSearchDashboardsRequest({
-          path: '/alpha/major/foxtrot'
+          path: '/alpha/major/foxtrot',
         }),
         'xyz'
       )

--- a/server/utils/next_url.ts
+++ b/server/utils/next_url.ts
@@ -17,6 +17,7 @@ import { parse } from 'url';
 import { ParsedUrlQuery } from 'querystring';
 import { OpenSearchDashboardsRequest } from 'opensearch-dashboards/server';
 import { encodeUriQuery } from '../../../../src/plugins/opensearch_dashboards_utils/common/url/encode_uri_query';
+import { getRedirectUrl } from '../../../../src/core/server/http';
 
 export function composeNextUrlQueryParam(
   request: OpenSearchDashboardsRequest,
@@ -28,7 +29,11 @@ export function composeNextUrlQueryParam(
     const nextUrl = parsedUrl?.path;
 
     if (!!nextUrl && nextUrl !== '/') {
-      return `nextUrl=${encodeUriQuery(basePath + nextUrl)}`;
+      return `nextUrl=${encodeUriQuery(getRedirectUrl({
+        request,
+        basePath,
+        nextUrl,
+      }))}`;
     }
   } catch (error) {
     /* Ignore errors from parsing */

--- a/server/utils/next_url.ts
+++ b/server/utils/next_url.ts
@@ -29,11 +29,13 @@ export function composeNextUrlQueryParam(
     const nextUrl = parsedUrl?.path;
 
     if (!!nextUrl && nextUrl !== '/') {
-      return `nextUrl=${encodeUriQuery(getRedirectUrl({
-        request,
-        basePath,
-        nextUrl,
-      }))}`;
+      return `nextUrl=${encodeUriQuery(
+        getRedirectUrl({
+          request,
+          basePath,
+          nextUrl,
+        })
+      )}`;
     }
   } catch (error) {
     /* Ignore errors from parsing */


### PR DESCRIPTION
### Description

This PR is to adopt the util function `getRedirectUrl` from OSD core to get a unified url after login.

This PR should not merged until https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7600 get merged.

### Category
Bug fix

### Why these changes are required?
#2069 

### What is the old behavior before changes and new behavior after changes?

### Issues Resolved
#2069 

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).