### PR TITLE
 Use smaller and compressed varients of buttons and form components

### DIFF
--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -18,7 +18,7 @@ import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiCallOut,
-  EuiFieldPassword,
+  EuiCompressedFieldPassword,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedFormRow,
@@ -116,7 +116,7 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
             isInvalid={isCurrentPasswordInvalid}
             error={currentPasswordError}
           >
-            <EuiFieldPassword
+            <EuiCompressedFieldPassword
               data-test-subj="current-password"
               onChange={function (e: React.ChangeEvent<HTMLInputElement>) {
                 setCurrentPassword(e.target.value);
@@ -135,7 +135,7 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
                 helpText={passwordHelpText}
                 isInvalid={isNewPasswordInvalid}
               >
-                <EuiFieldPassword
+                <EuiCompressedFieldPassword
                   data-test-subj="new-password"
                   onChange={function (e: React.ChangeEvent<HTMLInputElement>) {
                     setNewPassword(e.target.value);
@@ -156,7 +156,7 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
             headerText="Re-enter new password"
             helpText="The password must be identical to what you entered above."
           >
-            <EuiFieldPassword
+            <EuiCompressedFieldPassword
               data-test-subj="reenter-new-password"
               isInvalid={isRepeatNewPasswordInvalid}
               onChange={function (e: React.ChangeEvent<HTMLInputElement>) {

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -15,7 +15,7 @@
 
 import React from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiFieldPassword,
@@ -181,14 +181,14 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
             Cancel
           </EuiButtonEmpty>
 
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="reset"
             fill
             disabled={isRepeatNewPasswordInvalid}
             onClick={handleReset}
           >
             Reset
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -21,7 +21,7 @@ import {
   EuiFieldPassword,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -146,9 +146,9 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
                   isInvalid={isNewPasswordInvalid}
                 />
               </FormRow>
-              <EuiFormRow>
+              <EuiCompressedFormRow>
                 <PasswordStrengthBar password={newPassword} />
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>
 

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCallOut,
   EuiFieldPassword,
   EuiFlexGroup,
@@ -177,9 +177,9 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
           )}
         </EuiModalBody>
         <EuiModalFooter>
-          <EuiButtonEmpty data-test-subj="cancel" onClick={props.handleClose}>
+          <EuiSmallButtonEmpty data-test-subj="cancel" onClick={props.handleClose}>
             Cancel
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
 
           <EuiSmallButton
             data-test-subj="reset"

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -23,7 +23,7 @@ import {
   EuiModalBody,
   EuiModalFooter,
   EuiOverlayMask,
-  EuiRadioGroup,
+  EuiCompressedRadioGroup,
   EuiSpacer,
   EuiText,
   EuiTitle,
@@ -247,7 +247,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
   if (isMultiTenancyEnabled) {
     content = (
       <>
-        <EuiRadioGroup
+        <EuiCompressedRadioGroup
           data-test-subj="tenant-switch-radios"
           options={tenantSwitchRadios}
           idSelected={tenantSwitchRadioIdSelected}

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -15,7 +15,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiCallOut,
   EuiComboBox,
   EuiComboBoxOptionOption,
@@ -304,7 +304,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
           <EuiSpacer />
         </EuiModalBody>
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={props.handleClose}>Cancel</EuiSmallButtonEmpty>
 
           <EuiSmallButton
             data-test-subj="confirm"

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -17,7 +17,7 @@ import {
   EuiSmallButton,
   EuiSmallButtonEmpty,
   EuiCallOut,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiComboBoxOptionOption,
   EuiModal,
   EuiModalBody,
@@ -258,7 +258,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         {/* This combo box has to be outside the radio group.
           In current EUI if put into the child of radio option, clicking in the combo box will not
           show the drop down list since the radio option consumes the click event. */}
-        <EuiComboBox
+        <EuiCompressedComboBox
           placeholder="Select a custom tenant"
           options={customTenantOptions}
           singleSelection={{ asPlainText: true }}

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -14,7 +14,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiComboBox,
@@ -306,14 +306,14 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         <EuiModalFooter>
           <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
 
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="confirm"
             fill={isMultiTenancyEnabled && !invalidCustomTenant}
             disabled={!isMultiTenancyEnabled || invalidCustomTenant}
             onClick={handleTenantConfirmation}
           >
             Confirm
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/apps/account/test/__snapshots__/tenant-switch-panel.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/tenant-switch-panel.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
         Tenants are useful for safely sharing your work with other OpenSearch Dashboards users. You can switch your tenant anytime by clicking the user avatar on top right.
       </EuiText>
       <EuiSpacer />
-      <EuiRadioGroup
+      <EuiCompressedRadioGroup
         data-test-subj="tenant-switch-radios"
         name="tenantSwitchRadios"
         onChange={[Function]}
@@ -63,9 +63,9 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
           ]
         }
       />
-      <EuiComboBox
+      <EuiCompressedComboBox
         async={false}
-        compressed={false}
+        compressed={true}
         fullWidth={false}
         isClearable={true}
         onChange={[Function]}
@@ -94,19 +94,19 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
       <EuiSpacer />
     </EuiModalBody>
     <EuiModalFooter>
-      <EuiButtonEmpty
+      <EuiSmallButtonEmpty
         onClick={[MockFunction]}
       >
         Cancel
-      </EuiButtonEmpty>
-      <EuiButton
+      </EuiSmallButtonEmpty>
+      <EuiSmallButton
         data-test-subj="confirm"
         disabled={false}
         fill={true}
         onClick={[Function]}
       >
         Confirm
-      </EuiButton>
+      </EuiSmallButton>
     </EuiModalFooter>
   </EuiModal>
 </EuiOverlayMask>
@@ -133,7 +133,7 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
         Tenants are useful for safely sharing your work with other OpenSearch Dashboards users. You can switch your tenant anytime by clicking the user avatar on top right.
       </EuiText>
       <EuiSpacer />
-      <EuiRadioGroup
+      <EuiCompressedRadioGroup
         data-test-subj="tenant-switch-radios"
         name="tenantSwitchRadios"
         onChange={[Function]}
@@ -178,9 +178,9 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
           ]
         }
       />
-      <EuiComboBox
+      <EuiCompressedComboBox
         async={false}
-        compressed={false}
+        compressed={true}
         fullWidth={false}
         isClearable={true}
         onChange={[Function]}
@@ -209,19 +209,19 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
       <EuiSpacer />
     </EuiModalBody>
     <EuiModalFooter>
-      <EuiButtonEmpty
+      <EuiSmallButtonEmpty
         onClick={[MockFunction]}
       >
         Cancel
-      </EuiButtonEmpty>
-      <EuiButton
+      </EuiSmallButtonEmpty>
+      <EuiSmallButton
         data-test-subj="confirm"
         disabled={false}
         fill={true}
         onClick={[Function]}
       >
         Confirm
-      </EuiButton>
+      </EuiSmallButton>
     </EuiModalFooter>
   </EuiModal>
 </EuiOverlayMask>
@@ -248,7 +248,7 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
         Tenants are useful for safely sharing your work with other OpenSearch Dashboards users. You can switch your tenant anytime by clicking the user avatar on top right.
       </EuiText>
       <EuiSpacer />
-      <EuiRadioGroup
+      <EuiCompressedRadioGroup
         data-test-subj="tenant-switch-radios"
         name="tenantSwitchRadios"
         onChange={[Function]}
@@ -293,9 +293,9 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
           ]
         }
       />
-      <EuiComboBox
+      <EuiCompressedComboBox
         async={false}
-        compressed={false}
+        compressed={true}
         fullWidth={false}
         isClearable={true}
         onChange={[Function]}
@@ -324,19 +324,19 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
       <EuiSpacer />
     </EuiModalBody>
     <EuiModalFooter>
-      <EuiButtonEmpty
+      <EuiSmallButtonEmpty
         onClick={[MockFunction]}
       >
         Cancel
-      </EuiButtonEmpty>
-      <EuiButton
+      </EuiSmallButtonEmpty>
+      <EuiSmallButton
         data-test-subj="confirm"
         disabled={false}
         fill={true}
         onClick={[Function]}
       >
         Confirm
-      </EuiButton>
+      </EuiSmallButton>
     </EuiModalFooter>
   </EuiModal>
 </EuiOverlayMask>
@@ -363,7 +363,7 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
         Tenants are useful for safely sharing your work with other OpenSearch Dashboards users. You can switch your tenant anytime by clicking the user avatar on top right.
       </EuiText>
       <EuiSpacer />
-      <EuiRadioGroup
+      <EuiCompressedRadioGroup
         data-test-subj="tenant-switch-radios"
         name="tenantSwitchRadios"
         onChange={[Function]}
@@ -408,9 +408,9 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
           ]
         }
       />
-      <EuiComboBox
+      <EuiCompressedComboBox
         async={false}
-        compressed={false}
+        compressed={true}
         fullWidth={false}
         isClearable={true}
         onChange={[Function]}
@@ -439,19 +439,19 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
       <EuiSpacer />
     </EuiModalBody>
     <EuiModalFooter>
-      <EuiButtonEmpty
+      <EuiSmallButtonEmpty
         onClick={[MockFunction]}
       >
         Cancel
-      </EuiButtonEmpty>
-      <EuiButton
+      </EuiSmallButtonEmpty>
+      <EuiSmallButton
         data-test-subj="confirm"
         disabled={false}
         fill={true}
         onClick={[Function]}
       >
         Confirm
-      </EuiButton>
+      </EuiSmallButton>
     </EuiModalFooter>
   </EuiModal>
 </EuiOverlayMask>
@@ -478,7 +478,7 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
         Tenants are useful for safely sharing your work with other OpenSearch Dashboards users. You can switch your tenant anytime by clicking the user avatar on top right.
       </EuiText>
       <EuiSpacer />
-      <EuiRadioGroup
+      <EuiCompressedRadioGroup
         data-test-subj="tenant-switch-radios"
         name="tenantSwitchRadios"
         onChange={[Function]}
@@ -523,9 +523,9 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
           ]
         }
       />
-      <EuiComboBox
+      <EuiCompressedComboBox
         async={false}
-        compressed={false}
+        compressed={true}
         fullWidth={false}
         isClearable={true}
         onChange={[Function]}
@@ -554,19 +554,19 @@ exports[`Account menu -tenant switch panel confirm button and renders renders wh
       <EuiSpacer />
     </EuiModalBody>
     <EuiModalFooter>
-      <EuiButtonEmpty
+      <EuiSmallButtonEmpty
         onClick={[MockFunction]}
       >
         Cancel
-      </EuiButtonEmpty>
-      <EuiButton
+      </EuiSmallButtonEmpty>
+      <EuiSmallButton
         data-test-subj="confirm"
         disabled={false}
         fill={true}
         onClick={[Function]}
       >
         Confirm
-      </EuiButton>
+      </EuiSmallButton>
     </EuiModalFooter>
   </EuiModal>
 </EuiOverlayMask>

--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -15,7 +15,7 @@
 
 import React, { useContext } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiGlobalToastList,
@@ -83,17 +83,17 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
       <>
         <EuiFlexGroup justifyContent="flexEnd">
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="cancel"
               onClick={() => {
                 window.location.href = buildHashUrl(ResourceType.auditLogging);
               }}
             >
               Cancel
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="save"
               fill
               isDisabled={invalidSettings.length !== 0}
@@ -102,7 +102,7 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
               }}
             >
               Save
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </>

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -20,7 +20,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiHorizontalRule,
   EuiLoadingContent,
   EuiPageHeader,
@@ -59,7 +59,7 @@ function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnabled: bool
     <EuiPanel>
       <EuiForm>
         <EuiDescribedFormGroup title={<h3>Storage location</h3>} className="described-form-group">
-          <EuiFormRow className="form-row">
+          <EuiCompressedFormRow className="form-row">
             <EuiText color="subdued" grow={false}>
               <FormattedMessage
                 id="audit.logs.storageInstruction"
@@ -71,14 +71,14 @@ function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnabled: bool
               />{' '}
               <ExternalLink href={DocLinks.AuditLogsStorageDoc} />
             </EuiText>
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiDescribedFormGroup>
 
         <EuiDescribedFormGroup
           title={<h3>Enable audit logging</h3>}
           className="described-form-group"
         >
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <EuiSwitch
               data-test-subj="audit-logging-enabled-switch"
               name="auditLoggingEnabledSwitch"
@@ -86,7 +86,7 @@ function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnabled: bool
               checked={auditLoggingEnabled}
               onChange={onSwitchChange}
             />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiDescribedFormGroup>
       </EuiForm>
     </EuiPanel>

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -26,7 +26,7 @@ import {
   EuiPageHeader,
   EuiPanel,
   EuiSpacer,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiText,
   EuiTitle,
 } from '@elastic/eui';
@@ -79,7 +79,7 @@ function renderStatusPanel(onSwitchChange: () => void, auditLoggingEnabled: bool
           className="described-form-group"
         >
           <EuiCompressedFormRow>
-            <EuiSwitch
+            <EuiCompressedSwitch
               data-test-subj="audit-logging-enabled-switch"
               name="auditLoggingEnabledSwitch"
               label={displayBoolean(auditLoggingEnabled)}

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -14,7 +14,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiCode,
   EuiDescribedFormGroup,
   EuiFlexGroup,
@@ -206,7 +206,7 @@ export function AuditLogging(props: AuditLoggingProps) {
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 data-test-subj="general-settings-configure"
                 onClick={() => {
                   window.location.href =
@@ -214,7 +214,7 @@ export function AuditLogging(props: AuditLoggingProps) {
                 }}
               >
                 Configure
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
           <EuiHorizontalRule margin="m" />
@@ -231,7 +231,7 @@ export function AuditLogging(props: AuditLoggingProps) {
               </EuiTitle>
             </EuiFlexItem>
             <EuiFlexItem grow={false}>
-              <EuiButton
+              <EuiSmallButton
                 data-test-subj="compliance-settings-configure"
                 onClick={() => {
                   window.location.href =
@@ -239,7 +239,7 @@ export function AuditLogging(props: AuditLoggingProps) {
                 }}
               >
                 Configure
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFlexItem>
           </EuiFlexGroup>
 

--- a/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
+++ b/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
@@ -20,7 +20,7 @@ import {
   EuiDescribedFormGroup,
   EuiCompressedFormRow,
   EuiSpacer,
-  EuiSwitch,
+  EuiCompressedSwitch,
   EuiTitle,
 } from '@elastic/eui';
 import { get, isEmpty } from 'lodash';
@@ -63,7 +63,7 @@ export function EditSettingGroup(props: {
       val = val || false;
 
       return (
-        <EuiSwitch
+        <EuiCompressedSwitch
           // @ts-ignore
           label={displayBoolean(val)}
           // @ts-ignore

--- a/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
+++ b/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
@@ -16,7 +16,7 @@
 import React, { Fragment } from 'react';
 import {
   EuiCodeBlock,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiDescribedFormGroup,
   EuiCompressedFormRow,
   EuiSpacer,
@@ -77,7 +77,7 @@ export function EditSettingGroup(props: {
       val = val || [];
 
       return (
-        <EuiComboBox
+        <EuiCompressedComboBox
           placeholder={setting.title}
           options={setting.options.map(stringToComboBoxOption)}
           // @ts-ignore
@@ -91,7 +91,7 @@ export function EditSettingGroup(props: {
       val = val || [];
 
       return (
-        <EuiComboBox
+        <EuiCompressedComboBox
           noSuggestions
           placeholder={setting.title}
           // @ts-ignore

--- a/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
+++ b/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
@@ -18,7 +18,7 @@ import {
   EuiCodeBlock,
   EuiComboBox,
   EuiDescribedFormGroup,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
   EuiSwitch,
   EuiTitle,
@@ -168,10 +168,10 @@ export function EditSettingGroup(props: {
               fullWidth
             >
               {/* @ts-ignore*/}
-              <EuiFormRow label={displayLabel(setting.path)}>
+              <EuiCompressedFormRow label={displayLabel(setting.path)}>
                 {/* @ts-ignore*/}
                 {renderField(props.config, setting, props.handleChange, props.handleInvalid)}
-              </EuiFormRow>
+              </EuiCompressedFormRow>
             </EuiDescribedFormGroup>
           </Fragment>
         );

--- a/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
+++ b/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
@@ -276,10 +276,10 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
           </h3>
         }
       >
-        <EuiFormRow
+        <EuiCompressedFormRow
           className="form-row"
           describedByIds={Array []}
-          display="row"
+          display="rowCompressed"
           fullWidth={false}
           hasChildLabel={true}
           hasEmptyLabelSpace={false}
@@ -308,7 +308,7 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
               href="https://opensearch.org/docs/latest/security-plugin/audit-logs/storage-types/"
             />
           </EuiText>
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiDescribedFormGroup>
       <EuiDescribedFormGroup
         className="described-form-group"
@@ -318,22 +318,22 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
           </h3>
         }
       >
-        <EuiFormRow
+        <EuiCompressedFormRow
           describedByIds={Array []}
-          display="row"
+          display="rowCompressed"
           fullWidth={false}
           hasChildLabel={true}
           hasEmptyLabelSpace={false}
           labelType="label"
         >
-          <EuiSwitch
+          <EuiCompressedSwitch
             checked={true}
             data-test-subj="audit-logging-enabled-switch"
             label="Enabled"
             name="auditLoggingEnabledSwitch"
             onChange={[Function]}
           />
-        </EuiFormRow>
+        </EuiCompressedFormRow>
       </EuiDescribedFormGroup>
     </EuiForm>
   </EuiPanel>
@@ -352,12 +352,12 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
       <EuiFlexItem
         grow={false}
       >
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="general-settings-configure"
           onClick={[Function]}
         >
           Configure
-        </EuiButton>
+        </EuiSmallButton>
       </EuiFlexItem>
     </EuiFlexGroup>
     <EuiHorizontalRule
@@ -503,12 +503,12 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
       <EuiFlexItem
         grow={false}
       >
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="compliance-settings-configure"
           onClick={[Function]}
         >
           Configure
-        </EuiButton>
+        </EuiSmallButton>
       </EuiFlexItem>
     </EuiFlexGroup>
     <EuiHorizontalRule

--- a/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
@@ -16,7 +16,7 @@
 import { shallow } from 'enzyme';
 import { AuditLogging, renderComplianceSettings, renderGeneralSettings } from '../audit-logging';
 import React from 'react';
-import { EuiSwitch } from '@elastic/eui';
+import { EuiCompressedSwitch } from '@elastic/eui';
 import { buildHashUrl } from '../../../utils/url-builder';
 import { ResourceType } from '../../../../../../common';
 import {
@@ -61,7 +61,7 @@ describe('Audit logs', () => {
       <AuditLogging coreStart={mockCoreStart as any} navigation={{} as any} />
     );
 
-    const switchFound = component.find(EuiSwitch);
+    const switchFound = component.find(EuiCompressedSwitch);
 
     expect(switchFound.prop('checked')).toBeFalsy();
     expect(switchFound.prop('label')).toBe('Disabled');

--- a/public/apps/configuration/panels/audit-logging/test/edit-setting-group.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/edit-setting-group.test.tsx
@@ -18,7 +18,7 @@ import React from 'react';
 import { EditSettingGroup } from '../edit-setting-group';
 import { CONFIG, SettingContent, SettingGroup } from '../constants';
 import { AuditLoggingSettings, ComplianceSettings, GeneralSettings } from '../types';
-import { EuiComboBox, EuiSwitch } from '@elastic/eui';
+import { EuiCompressedComboBox, EuiCompressedSwitch } from '@elastic/eui';
 import { stringToComboBoxOption } from '../../../utils/combo-box-utils';
 import { JsonCodeEditor } from '../code-editor';
 import { displayObject } from '../../../utils/display-utils';
@@ -82,15 +82,15 @@ describe('Edit setting', () => {
       />
     );
 
-    expect(component.find(EuiSwitch).prop('checked')).toBeTruthy();
+    expect(component.find(EuiCompressedSwitch).prop('checked')).toBeTruthy();
 
-    expect(component.find(EuiComboBox).length).toEqual(2);
+    expect(component.find(EuiCompressedComboBox).length).toEqual(2);
 
-    expect(component.find(EuiComboBox).at(0).prop('selectedOptions')).toEqual(
+    expect(component.find(EuiCompressedComboBox).at(0).prop('selectedOptions')).toEqual(
       audit.disabled_rest_categories?.map(stringToComboBoxOption)
     );
 
-    expect(component.find(EuiComboBox).at(1).prop('selectedOptions')).toEqual(
+    expect(component.find(EuiCompressedComboBox).at(1).prop('selectedOptions')).toEqual(
       compliance.read_ignore_users?.map(stringToComboBoxOption)
     );
 

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -14,7 +14,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiCode,
   EuiFlexGroup,
   EuiFlexItem,
@@ -64,14 +64,14 @@ const addBackendStep = {
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             data-test-subj="review-authentication-and-authorization"
             onClick={() => {
               window.location.href = buildHashUrl(ResourceType.auth);
             }}
           >
             Review authentication and authorization
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
 
@@ -95,7 +95,7 @@ const setOfSteps = [
 
         <EuiFlexGroup gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="explore-existing-roles"
               fill
               onClick={() => {
@@ -103,17 +103,17 @@ const setOfSteps = [
               }}
             >
               Explore existing roles
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="create-new-role"
               onClick={() => {
                 window.location.href = buildHashUrl(ResourceType.roles, Action.create);
               }}
             >
               Create new role
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
 
@@ -135,7 +135,7 @@ const setOfSteps = [
 
         <EuiFlexGroup gutterSize="s">
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="map-users-to-role"
               fill
               onClick={() => {
@@ -143,17 +143,17 @@ const setOfSteps = [
               }}
             >
               Map users to a role
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="create-internal-user"
               onClick={() => {
                 window.location.href = buildHashUrl(ResourceType.users, Action.create);
               }}
             >
               Create internal user
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </>
@@ -219,7 +219,7 @@ export function GetStarted(props: AppDependencies) {
               />{' '}
               <ExternalLink href={DocLinks.AuditLogsDoc} />
             </p>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="review-audit-log-configuration"
               fill
               onClick={() => {
@@ -227,7 +227,7 @@ export function GetStarted(props: AppDependencies) {
               }}
             >
               Review Audit Log Configuration
-            </EuiButton>
+            </EuiSmallButton>
           </EuiText>
         </EuiPanel>
 
@@ -242,7 +242,7 @@ export function GetStarted(props: AppDependencies) {
               By default, the security plugin caches authenticated users, along with their roles and
               permissions. This option will purge cached users, roles and permissions.
             </p>
-            <EuiButton
+            <EuiSmallButton
               iconType="refresh"
               fill
               data-test-subj="purge-cache"
@@ -270,7 +270,7 @@ export function GetStarted(props: AppDependencies) {
               }}
             >
               Purge cache
-            </EuiButton>
+            </EuiSmallButton>
           </EuiText>
         </EuiPanel>
 
@@ -289,23 +289,23 @@ export function GetStarted(props: AppDependencies) {
               </p>
               <EuiFlexGroup gutterSize="s">
                 <EuiFlexItem grow={false}>
-                  <EuiButton
+                  <EuiSmallButton
                     fill
                     onClick={() => {
                       window.location.href = buildHashUrl(ResourceType.tenants);
                     }}
                   >
                     Manage Multi-tenancy
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiFlexItem>
                 <EuiFlexItem grow={false}>
-                  <EuiButton
+                  <EuiSmallButton
                     onClick={() => {
                       window.location.href = buildHashUrl(ResourceType.tenantsConfigureTab);
                     }}
                   >
                     Configure Multi-tenancy
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiText>

--- a/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
@@ -14,7 +14,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -88,13 +88,13 @@ function generateAttributesPanels(
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFormRow hasEmptyLabelSpace={arrayIndex === 0 ? true : false}>
-              <EuiButton
+              <EuiSmallButton
                 id={`delete-${arrayIndex}`}
                 color="danger"
                 onClick={() => removeElementFromArray(setAttributes, [], arrayIndex)}
               >
                 Remove
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -116,22 +116,22 @@ export function AttributePanel(props: {
   return (
     <PanelWithHeader
       headerText="Attributes"
-      headerSubText="Attributes can be used to further describe the user, and, more importantly they can be used as 
-      variables in the Document Level Security query in the index permission of a role. This makes it possible to 
+      headerSubText="Attributes can be used to further describe the user, and, more importantly they can be used as
+      variables in the Document Level Security query in the index permission of a role. This makes it possible to
       write dynamic DLS queries based on a user's attributes."
       helpLink={DocLinks.AttributeBasedSecurityDoc}
       optional
     >
       {generateAttributesPanels(state, setState)}
       <EuiSpacer />
-      <EuiButton
+      <EuiSmallButton
         id="add-row"
         onClick={() => {
           appendElementToArray(setState, [], getEmptyAttribute());
         }}
       >
         Add another attribute
-      </EuiButton>
+      </EuiSmallButton>
     </PanelWithHeader>
   );
 }

--- a/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
@@ -19,7 +19,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
-  EuiFormRow,
+  EuiCompressedFormRow,
 } from '@elastic/eui';
 import { map, isEmpty } from 'lodash';
 import React, { Dispatch, Fragment, SetStateAction } from 'react';
@@ -87,7 +87,7 @@ function generateAttributesPanels(
             </FormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFormRow hasEmptyLabelSpace={arrayIndex === 0 ? true : false}>
+            <EuiCompressedFormRow hasEmptyLabelSpace={arrayIndex === 0 ? true : false}>
               <EuiSmallButton
                 id={`delete-${arrayIndex}`}
                 color="danger"
@@ -95,7 +95,7 @@ function generateAttributesPanels(
               >
                 Remove
               </EuiSmallButton>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
       </Fragment>

--- a/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
@@ -15,7 +15,7 @@
 
 import {
   EuiSmallButton,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -68,7 +68,7 @@ function generateAttributesPanels(
         <EuiFlexGroup>
           <EuiFlexItem grow={false}>
             <FormRow headerText={arrayIndex === 0 ? 'Variable name' : ''}>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 id={`attribute-${arrayIndex}`}
                 value={userAttribute.key}
                 onChange={(e) => onValueChangeHandler('key')(e.target.value)}
@@ -78,7 +78,7 @@ function generateAttributesPanels(
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <FormRow headerText={arrayIndex === 0 ? 'Value' : ''}>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 id={`value-${arrayIndex}`}
                 value={userAttribute.value}
                 onChange={(e) => onValueChangeHandler('value')(e.target.value)}

--- a/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
@@ -15,7 +15,7 @@
 
 import {
   EuiSmallButton,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
@@ -48,7 +48,7 @@ function generateBackendRolesPanels(
               error={roleEmptyErrorMessage}
               isInvalid={arrayIndex === emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}
             >
-              <EuiFieldText
+              <EuiCompressedFieldText
                 isInvalid={arrayIndex === emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}
                 id={`backend-role-${arrayIndex}`}
                 value={backendRole}

--- a/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
@@ -14,7 +14,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFieldText,
   EuiFlexGroup,
   EuiFlexItem,
@@ -62,13 +62,13 @@ function generateBackendRolesPanels(
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFormRow hasEmptyLabelSpace={arrayIndex === 0 ? true : false}>
-              <EuiButton
+              <EuiSmallButton
                 id={`backend-role-delete-${arrayIndex}`}
                 color="danger"
                 onClick={() => removeElementFromArray(setBackendRoles, [], arrayIndex)}
               >
                 Remove
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -105,7 +105,7 @@ export function BackendRolePanel(props: {
         setRoleEmptyErrorMessage
       )}
       <EuiSpacer />
-      <EuiButton
+      <EuiSmallButton
         id="backend-role-add-row"
         onClick={() => {
           if (state.indexOf('') !== -1) {
@@ -118,7 +118,7 @@ export function BackendRolePanel(props: {
         }}
       >
         Add another backend role
-      </EuiButton>
+      </EuiSmallButton>
     </PanelWithHeader>
   );
 }

--- a/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
@@ -19,7 +19,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiSpacer,
-  EuiFormRow,
+  EuiCompressedFormRow,
 } from '@elastic/eui';
 import { isEmpty } from 'lodash';
 import React, { Dispatch, Fragment, SetStateAction, useState } from 'react';
@@ -43,7 +43,7 @@ function generateBackendRolesPanels(
       <Fragment key={`backend-role-${arrayIndex}`}>
         <EuiFlexGroup>
           <EuiFlexItem className={LIMIT_WIDTH_INPUT_CLASS}>
-            <EuiFormRow
+            <EuiCompressedFormRow
               label={arrayIndex === 0 ? 'Backend role' : ''}
               error={roleEmptyErrorMessage}
               isInvalid={arrayIndex === emptyRoleIndex && !isEmpty(roleEmptyErrorMessage)}
@@ -58,10 +58,10 @@ function generateBackendRolesPanels(
                 }}
                 placeholder="Type in backend role"
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFormRow hasEmptyLabelSpace={arrayIndex === 0 ? true : false}>
+            <EuiCompressedFormRow hasEmptyLabelSpace={arrayIndex === 0 ? true : false}>
               <EuiSmallButton
                 id={`backend-role-delete-${arrayIndex}`}
                 color="danger"
@@ -69,7 +69,7 @@ function generateBackendRolesPanels(
               >
                 Remove
               </EuiSmallButton>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
       </Fragment>

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -14,7 +14,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
@@ -198,16 +198,16 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
       <EuiSpacer size="m" />
       <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             onClick={() => {
               window.location.href = buildHashUrl(ResourceType.users);
             }}
           >
             Cancel
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             id="submit"
             fill
             onClick={updateUserHandler}
@@ -215,7 +215,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
             data-test-subj="submit-save-user"
           >
             {props.action === 'edit' ? 'Save changes' : 'Create'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />

--- a/public/apps/configuration/panels/internal-user-edit/test/__snapshots__/backend-role-panel.test.tsx.snap
+++ b/public/apps/configuration/panels/internal-user-edit/test/__snapshots__/backend-role-panel.test.tsx.snap
@@ -11,9 +11,9 @@ exports[`User editing - backend role panel BackendRolePanel add backend role whe
     <EuiFlexItem
       className="limit-width-input"
     >
-      <EuiFormRow
+      <EuiCompressedFormRow
         describedByIds={Array []}
-        display="row"
+        display="rowCompressed"
         error=""
         fullWidth={false}
         hasChildLabel={true}
@@ -22,43 +22,43 @@ exports[`User editing - backend role panel BackendRolePanel add backend role whe
         label="Backend role"
         labelType="label"
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           id="backend-role-0"
           isInvalid={false}
           onChange={[Function]}
           placeholder="Type in backend role"
           value="admin"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </EuiFlexItem>
     <EuiFlexItem
       grow={false}
     >
-      <EuiFormRow
+      <EuiCompressedFormRow
         describedByIds={Array []}
-        display="row"
+        display="rowCompressed"
         fullWidth={false}
         hasChildLabel={true}
         hasEmptyLabelSpace={true}
         labelType="label"
       >
-        <EuiButton
+        <EuiSmallButton
           color="danger"
           id="backend-role-delete-0"
           onClick={[Function]}
         >
           Remove
-        </EuiButton>
-      </EuiFormRow>
+        </EuiSmallButton>
+      </EuiCompressedFormRow>
     </EuiFlexItem>
   </EuiFlexGroup>
   <EuiFlexGroup>
     <EuiFlexItem
       className="limit-width-input"
     >
-      <EuiFormRow
+      <EuiCompressedFormRow
         describedByIds={Array []}
-        display="row"
+        display="rowCompressed"
         error=""
         fullWidth={false}
         hasChildLabel={true}
@@ -67,43 +67,43 @@ exports[`User editing - backend role panel BackendRolePanel add backend role whe
         label=""
         labelType="label"
       >
-        <EuiFieldText
+        <EuiCompressedFieldText
           id="backend-role-1"
           isInvalid={false}
           onChange={[Function]}
           placeholder="Type in backend role"
           value="HR"
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </EuiFlexItem>
     <EuiFlexItem
       grow={false}
     >
-      <EuiFormRow
+      <EuiCompressedFormRow
         describedByIds={Array []}
-        display="row"
+        display="rowCompressed"
         fullWidth={false}
         hasChildLabel={true}
         hasEmptyLabelSpace={false}
         labelType="label"
       >
-        <EuiButton
+        <EuiSmallButton
           color="danger"
           id="backend-role-delete-1"
           onClick={[Function]}
         >
           Remove
-        </EuiButton>
-      </EuiFormRow>
+        </EuiSmallButton>
+      </EuiCompressedFormRow>
     </EuiFlexItem>
   </EuiFlexGroup>
   <EuiSpacer />
-  <EuiButton
+  <EuiSmallButton
     id="backend-role-add-row"
     onClick={[Function]}
   >
     Add another backend role
-  </EuiButton>
+  </EuiSmallButton>
 </PanelWithHeader>
 `;
 
@@ -115,11 +115,11 @@ exports[`User editing - backend role panel BackendRolePanel add backend role whe
   optional={true}
 >
   <EuiSpacer />
-  <EuiButton
+  <EuiSmallButton
     id="backend-role-add-row"
     onClick={[Function]}
   >
     Add another backend role
-  </EuiButton>
+  </EuiSmallButton>
 </PanelWithHeader>
 `;

--- a/public/apps/configuration/panels/internal-user-edit/test/attribute-panel.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/attribute-panel.test.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiFieldText, EuiFlexGroup } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiFlexGroup } from '@elastic/eui';
 import { shallow } from 'enzyme';
 import React from 'react';
 import {
@@ -66,10 +66,10 @@ describe('User editing - attribute panel', () => {
       const component = shallow(<AttributePanel state={sampleState} setState={setState} />);
 
       expect(component.find(EuiFlexGroup).length).toBe(2);
-      expect(component.find(EuiFieldText).at(0).prop('value')).toBe(attr1);
-      expect(component.find(EuiFieldText).at(1).prop('value')).toBe(value1);
-      expect(component.find(EuiFieldText).at(2).prop('value')).toBe(attr2);
-      expect(component.find(EuiFieldText).at(3).prop('value')).toBe(value2);
+      expect(component.find(EuiCompressedFieldText).at(0).prop('value')).toBe(attr1);
+      expect(component.find(EuiCompressedFieldText).at(1).prop('value')).toBe(value1);
+      expect(component.find(EuiCompressedFieldText).at(2).prop('value')).toBe(attr2);
+      expect(component.find(EuiCompressedFieldText).at(3).prop('value')).toBe(value2);
     });
 
     it('add row', () => {

--- a/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiFieldText, EuiFlexGroup } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiFlexGroup } from '@elastic/eui';
 import { shallow } from 'enzyme';
 import React from 'react';
 import {
@@ -48,8 +48,8 @@ describe('User editing - backend role panel', () => {
       const component = shallow(<BackendRolePanel state={sampleState} setState={setState} />);
 
       expect(component.find(EuiFlexGroup).length).toBe(2);
-      expect(component.find(EuiFieldText).at(0).prop('value')).toBe(backendRole1);
-      expect(component.find(EuiFieldText).at(1).prop('value')).toBe(backendRole2);
+      expect(component.find(EuiCompressedFieldText).at(0).prop('value')).toBe(backendRole1);
+      expect(component.find(EuiCompressedFieldText).at(1).prop('value')).toBe(backendRole2);
     });
 
     it('add row', () => {

--- a/public/apps/configuration/panels/permission-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/permission-list/edit-modal.tsx
@@ -15,7 +15,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -87,7 +87,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
         </EuiModalBody>
 
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={props.handleClose}>Cancel</EuiSmallButtonEmpty>
 
           <EuiSmallButton
             id="submit"

--- a/public/apps/configuration/panels/permission-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/permission-list/edit-modal.tsx
@@ -23,7 +23,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiForm,
-  EuiComboBox,
+  EuiCompressedComboBox,
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import { ComboBoxOptions, Action } from '../../types';
@@ -76,7 +76,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
               setIsFormValid={setIsFormValid}
             />
             <FormRow headerText="Permissions">
-              <EuiComboBox
+              <EuiCompressedComboBox
                 options={props.optionUniverse}
                 selectedOptions={allowedActions}
                 onCreateOption={appendOptionToComboBoxHandler(setAllowedActions, [])}

--- a/public/apps/configuration/panels/permission-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/permission-list/edit-modal.tsx
@@ -14,7 +14,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiModal,
   EuiModalBody,
@@ -89,7 +89,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
         <EuiModalFooter>
           <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
 
-          <EuiButton
+          <EuiSmallButton
             id="submit"
             onClick={async () => {
               await props.handleSave(groupName, allowedActions.map(comboBoxOptionToString));
@@ -98,7 +98,7 @@ export function PermissionEditModal(props: PermissionEditModalDeps) {
             disabled={!isFormValid}
           >
             {props.action === Action.create ? 'Create' : 'Save'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -30,7 +30,7 @@ import {
   EuiText,
   EuiTitle,
   RIGHT_ALIGNMENT,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   Query,
   EuiLoadingContent,
 } from '@elastic/eui';
@@ -249,15 +249,15 @@ export function PermissionList(props: AppDependencies) {
   );
 
   const actionsMenuItems = [
-    <EuiButtonEmpty
+    <EuiSmallButtonEmpty
       id="edit"
       key="edit"
       onClick={() => showEditModal(selection[0].name, Action.edit, selection[0].allowedActions)}
       disabled={selection.length !== 1 || selection[0].reserved}
     >
       Edit
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       id="duplicate"
       key="duplicate"
       onClick={() =>
@@ -270,15 +270,15 @@ export function PermissionList(props: AppDependencies) {
       disabled={selection.length !== 1 || selection[0].type !== 'Action group'}
     >
       Duplicate
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       key="delete"
       color="danger"
       onClick={showDeleteConfirmModal}
       disabled={selection.length === 0 || selection.some((group) => group.reserved)}
     >
       Delete
-    </EuiButtonEmpty>,
+    </EuiSmallButtonEmpty>,
   ];
 
   const [actionsMenu, closeActionsMenu] = useContextMenuState('Actions', {}, actionsMenuItems);
@@ -331,10 +331,10 @@ export function PermissionList(props: AppDependencies) {
   };
 
   const createActionGroupMenuItems = [
-    <EuiButtonEmpty key="create-from-blank" onClick={() => showEditModal('', Action.create, [])}>
+    <EuiSmallButtonEmpty key="create-from-blank" onClick={() => showEditModal('', Action.create, [])}>
       Create from blank
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       key="create-from-selection"
       id="create-from-selection"
       onClick={() =>
@@ -347,7 +347,7 @@ export function PermissionList(props: AppDependencies) {
       disabled={selection.length === 0}
     >
       Create from selection
-    </EuiButtonEmpty>,
+    </EuiSmallButtonEmpty>,
   ];
 
   const [createActionGroupMenu] = useContextMenuState(

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -15,7 +15,7 @@
 
 import {
   EuiBasicTableColumn,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiFlexGroup,
   EuiFlexItem,
   EuiGlobalToastList,
@@ -95,7 +95,7 @@ export function renderRowExpansionArrow(
 ) {
   return (item: PermissionListingItem) =>
     item.type === 'Action group' && (
-      <EuiButtonIcon
+      <EuiSmallButtonIcon
         onClick={() => toggleRowDetails(item, actionGroupDict, setItemIdToExpandedRowMap)}
         aria-label={itemIdToExpandedRowMap[item.name] ? 'Collapse' : 'Expand'}
         iconType={itemIdToExpandedRowMap[item.name] ? 'arrowUp' : 'arrowDown'}

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -331,7 +331,10 @@ export function PermissionList(props: AppDependencies) {
   };
 
   const createActionGroupMenuItems = [
-    <EuiSmallButtonEmpty key="create-from-blank" onClick={() => showEditModal('', Action.create, [])}>
+    <EuiSmallButtonEmpty
+      key="create-from-blank"
+      onClick={() => showEditModal('', Action.create, [])}
+    >
       Create from blank
     </EuiSmallButtonEmpty>,
     <EuiSmallButtonEmpty

--- a/public/apps/configuration/panels/permission-list/test/permission-list.test.tsx
+++ b/public/apps/configuration/panels/permission-list/test/permission-list.test.tsx
@@ -21,7 +21,7 @@ import {
   toggleRowDetails,
   renderRowExpansionArrow,
 } from '../permission-list';
-import { EuiInMemoryTable, EuiButtonIcon } from '@elastic/eui';
+import { EuiInMemoryTable, EuiSmallButtonIcon } from '@elastic/eui';
 import {
   requestDeleteActionGroups,
   fetchActionGroups,
@@ -82,7 +82,7 @@ describe('Permission list page ', () => {
       const Wrapper = () => <>{renderFunc(sampleActionGroup)}</>;
       const component = shallow(<Wrapper />);
 
-      expect(component.find(EuiButtonIcon).prop('iconType')).toBe('arrowDown');
+      expect(component.find(EuiSmallButtonIcon).prop('iconType')).toBe('arrowDown');
     });
 
     it('should render up arrow when expanded', () => {
@@ -94,7 +94,7 @@ describe('Permission list page ', () => {
       const Wrapper = () => <>{renderFunc(sampleActionGroup)}</>;
       const component = shallow(<Wrapper />);
 
-      expect(component.find(EuiButtonIcon).prop('iconType')).toBe('arrowUp');
+      expect(component.find(EuiSmallButtonIcon).prop('iconType')).toBe('arrowUp');
     });
   });
 

--- a/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { Dispatch, SetStateAction } from 'react';
-import { EuiForm, EuiFlexGroup, EuiFlexItem, EuiComboBox } from '@elastic/eui';
+import { EuiForm, EuiFlexGroup, EuiFlexItem, EuiCompressedComboBox } from '@elastic/eui';
 import { ComboBoxOptions } from '../../types';
 import { ResourceType } from '../../../../../common';
 import { PanelWithHeader } from '../../utils/panel-with-header';
@@ -45,7 +45,7 @@ export function ClusterPermissionPanel(props: {
         >
           <EuiFlexGroup>
             <EuiFlexItem className={LIMIT_WIDTH_INPUT_CLASS}>
-              <EuiComboBox
+              <EuiCompressedComboBox
                 placeholder="Search for action group name or permission name"
                 options={optionUniverse}
                 selectedOptions={state}

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -21,7 +21,7 @@ import {
   EuiFlexItem,
   EuiHorizontalRule,
   EuiCompressedSuperSelect,
-  EuiTextArea,
+  EuiCompressedTextArea,
 } from '@elastic/eui';
 import React, { Dispatch, Fragment, SetStateAction, useEffect } from 'react';
 import { isEmpty } from 'lodash';
@@ -180,7 +180,7 @@ export function DocLevelSecurityRow(props: {
       helpLink={DocLinks.DocumentLevelSecurityDoc}
       optional
     >
-      <EuiTextArea
+      <EuiCompressedTextArea
         placeholder={FIELD_LEVEL_SECURITY_PLACEHOLDER}
         value={props.value}
         onChange={props.onChangeHandler}

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -15,7 +15,7 @@
 
 import {
   EuiAccordion,
-  EuiButton,
+  EuiSmallButton,
   EuiComboBox,
   EuiFlexGroup,
   EuiFlexItem,
@@ -271,12 +271,12 @@ export function generateIndexPermissionPanels(
             'Add index permission'
           }
           extraAction={
-            <EuiButton
+            <EuiSmallButton
               color="danger"
               onClick={() => removeElementFromArray(setRoleIndexPermission, [], arrayIndex)}
             >
               Remove
-            </EuiButton>
+            </EuiSmallButton>
           }
         >
           <IndexPatternRow
@@ -332,13 +332,13 @@ export function IndexPermissionPanel(props: {
       helpLink={DocLinks.IndexPermissionsDoc}
     >
       {generateIndexPermissionPanels(state, optionUniverse, setState)}
-      <EuiButton
+      <EuiSmallButton
         onClick={() => {
           appendElementToArray(setState, [], getEmptyIndexPermission());
         }}
       >
         Add another index permission
-      </EuiButton>
+      </EuiSmallButton>
     </PanelWithHeader>
   );
 }

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -20,7 +20,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
   EuiTextArea,
 } from '@elastic/eui';
 import React, { Dispatch, Fragment, SetStateAction, useEffect } from 'react';
@@ -204,7 +204,7 @@ export function FieldLevelSecurityRow(props: {
     >
       <EuiFlexGroup>
         <EuiFlexItem grow={1}>
-          <EuiSuperSelect
+          <EuiCompressedSuperSelect
             valueOfSelected={props.method}
             options={[
               { inputDisplay: 'Include', value: 'include' },

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -16,7 +16,7 @@
 import {
   EuiAccordion,
   EuiSmallButton,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiFlexGroup,
   EuiFlexItem,
   EuiHorizontalRule,
@@ -121,7 +121,7 @@ export function IndexPatternRow(props: {
   return (
     <FormRow headerText="Index" helpText="Specify index pattern using *">
       <EuiFlexItem className={LIMIT_WIDTH_INPUT_CLASS}>
-        <EuiComboBox
+        <EuiCompressedComboBox
           noSuggestions
           placeholder="Search for index name or type in index pattern"
           selectedOptions={props.value}
@@ -149,7 +149,7 @@ export function IndexPermissionRow(props: {
     >
       <EuiFlexGroup>
         <EuiFlexItem className={LIMIT_WIDTH_INPUT_CLASS}>
-          <EuiComboBox
+          <EuiCompressedComboBox
             placeholder="Search for action group name or permission name"
             options={props.permisionOptionsSet}
             selectedOptions={props.value}
@@ -214,7 +214,7 @@ export function FieldLevelSecurityRow(props: {
           />
         </EuiFlexItem>
         <EuiFlexItem grow={9}>
-          <EuiComboBox
+          <EuiCompressedComboBox
             noSuggestions
             placeholder="Type in field name"
             selectedOptions={props.fields}
@@ -238,7 +238,7 @@ export function AnonymizationRow(props: {
       headerSubText="Masks any sensitive fields with a random value to protect your data security."
       optional
     >
-      <EuiComboBox
+      <EuiCompressedComboBox
         noSuggestions
         placeholder="Type in field name"
         selectedOptions={props.value}

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -14,7 +14,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiForm,
@@ -288,23 +288,23 @@ export function RoleEdit(props: RoleEditDeps) {
       <EuiSpacer size="m" />
       <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             onClick={() => {
               window.location.href = buildHashUrl(ResourceType.roles);
             }}
           >
             Cancel
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             fill
             onClick={updateRoleHandler}
             disabled={!isFormValid}
             data-test-subj="create-or-update-role"
           >
             {props.action === 'edit' ? 'Update' : 'Create'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -15,7 +15,7 @@
 
 import {
   EuiSmallButton,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiFlexGroup,
   EuiFlexItem,
   EuiCompressedSuperSelect,
@@ -91,7 +91,7 @@ function generateTenantPermissionPanels(
       <Fragment key={`tenant-permission-${arrayIndex}`}>
         <EuiFlexGroup>
           <EuiFlexItem style={{ maxWidth: '400px' }}>
-            <EuiComboBox
+            <EuiCompressedComboBox
               placeholder="Search tenant name or add a tenant pattern"
               selectedOptions={tenantPermission.tenantPatterns}
               onChange={onValueChangeHandler('tenantPatterns')}

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -18,7 +18,7 @@ import {
   EuiComboBox,
   EuiFlexGroup,
   EuiFlexItem,
-  EuiSuperSelect,
+  EuiCompressedSuperSelect,
 } from '@elastic/eui';
 import React, { Dispatch, Fragment, SetStateAction, useEffect } from 'react';
 import { isEmpty } from 'lodash';
@@ -101,7 +101,7 @@ function generateTenantPermissionPanels(
             />
           </EuiFlexItem>
           <EuiFlexItem style={{ maxWidth: '170px' }}>
-            <EuiSuperSelect
+            <EuiCompressedSuperSelect
               valueOfSelected={tenantPermission.permissionType}
               onChange={onValueChangeHandler('permissionType')}
               options={[

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -13,7 +13,13 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiSmallButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiSuperSelect } from '@elastic/eui';
+import {
+  EuiSmallButton,
+  EuiComboBox,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSuperSelect,
+} from '@elastic/eui';
 import React, { Dispatch, Fragment, SetStateAction, useEffect } from 'react';
 import { isEmpty } from 'lodash';
 import { RoleTenantPermission, TenantPermissionType, ComboBoxOptions } from '../../types';

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiSuperSelect } from '@elastic/eui';
+import { EuiSmallButton, EuiComboBox, EuiFlexGroup, EuiFlexItem, EuiSuperSelect } from '@elastic/eui';
 import React, { Dispatch, Fragment, SetStateAction, useEffect } from 'react';
 import { isEmpty } from 'lodash';
 import { RoleTenantPermission, TenantPermissionType, ComboBoxOptions } from '../../types';
@@ -108,12 +108,12 @@ function generateTenantPermissionPanels(
             />
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiButton
+            <EuiSmallButton
               color="danger"
               onClick={() => removeElementFromArray(setPermissions, [], arrayIndex)}
             >
               Remove
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </Fragment>
@@ -145,13 +145,13 @@ export function TenantPanel(props: {
         {generateTenantPermissionPanels(state, optionUniverse, setState)}
       </FormRow>
 
-      <EuiButton
+      <EuiSmallButton
         onClick={() => {
           appendElementToArray(setState, [], getEmptyTenantPermission());
         }}
       >
         Add another tenant permission
-      </EuiButton>
+      </EuiSmallButton>
     </PanelWithHeader>
   );
 }

--- a/public/apps/configuration/panels/role-edit/test/cluster-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/cluster-permission-panel.test.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiComboBox } from '@elastic/eui';
+import { EuiCompressedComboBox } from '@elastic/eui';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { ComboBoxOptions } from '../../../types';
@@ -34,7 +34,7 @@ describe('Role edit - cluster permission panel', () => {
       <ClusterPermissionPanel state={state} optionUniverse={optionUniverse} setState={setState} />
     );
 
-    const comboBox = component.find(EuiComboBox).first();
+    const comboBox = component.find(EuiCompressedComboBox).first();
     expect(comboBox.prop('selectedOptions')).toBe(state);
     expect(comboBox.prop('options')).toBe(optionUniverse);
     expect(comboBox.prop('onChange')).toBe(setState);

--- a/public/apps/configuration/panels/role-edit/test/index-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/index-permission-panel.test.tsx
@@ -29,7 +29,12 @@ import {
   AnonymizationRow,
 } from '../index-permission-panel';
 import { RoleIndexPermissionStateClass } from '../types';
-import { EuiComboBox, EuiSuperSelect, EuiButton, EuiTextArea } from '@elastic/eui';
+import {
+  EuiCompressedComboBox,
+  EuiCompressedSuperSelect,
+  EuiSmallButton,
+  EuiCompressedTextArea,
+} from '@elastic/eui';
 
 jest.mock('../../../utils/array-state-utils');
 // eslint-disable-next-line
@@ -123,7 +128,7 @@ describe('Role edit - index permission panel', () => {
 
     const component = shallow(<IndexPatternRow {...{ value, onChangeHandler, onCreateHandler }} />);
 
-    expect(component.find(EuiComboBox).first().prop('selectedOptions')).toBe(value);
+    expect(component.find(EuiCompressedComboBox).first().prop('selectedOptions')).toBe(value);
   });
 
   it('IndexPermissionRow', () => {
@@ -135,7 +140,7 @@ describe('Role edit - index permission panel', () => {
       <IndexPermissionRow {...{ value, onChangeHandler, permisionOptionsSet }} />
     );
 
-    expect(component.find(EuiComboBox).first().prop('selectedOptions')).toBe(value);
+    expect(component.find(EuiCompressedComboBox).first().prop('selectedOptions')).toBe(value);
   });
 
   it('DocLevelSecurityRow', () => {
@@ -144,7 +149,7 @@ describe('Role edit - index permission panel', () => {
 
     const component = shallow(<DocLevelSecurityRow {...{ value, onChangeHandler }} />);
 
-    expect(component.find(EuiTextArea).first().prop('value')).toBe(value);
+    expect(component.find(EuiCompressedTextArea).first().prop('value')).toBe(value);
   });
 
   it('FieldLevelSecurityRow', () => {
@@ -160,8 +165,8 @@ describe('Role edit - index permission panel', () => {
       />
     );
 
-    expect(component.find(EuiSuperSelect).first().prop('valueOfSelected')).toBe(method);
-    expect(component.find(EuiComboBox).first().prop('selectedOptions')).toBe(fields);
+    expect(component.find(EuiCompressedSuperSelect).first().prop('valueOfSelected')).toBe(method);
+    expect(component.find(EuiCompressedComboBox).first().prop('selectedOptions')).toBe(fields);
   });
 
   it('AnonymizationRow', () => {
@@ -173,7 +178,7 @@ describe('Role edit - index permission panel', () => {
       <AnonymizationRow {...{ value, onChangeHandler, onCreateHandler }} />
     );
 
-    expect(component.find(EuiComboBox).first().prop('selectedOptions')).toBe(value);
+    expect(component.find(EuiCompressedComboBox).first().prop('selectedOptions')).toBe(value);
   });
 
   describe('IndexPermissionPanel', () => {
@@ -230,7 +235,7 @@ describe('Role edit - index permission panel', () => {
       const optionUniverse = [allowedAction1, allowedAction2].map(stringToComboBoxOption);
 
       const component = shallow(<IndexPermissionPanel {...{ state, optionUniverse, setState }} />);
-      component.find(EuiButton).last().simulate('click');
+      component.find(EuiSmallButton).last().simulate('click');
 
       expect(arrayStateUtils.appendElementToArray).toHaveBeenCalledTimes(1);
     });

--- a/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiButton } from '@elastic/eui';
+import { EuiSmallButton } from '@elastic/eui';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { updateRole } from '../../../utils/role-detail-utils';
@@ -118,7 +118,7 @@ describe('Role edit', () => {
       />
     );
     // click update
-    component.find(EuiButton).last().simulate('click');
+    component.find(EuiSmallButton).last().simulate('click');
 
     expect(updateRole).toBeCalledWith(
       mockCoreStart.http,

--- a/public/apps/configuration/panels/role-edit/test/tenant-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/tenant-panel.test.tsx
@@ -23,7 +23,7 @@ import {
 } from '../tenant-panel';
 import { shallow } from 'enzyme';
 import React from 'react';
-import { EuiComboBox, EuiButton, EuiSuperSelect } from '@elastic/eui';
+import { EuiCompressedComboBox, EuiSmallButton, EuiCompressedSuperSelect } from '@elastic/eui';
 import { render } from '@testing-library/react';
 
 jest.mock('../../../utils/array-state-utils');
@@ -103,12 +103,12 @@ describe('Role edit - tenant panel', () => {
         <TenantPanel state={state} optionUniverse={optionUniverse} setState={setState} />
       );
 
-      const comboBoxArray = component.find(EuiComboBox);
+      const comboBoxArray = component.find(EuiCompressedComboBox);
       expect(comboBoxArray.length).toEqual(2);
       expect(comboBoxArray.at(0).prop('selectedOptions')).toBe(state[0].tenantPatterns);
       expect(comboBoxArray.at(1).prop('selectedOptions')).toBe(state[1].tenantPatterns);
 
-      const superSelectArray = component.find(EuiSuperSelect);
+      const superSelectArray = component.find(EuiCompressedSuperSelect);
       expect(superSelectArray.at(0).prop('valueOfSelected')).toBe(state[0].permissionType);
       expect(superSelectArray.at(1).prop('valueOfSelected')).toBe(state[1].permissionType);
     });
@@ -118,7 +118,7 @@ describe('Role edit - tenant panel', () => {
         <TenantPanel state={[]} optionUniverse={optionUniverse} setState={setState} />
       );
 
-      const addRowButton = component.find(EuiButton).last();
+      const addRowButton = component.find(EuiSmallButton).last();
       addRowButton.simulate('click');
       expect(arrayStateUtils.appendElementToArray).toHaveBeenCalledTimes(1);
     });
@@ -135,7 +135,7 @@ describe('Role edit - tenant panel', () => {
         <TenantPanel state={state} optionUniverse={optionUniverse} setState={setState} />
       );
 
-      const removeRowButton = component.find(EuiButton).first();
+      const removeRowButton = component.find(EuiSmallButton).first();
       removeRowButton.simulate('click');
       expect(arrayStateUtils.removeElementFromArray).toHaveBeenCalledTimes(1);
     });

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -27,7 +27,7 @@ import {
   EuiPageBody,
   EuiInMemoryTable,
   EuiBasicTableColumn,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiSearchBarProps,
   Query,
   EuiLoadingContent,
@@ -159,7 +159,7 @@ export function RoleList(props: AppDependencies) {
   );
 
   const actionsMenuItems = [
-    <EuiButtonEmpty
+    <EuiSmallButtonEmpty
       data-test-subj="edit"
       key="edit"
       onClick={() => {
@@ -168,9 +168,9 @@ export function RoleList(props: AppDependencies) {
       disabled={selection.length !== 1 || selection[0].reserved}
     >
       Edit
-    </EuiButtonEmpty>,
+    </EuiSmallButtonEmpty>,
     // TODO: Change duplication to a popup window
-    <EuiButtonEmpty
+    <EuiSmallButtonEmpty
       data-test-subj="duplicate"
       key="duplicate"
       onClick={() => {
@@ -183,15 +183,15 @@ export function RoleList(props: AppDependencies) {
       disabled={selection.length !== 1}
     >
       Duplicate
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       key="delete"
       color="danger"
       onClick={showDeleteConfirmModal}
       disabled={selection.length === 0 || selection.some((e) => e.reserved)}
     >
       Delete
-    </EuiButtonEmpty>,
+    </EuiSmallButtonEmpty>,
   ];
 
   const [actionsMenu, closeActionsMenu] = useContextMenuState('Actions', {}, actionsMenuItems);

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -23,7 +23,7 @@ import {
   EuiPageContentHeader,
   EuiPageContentHeaderSection,
   EuiFlexItem,
-  EuiButton,
+  EuiSmallButton,
   EuiPageBody,
   EuiInMemoryTable,
   EuiBasicTableColumn,
@@ -301,13 +301,13 @@ export function RoleList(props: AppDependencies) {
               <EuiFlexGroup>
                 <EuiFlexItem>{actionsMenu}</EuiFlexItem>
                 <EuiFlexItem>
-                  <EuiButton
+                  <EuiSmallButton
                     fill
                     href={buildHashUrl(ResourceType.roles, Action.create)}
                     data-test-subj="create-role"
                   >
                     Create role
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiPageContentHeaderSection>

--- a/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
+++ b/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
@@ -19,7 +19,7 @@ import {
   EuiFlexItem,
   EuiFieldText,
   EuiSmallButton,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiSpacer,
 } from '@elastic/eui';
 import { isEmpty, map } from 'lodash';
@@ -81,7 +81,7 @@ export function ExternalIdentitiesPanel(props: {
             </FormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            <EuiFormRow hasEmptyLabelSpace={arrayIndex === 0 ? true : false}>
+            <EuiCompressedFormRow hasEmptyLabelSpace={arrayIndex === 0 ? true : false}>
               <EuiSmallButton
                 id={`remove-${arrayIndex}`}
                 color="danger"
@@ -89,7 +89,7 @@ export function ExternalIdentitiesPanel(props: {
               >
                 Remove
               </EuiSmallButton>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
       </Fragment>

--- a/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
+++ b/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
@@ -17,7 +17,7 @@ import React, { Dispatch, SetStateAction, Fragment } from 'react';
 import {
   EuiFlexGroup,
   EuiFlexItem,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSmallButton,
   EuiCompressedFormRow,
   EuiSpacer,
@@ -72,7 +72,7 @@ export function ExternalIdentitiesPanel(props: {
         <EuiFlexGroup>
           <EuiFlexItem style={{ maxWidth: '400px' }}>
             <FormRow headerText={arrayIndex === 0 ? 'Backend roles' : ''}>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 id={`externalIdentity-${arrayIndex}`}
                 value={externalIdentity.externalIdentity}
                 onChange={(e) => onValueChangeHandler('externalIdentity')(e.target.value)}

--- a/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
+++ b/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
@@ -18,7 +18,7 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
   EuiFieldText,
-  EuiButton,
+  EuiSmallButton,
   EuiFormRow,
   EuiSpacer,
 } from '@elastic/eui';
@@ -82,13 +82,13 @@ export function ExternalIdentitiesPanel(props: {
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
             <EuiFormRow hasEmptyLabelSpace={arrayIndex === 0 ? true : false}>
-              <EuiButton
+              <EuiSmallButton
                 id={`remove-${arrayIndex}`}
                 color="danger"
                 onClick={() => removeElementFromArray(setExternalIdentities, [], arrayIndex)}
               >
                 Remove
-              </EuiButton>
+              </EuiSmallButton>
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
@@ -104,14 +104,14 @@ export function ExternalIdentitiesPanel(props: {
     >
       {panel}
       <EuiSpacer />
-      <EuiButton
+      <EuiSmallButton
         id="add-row"
         onClick={() => {
           appendElementToArray(setExternalIdentities, [], getEmptyExternalIdentity());
         }}
       >
         Add another backend role
-      </EuiButton>
+      </EuiSmallButton>
     </PanelWithHeader>
   );
 }

--- a/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
+++ b/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
@@ -14,7 +14,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPageHeader,
@@ -174,18 +174,18 @@ export function RoleEditMappedUser(props: RoleEditMappedUserProps) {
       <EuiSpacer size="m" />
       <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
-          <EuiButton
+          <EuiSmallButton
             onClick={() => {
               window.location.href = buildHashUrl(ResourceType.roles, Action.view, props.roleName);
             }}
           >
             Cancel
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
         <EuiFlexItem grow={false}>
-          <EuiButton id="map" fill onClick={updateRoleMappingHandler}>
+          <EuiSmallButton id="map" fill onClick={updateRoleMappingHandler}>
             Map
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiGlobalToastList toasts={toasts} toastLifeTimeMs={10000} dismissToast={removeToast} />

--- a/public/apps/configuration/panels/role-mapping/test/external-identities-panel.test.tsx
+++ b/public/apps/configuration/panels/role-mapping/test/external-identities-panel.test.tsx
@@ -21,7 +21,7 @@ import {
 import { shallow } from 'enzyme';
 import { ExternalIdentityStateClass } from '../types';
 import React from 'react';
-import { EuiFieldText, EuiFlexGroup } from '@elastic/eui';
+import { EuiCompressedFieldText, EuiFlexGroup } from '@elastic/eui';
 import {
   appendElementToArray,
   removeElementFromArray,
@@ -91,8 +91,8 @@ describe('Role mapping - external identities panel', () => {
       );
 
       expect(component.find(EuiFlexGroup).length).toBe(2);
-      expect(component.find(EuiFieldText).at(0).prop('value')).toBe(externalIdentity1);
-      expect(component.find(EuiFieldText).at(1).prop('value')).toBe(externalIdentity2);
+      expect(component.find(EuiCompressedFieldText).at(0).prop('value')).toBe(externalIdentity1);
+      expect(component.find(EuiCompressedFieldText).at(1).prop('value')).toBe(externalIdentity2);
     });
 
     it('add row', () => {

--- a/public/apps/configuration/panels/role-mapping/test/users-panel.test.tsx
+++ b/public/apps/configuration/panels/role-mapping/test/users-panel.test.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiComboBox } from '@elastic/eui';
+import { EuiCompressedComboBox } from '@elastic/eui';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { ComboBoxOptions } from '../../../types';
@@ -31,7 +31,7 @@ describe('Role mapping - Internal users panel', () => {
       <InternalUsersPanel state={state} optionUniverse={optionUniverse} setState={setState} />
     );
 
-    const comboBox = component.find(EuiComboBox).first();
+    const comboBox = component.find(EuiCompressedComboBox).first();
     expect(comboBox.prop('selectedOptions')).toBe(state);
     expect(comboBox.prop('options')).toBe(optionUniverse);
     expect(comboBox.prop('onChange')).toBe(setState);

--- a/public/apps/configuration/panels/role-mapping/users-panel.tsx
+++ b/public/apps/configuration/panels/role-mapping/users-panel.tsx
@@ -14,7 +14,7 @@
  */
 
 import React, { Dispatch, SetStateAction } from 'react';
-import { EuiForm, EuiFlexGroup, EuiFlexItem, EuiComboBox } from '@elastic/eui';
+import { EuiForm, EuiFlexGroup, EuiFlexItem, EuiCompressedComboBox } from '@elastic/eui';
 import { ComboBoxOptions } from '../../types';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { FormRow } from '../../utils/form-row';
@@ -47,7 +47,7 @@ export function InternalUsersPanel(props: {
         >
           <EuiFlexGroup>
             <EuiFlexItem style={{ maxWidth: '400px' }}>
-              <EuiComboBox
+              <EuiCompressedComboBox
                 options={optionUniverse}
                 selectedOptions={state}
                 onChange={setState}

--- a/public/apps/configuration/panels/role-view/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/cluster-permission-panel.tsx
@@ -14,7 +14,7 @@
  */
 
 import React from 'react';
-import { EuiEmptyPrompt, EuiButton } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiSmallButton } from '@elastic/eui';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import { PermissionTree } from '../permission-tree';
 import { ActionGroupItem, DataObject, Action } from '../../types';
@@ -37,7 +37,7 @@ export function ClusterPermissionPanel(props: ClusterPermissionPanelProps) {
       title={<h3>No cluster permission</h3>}
       titleSize="s"
       actions={
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="addClusterPermission"
           disabled={props.isReserved}
           onClick={() => {
@@ -45,7 +45,7 @@ export function ClusterPermissionPanel(props: ClusterPermissionPanelProps) {
           }}
         >
           Add cluster permission
-        </EuiButton>
+        </EuiSmallButton>
       }
     />
   );

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -22,7 +22,7 @@ import {
   EuiText,
   EuiFlexGroup,
   EuiEmptyPrompt,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 import { PanelWithHeader } from '../../utils/panel-with-header';
 import {
@@ -188,7 +188,7 @@ export function IndexPermissionPanel(props: IndexPermissionPanelProps) {
       title={<h3>No index permission</h3>}
       titleSize="s"
       actions={
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="addIndexPermission"
           disabled={props.isReserved}
           onClick={() => {
@@ -196,7 +196,7 @@ export function IndexPermissionPanel(props: IndexPermissionPanelProps) {
           }}
         >
           Add index permission
-        </EuiButton>
+        </EuiSmallButton>
       }
     />
   );

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -18,7 +18,7 @@ import {
   EuiInMemoryTable,
   EuiBasicTableColumn,
   RIGHT_ALIGNMENT,
-  EuiButtonIcon,
+  EuiSmallButtonIcon,
   EuiText,
   EuiFlexGroup,
   EuiEmptyPrompt,
@@ -66,7 +66,7 @@ export function renderRowExpanstionArrow(
   setItemIdToExpandedRowMap: Dispatch<SetStateAction<ExpandedRowMapInterface>>
 ) {
   return (item: RoleIndexPermissionView) => (
-    <EuiButtonIcon
+    <EuiSmallButtonIcon
       onClick={() => toggleRowDetails(item, actionGroupDict, setItemIdToExpandedRowMap)}
       aria-label={itemIdToExpandedRowMap[item.id] ? 'Collapse' : 'Expand'}
       iconType={itemIdToExpandedRowMap[item.id] ? 'arrowUp' : 'arrowDown'}

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -15,7 +15,7 @@
 
 import React, { useState, useContext } from 'react';
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiPageContentHeader,
   EuiPageContentHeaderSection,
   EuiSpacer,
@@ -195,7 +195,7 @@ export function RoleView(props: RoleViewProps) {
             />
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="map-users"
               fill
               onClick={() => {
@@ -208,7 +208,7 @@ export function RoleView(props: RoleViewProps) {
               }}
             >
               Map users
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       }
@@ -302,12 +302,12 @@ export function RoleView(props: RoleViewProps) {
               <EuiPageContentHeaderSection>
                 <EuiFlexGroup>
                   <EuiFlexItem>
-                    <EuiButton onClick={showDeleteConfirmModal} disabled={selection.length === 0}>
+                    <EuiSmallButton onClick={showDeleteConfirmModal} disabled={selection.length === 0}>
                       Delete mapping
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="manage-mapping"
                       onClick={() => {
                         window.location.href = buildHashUrl(
@@ -319,7 +319,7 @@ export function RoleView(props: RoleViewProps) {
                       }}
                     >
                       Manage mapping
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiPageContentHeaderSection>
@@ -377,15 +377,15 @@ export function RoleView(props: RoleViewProps) {
   const [actionsMenu] = useContextMenuState('Actions', {}, actionsMenuItems);
 
   if (isReserved) {
-    pageActions = <EuiButton href={duplicateRoleLink}>Duplicate role</EuiButton>;
+    pageActions = <EuiSmallButton href={duplicateRoleLink}>Duplicate role</EuiSmallButton>;
   } else {
     pageActions = (
       <EuiFlexGroup gutterSize="s">
         <EuiFlexItem>{actionsMenu}</EuiFlexItem>
         <EuiFlexItem>
-          <EuiButton href={buildHashUrl(ResourceType.roles, Action.edit, props.roleName)}>
+          <EuiSmallButton href={buildHashUrl(ResourceType.roles, Action.edit, props.roleName)}>
             Edit role
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     );

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -302,7 +302,10 @@ export function RoleView(props: RoleViewProps) {
               <EuiPageContentHeaderSection>
                 <EuiFlexGroup>
                   <EuiFlexItem>
-                    <EuiSmallButton onClick={showDeleteConfirmModal} disabled={selection.length === 0}>
+                    <EuiSmallButton
+                      onClick={showDeleteConfirmModal}
+                      disabled={selection.length === 0}
+                    >
                       Delete mapping
                     </EuiSmallButton>
                   </EuiFlexItem>

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -32,7 +32,7 @@ import {
   EuiCallOut,
   EuiGlobalToastList,
   EuiHorizontalRule,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
 } from '@elastic/eui';
 import { difference } from 'lodash';
 import { BreadcrumbsPageDependencies } from '../../../types';
@@ -353,10 +353,10 @@ export function RoleView(props: RoleViewProps) {
 
   let pageActions;
   const actionsMenuItems: React.ReactElement[] = [
-    <EuiButtonEmpty key="duplicate" href={duplicateRoleLink}>
+    <EuiSmallButtonEmpty key="duplicate" href={duplicateRoleLink}>
       duplicate
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       data-test-subj="delete"
       key="delete"
       color="danger"
@@ -375,7 +375,7 @@ export function RoleView(props: RoleViewProps) {
       }}
     >
       delete
-    </EuiButtonEmpty>,
+    </EuiSmallButtonEmpty>,
   ];
   const [actionsMenu] = useContextMenuState('Actions', {}, actionsMenuItems);
 

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -21,7 +21,7 @@ import {
   EuiGlobalToastList,
   EuiBasicTableColumn,
   EuiEmptyPrompt,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { getCurrentUser } from '../../../../utils/auth-info-utils';
@@ -171,7 +171,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
       title={<h3>No tenant permission</h3>}
       titleSize="s"
       actions={
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="addTenantPermission"
           disabled={props.isReserved}
           onClick={() => {
@@ -179,7 +179,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
           }}
         >
           Add tenant permission
-        </EuiButton>
+        </EuiSmallButton>
       }
     />
   );

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/index-permission-panel.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/index-permission-panel.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Role view - index permission panel Render document level security rende
 
 exports[`Role view - index permission panel Render row expanstion arrow renders when arrow expanded 1`] = `
 <Fragment>
-  <EuiButtonIcon
+  <EuiSmallButtonIcon
     aria-label="Collapse"
     iconType="arrowUp"
     onClick={[Function]}

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
@@ -51,27 +51,27 @@ exports[`Role view basic rendering when permission tab is selected 1`] = `
         gutterSize="s"
       >
         <EuiFlexItem>
-          <EuiButtonEmpty
+          <EuiSmallButtonEmpty
             href="#/roles/duplicate/role"
             key="duplicate"
           >
             duplicate
-          </EuiButtonEmpty>
-          <EuiButtonEmpty
+          </EuiSmallButtonEmpty>
+          <EuiSmallButtonEmpty
             color="danger"
             data-test-subj="delete"
             key="delete"
             onClick={[Function]}
           >
             delete
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiButton
+          <EuiSmallButton
             href="#/roles/edit/role"
           >
             Edit role
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPageContentHeaderSection>
@@ -211,20 +211,20 @@ exports[`Role view basic rendering when permission tab is selected 1`] = `
                 <EuiPageContentHeaderSection>
                   <EuiFlexGroup>
                     <EuiFlexItem>
-                      <EuiButton
+                      <EuiSmallButton
                         disabled={true}
                         onClick={[MockFunction]}
                       >
                         Delete mapping
-                      </EuiButton>
+                      </EuiSmallButton>
                     </EuiFlexItem>
                     <EuiFlexItem>
-                      <EuiButton
+                      <EuiSmallButton
                         data-test-subj="manage-mapping"
                         onClick={[Function]}
                       >
                         Manage mapping
-                      </EuiButton>
+                      </EuiSmallButton>
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiPageContentHeaderSection>
@@ -268,13 +268,13 @@ exports[`Role view basic rendering when permission tab is selected 1`] = `
                             />
                           </EuiFlexItem>
                           <EuiFlexItem>
-                            <EuiButton
+                            <EuiSmallButton
                               data-test-subj="map-users"
                               fill={true}
                               onClick={[Function]}
                             >
                               Map users
-                            </EuiButton>
+                            </EuiSmallButton>
                           </EuiFlexItem>
                         </EuiFlexGroup>
                       }
@@ -378,27 +378,27 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
         gutterSize="s"
       >
         <EuiFlexItem>
-          <EuiButtonEmpty
+          <EuiSmallButtonEmpty
             href="#/roles/duplicate/role"
             key="duplicate"
           >
             duplicate
-          </EuiButtonEmpty>
-          <EuiButtonEmpty
+          </EuiSmallButtonEmpty>
+          <EuiSmallButtonEmpty
             color="danger"
             data-test-subj="delete"
             key="delete"
             onClick={[Function]}
           >
             delete
-          </EuiButtonEmpty>
+          </EuiSmallButtonEmpty>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiButton
+          <EuiSmallButton
             href="#/roles/edit/role"
           >
             Edit role
-          </EuiButton>
+          </EuiSmallButton>
         </EuiFlexItem>
       </EuiFlexGroup>
     </EuiPageContentHeaderSection>
@@ -441,20 +441,20 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
               <EuiPageContentHeaderSection>
                 <EuiFlexGroup>
                   <EuiFlexItem>
-                    <EuiButton
+                    <EuiSmallButton
                       disabled={true}
                       onClick={[MockFunction]}
                     >
                       Delete mapping
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem>
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="manage-mapping"
                       onClick={[Function]}
                     >
                       Manage mapping
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </EuiPageContentHeaderSection>
@@ -498,13 +498,13 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                           />
                         </EuiFlexItem>
                         <EuiFlexItem>
-                          <EuiButton
+                          <EuiSmallButton
                             data-test-subj="map-users"
                             fill={true}
                             onClick={[Function]}
                           >
                             Map users
-                          </EuiButton>
+                          </EuiSmallButton>
                         </EuiFlexItem>
                       </EuiFlexGroup>
                     }
@@ -629,20 +629,20 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                 <EuiPageContentHeaderSection>
                   <EuiFlexGroup>
                     <EuiFlexItem>
-                      <EuiButton
+                      <EuiSmallButton
                         disabled={true}
                         onClick={[MockFunction]}
                       >
                         Delete mapping
-                      </EuiButton>
+                      </EuiSmallButton>
                     </EuiFlexItem>
                     <EuiFlexItem>
-                      <EuiButton
+                      <EuiSmallButton
                         data-test-subj="manage-mapping"
                         onClick={[Function]}
                       >
                         Manage mapping
-                      </EuiButton>
+                      </EuiSmallButton>
                     </EuiFlexItem>
                   </EuiFlexGroup>
                 </EuiPageContentHeaderSection>
@@ -686,13 +686,13 @@ exports[`Role view renders when mapped user tab is selected 1`] = `
                             />
                           </EuiFlexItem>
                           <EuiFlexItem>
-                            <EuiButton
+                            <EuiSmallButton
                               data-test-subj="map-users"
                               fill={true}
                               onClick={[Function]}
                             >
                               Map users
-                            </EuiButton>
+                            </EuiSmallButton>
                           </EuiFlexItem>
                         </EuiFlexGroup>
                       }

--- a/public/apps/configuration/panels/role-view/test/cluster-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/cluster-permission-panel.test.tsx
@@ -16,7 +16,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { ClusterPermissionPanel } from '../cluster-permission-panel';
-import { EuiButton, EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
+import { EuiSmallButton, EuiEmptyPrompt, EuiLoadingSpinner } from '@elastic/eui';
 import { PermissionTree } from '../../permission-tree';
 import { Action } from '../../../types';
 import { ResourceType } from '../../../../../../common';
@@ -63,7 +63,7 @@ describe('Role view - cluster permission panel', () => {
       />
     );
     const prompt = wrapper.find(EuiEmptyPrompt).dive();
-    expect(prompt.find(EuiButton)).toHaveLength(1);
+    expect(prompt.find(EuiSmallButton)).toHaveLength(1);
     const button = prompt.find('[data-test-subj="addClusterPermission"]');
     expect(button.prop('disabled')).toBe(true);
   });

--- a/public/apps/configuration/panels/role-view/test/index-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/index-permission-panel.test.tsx
@@ -24,7 +24,7 @@ import {
   IndexPermissionPanel,
   renderDocumentLevelSecurity,
 } from '../index-permission-panel';
-import { EuiButtonIcon, EuiEmptyPrompt, EuiInMemoryTable } from '@elastic/eui';
+import { EuiSmallButtonIcon, EuiEmptyPrompt, EuiInMemoryTable } from '@elastic/eui';
 import { buildHashUrl } from '../../../utils/url-builder';
 
 describe('Role view - index permission panel', () => {
@@ -51,7 +51,7 @@ describe('Role view - index permission panel', () => {
       const Wrapper = () => <>{renderFunc(sampleRoleIndexPermission)}</>;
       const component = shallow(<Wrapper />);
 
-      expect(component.find(EuiButtonIcon).prop('iconType')).toBe('arrowDown');
+      expect(component.find(EuiSmallButtonIcon).prop('iconType')).toBe('arrowDown');
     });
 
     it('should render up arrow when expanded', () => {
@@ -63,7 +63,7 @@ describe('Role view - index permission panel', () => {
       const Wrapper = () => <>{renderFunc(sampleRoleIndexPermission)}</>;
       const component = shallow(<Wrapper />);
 
-      expect(component.find(EuiButtonIcon).prop('iconType')).toBe('arrowUp');
+      expect(component.find(EuiSmallButtonIcon).prop('iconType')).toBe('arrowUp');
     });
 
     it('renders when arrow expanded', () => {
@@ -74,7 +74,7 @@ describe('Role view - index permission panel', () => {
       );
       const Wrapper = () => <>{renderFunc(sampleRoleIndexPermission)}</>;
       const component = shallow(<Wrapper />);
-      component.find(EuiButtonIcon).simulate('click');
+      component.find(EuiSmallButtonIcon).simulate('click');
       expect(component).toMatchSnapshot();
     });
   });

--- a/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
+++ b/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
@@ -27,7 +27,7 @@ import {
   EuiHorizontalRule,
   EuiDescribedFormGroup,
   EuiSpacer,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiCallOut,
   EuiBottomBar,
   EuiComboBox,
@@ -373,7 +373,7 @@ export function ConfigureTab1(props: AppDependencies) {
               }
               className="described-form-group1"
             >
-              <EuiCheckbox
+              <EuiCompressedCheckbox
                 id="EnableMultitenancyCheckBox"
                 label={'Enabled'}
                 checked={updatedConfiguration.multitenancy_enabled}
@@ -419,7 +419,7 @@ export function ConfigureTab1(props: AppDependencies) {
               }
               className="described-form-group3"
             >
-              <EuiCheckbox
+              <EuiCompressedCheckbox
                 id="EnablePrivateTenantCheckBox"
                 label={'Enable'}
                 checked={updatedConfiguration.private_tenant_enabled}

--- a/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
+++ b/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
@@ -30,7 +30,7 @@ import {
   EuiCompressedCheckbox,
   EuiCallOut,
   EuiBottomBar,
-  EuiComboBox,
+  EuiCompressedComboBox,
   EuiIcon,
   EuiLoadingContent,
 } from '@elastic/eui';
@@ -453,7 +453,7 @@ export function ConfigureTab1(props: AppDependencies) {
             >
               <EuiFlexGroup>
                 <EuiFlexItem>
-                  <EuiComboBox
+                  <EuiCompressedComboBox
                     placeholder={updatedConfiguration.default_tenant}
                     options={comboBoxOptions}
                     selectedOptions={selectedComboBoxOptions}

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -15,7 +15,7 @@
 
 import {
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiModal,
   EuiModalBody,
   EuiModalFooter,
@@ -91,7 +91,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
         </EuiModalBody>
         <EuiHorizontalRule margin="xs" />
         <EuiModalFooter>
-          <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
+          <EuiSmallButtonEmpty onClick={props.handleClose}>Cancel</EuiSmallButtonEmpty>
 
           <EuiSmallButton
             id="submit"

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -14,7 +14,7 @@
  */
 
 import {
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiModal,
   EuiModalBody,
@@ -93,7 +93,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
         <EuiModalFooter>
           <EuiButtonEmpty onClick={props.handleClose}>Cancel</EuiButtonEmpty>
 
-          <EuiButton
+          <EuiSmallButton
             id="submit"
             onClick={async () => {
               await props.handleSave(tenantName, tenantDescription);
@@ -102,7 +102,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
             disabled={!isFormValid}
           >
             {props.action === Action.create ? 'Create' : 'Save'}
-          </EuiButton>
+          </EuiSmallButton>
         </EuiModalFooter>
       </EuiModal>
     </EuiOverlayMask>

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -23,7 +23,7 @@ import {
   EuiModalHeaderTitle,
   EuiOverlayMask,
   EuiForm,
-  EuiTextArea,
+  EuiCompressedTextArea,
   EuiHorizontalRule,
 } from '@elastic/eui';
 import React, { useState } from 'react';
@@ -79,7 +79,7 @@ export function TenantEditModal(props: TenantEditModalDeps) {
               headerSubText="Describe the purpose of the tenant."
               optional
             >
-              <EuiTextArea
+              <EuiCompressedTextArea
                 data-test-subj="tenant-description"
                 fullWidth
                 placeholder="Describe the tenant"

--- a/public/apps/configuration/panels/tenant-list/manage_tab.tsx
+++ b/public/apps/configuration/panels/tenant-list/manage_tab.tsx
@@ -15,7 +15,7 @@
 
 import {
   EuiBadge,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
@@ -237,13 +237,13 @@ export function ManageTab(props: AppDependencies) {
           Tenancy is currently disabled and users don&apos;t have access to this feature. To create,
           edit tenants you must enabled tenanc throught he configure tenancy page.
         </p>
-        <EuiButton
+        <EuiSmallButton
           id="switchToConfigure"
           color="warning"
           onClick={() => renderConfigurePage().then()}
         >
           Configure tenancy
-        </EuiButton>
+        </EuiSmallButton>
       </EuiCallOut>
     );
   }
@@ -529,13 +529,13 @@ export function ManageTab(props: AppDependencies) {
             <EuiFlexGroup>
               <EuiFlexItem>{actionsMenu}</EuiFlexItem>
               <EuiFlexItem>
-                <EuiButton
+                <EuiSmallButton
                   id="createTenant"
                   fill
                   onClick={() => showEditModal('', Action.create, '')}
                 >
                   Create tenant
-                </EuiButton>
+                </EuiSmallButton>
               </EuiFlexItem>
             </EuiFlexGroup>
           </EuiPageContentHeaderSection>

--- a/public/apps/configuration/panels/tenant-list/manage_tab.tsx
+++ b/public/apps/configuration/panels/tenant-list/manage_tab.tsx
@@ -16,7 +16,7 @@
 import {
   EuiBadge,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiInMemoryTable,
@@ -387,23 +387,23 @@ export function ManageTab(props: AppDependencies) {
   ];
 
   const actionsMenuItems = [
-    <EuiButtonEmpty
+    <EuiSmallButtonEmpty
       id="switchTenant"
       key="switchTenant"
       disabled={selection.length !== 1}
       onClick={() => switchToSelectedTenant(selection[0].tenantValue, selection[0].tenant)}
     >
       Switch to selected tenant
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       id="edit"
       key="edit"
       disabled={selection.length !== 1 || selection[0].reserved}
       onClick={() => showEditModal(selection[0].tenant, Action.edit, selection[0].description)}
     >
       Edit
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       id="duplicate"
       key="duplicate"
       disabled={selection.length !== 1}
@@ -416,32 +416,32 @@ export function ManageTab(props: AppDependencies) {
       }
     >
       Duplicate
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       id="createDashboard"
       key="createDashboard"
       disabled={selection.length !== 1}
       onClick={() => viewOrCreateDashboard(selection[0].tenantValue, Action.create)}
     >
       Create dashboard
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       id="createVisualizations"
       key="createVisualizations"
       disabled={selection.length !== 1}
       onClick={() => viewOrCreateVisualization(selection[0].tenantValue, Action.create)}
     >
       Create visualizations
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       id="set as Global Default"
       key="Set as Global Default key"
       disabled={selection.length !== 1 || !isMultiTenancyEnabled}
       onClick={showModal}
     >
       Set as Default Tenant
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       id="delete"
       key="delete"
       color="danger"
@@ -449,7 +449,7 @@ export function ManageTab(props: AppDependencies) {
       disabled={selection.length === 0 || selection.some((tenant) => tenant.reserved)}
     >
       Delete
-    </EuiButtonEmpty>,
+    </EuiSmallButtonEmpty>,
   ];
 
   const [actionsMenu, closeActionsMenu] = useContextMenuState('Actions', {}, actionsMenuItems);

--- a/public/apps/configuration/panels/tenant-list/save_changes_modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/save_changes_modal.tsx
@@ -16,7 +16,7 @@
 import {
   EuiPageContentHeader,
   EuiHorizontalRule,
-  EuiCheckbox,
+  EuiCompressedCheckbox,
   EuiConfirmModal,
 } from '@elastic/eui';
 import React from 'react';
@@ -92,7 +92,7 @@ export function SaveChangesModalGenerator(props: SaveChangesModalDeps) {
         'global tenant.';
     }
     tenancyChangeCheckbox = (
-      <EuiCheckbox
+      <EuiCompressedCheckbox
         id={'tenancyChangeCheckbox'}
         label={tenancyChangeMessage}
         checked={tenancyChecked}
@@ -117,7 +117,7 @@ export function SaveChangesModalGenerator(props: SaveChangesModalDeps) {
         'other OpenSearch Dashboards saved in their private tenant.';
     }
     privateTenancyChangeCheckbox = (
-      <EuiCheckbox
+      <EuiCompressedCheckbox
         id={'privateTenancyChangeCheckbox'}
         label={privateTenancyChangeMessage}
         checked={privateTenancyChecked}
@@ -138,7 +138,7 @@ export function SaveChangesModalGenerator(props: SaveChangesModalDeps) {
       'if they have the appropriate permissions. If users don’t have permissions to a custom ' +
       'tenant they will load into the global tenant.';
     defaultTenantChangeCheckbox = (
-      <EuiCheckbox
+      <EuiCompressedCheckbox
         id={'defaultTenantChangeCheckbox'}
         label={defaultTenantChangeMessage}
         checked={defaultTenantChecked}

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -20,7 +20,7 @@ import {
   EuiTabs,
   EuiTab,
   EuiCallOut,
-  EuiButton,
+  EuiSmallButton,
 } from '@elastic/eui';
 import { Route } from 'react-router-dom';
 import React, { useState, useMemo } from 'react';
@@ -60,13 +60,13 @@ export function TenantList(props: TenantListProps) {
           Tenancy is currently disabled and users don&apos;t have access to this feature. Enable
           tenancy through the configure tenancy page.
         </p>
-        <EuiButton
+        <EuiSmallButton
           id="switchToConfigure"
           color="warning"
           onClick={() => onSelectedTabChanged('Configure')}
         >
           Configure tenancy
-        </EuiButton>
+        </EuiSmallButton>
       </EuiCallOut>
     </>
   );

--- a/public/apps/configuration/panels/tenant-list/test/__snapshots__/edit-modal.test.tsx.snap
+++ b/public/apps/configuration/panels/tenant-list/test/__snapshots__/edit-modal.test.tsx.snap
@@ -1,31 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Permission edit modal Submit button text should be Create when user is creating tenant 1`] = `
-<EuiButtonDisplay
-  baseClassName="euiButton"
+<EuiButton
   disabled={false}
-  element="button"
   fill={true}
   id="submit"
-  isDisabled={false}
   onClick={[Function]}
-  type="button"
+  size="s"
 >
   Create
-</EuiButtonDisplay>
+</EuiButton>
 `;
 
 exports[`Permission edit modal Submit button text should be Save when user is updating tenant 1`] = `
-<EuiButtonDisplay
-  baseClassName="euiButton"
+<EuiButton
   disabled={false}
-  element="button"
   fill={true}
   id="submit"
-  isDisabled={false}
   onClick={[Function]}
-  type="button"
+  size="s"
 >
   Save
-</EuiButtonDisplay>
+</EuiButton>
 `;

--- a/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
+++ b/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
@@ -45,55 +45,55 @@ exports[`Tenant list Action menu click Duplicate click 1`] = `
       <EuiPageContentHeaderSection>
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiButtonEmpty
+            <EuiSmallButtonEmpty
               disabled={false}
               id="switchTenant"
               key="switchTenant"
               onClick={[Function]}
             >
               Switch to selected tenant
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               disabled={false}
               id="edit"
               key="edit"
               onClick={[Function]}
             >
               Edit
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               disabled={false}
               id="duplicate"
               key="duplicate"
               onClick={[Function]}
             >
               Duplicate
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               disabled={false}
               id="createDashboard"
               key="createDashboard"
               onClick={[Function]}
             >
               Create dashboard
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               disabled={false}
               id="createVisualizations"
               key="createVisualizations"
               onClick={[Function]}
             >
               Create visualizations
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               disabled={true}
               id="set as Global Default"
               key="Set as Global Default key"
               onClick={[Function]}
             >
               Set as Default Tenant
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               color="danger"
               disabled={false}
               id="delete"
@@ -101,16 +101,16 @@ exports[`Tenant list Action menu click Duplicate click 1`] = `
               onClick={[MockFunction]}
             >
               Delete
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiButton
+            <EuiSmallButton
               fill={true}
               id="createTenant"
               onClick={[Function]}
             >
               Create tenant
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPageContentHeaderSection>
@@ -233,55 +233,55 @@ exports[`Tenant list Action menu click Edit click 1`] = `
       <EuiPageContentHeaderSection>
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiButtonEmpty
+            <EuiSmallButtonEmpty
               disabled={false}
               id="switchTenant"
               key="switchTenant"
               onClick={[Function]}
             >
               Switch to selected tenant
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               disabled={false}
               id="edit"
               key="edit"
               onClick={[Function]}
             >
               Edit
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               disabled={false}
               id="duplicate"
               key="duplicate"
               onClick={[Function]}
             >
               Duplicate
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               disabled={false}
               id="createDashboard"
               key="createDashboard"
               onClick={[Function]}
             >
               Create dashboard
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               disabled={false}
               id="createVisualizations"
               key="createVisualizations"
               onClick={[Function]}
             >
               Create visualizations
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               disabled={true}
               id="set as Global Default"
               key="Set as Global Default key"
               onClick={[Function]}
             >
               Set as Default Tenant
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               color="danger"
               disabled={false}
               id="delete"
@@ -289,16 +289,16 @@ exports[`Tenant list Action menu click Edit click 1`] = `
               onClick={[MockFunction]}
             >
               Delete
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiButton
+            <EuiSmallButton
               fill={true}
               id="createTenant"
               onClick={[Function]}
             >
               Create tenant
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPageContentHeaderSection>

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -85,23 +85,23 @@ exports[`Get started (landing page) renders when backend configuration is disabl
                   <EuiFlexItem
                     grow={false}
                   >
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="explore-existing-roles"
                       fill={true}
                       onClick={[Function]}
                     >
                       Explore existing roles
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem
                     grow={false}
                   >
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="create-new-role"
                       onClick={[Function]}
                     >
                       Create new role
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
                 <EuiSpacer
@@ -131,23 +131,23 @@ exports[`Get started (landing page) renders when backend configuration is disabl
                   <EuiFlexItem
                     grow={false}
                   >
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="map-users-to-role"
                       fill={true}
                       onClick={[Function]}
                     >
                       Map users to a role
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem
                     grow={false}
                   >
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="create-internal-user"
                       onClick={[Function]}
                     >
                       Create internal user
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </React.Fragment>,
@@ -185,13 +185,13 @@ exports[`Get started (landing page) renders when backend configuration is disabl
             href="https://opensearch.org/docs/latest/security-plugin/audit-logs/"
           />
         </p>
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="review-audit-log-configuration"
           fill={true}
           onClick={[Function]}
         >
           Review Audit Log Configuration
-        </EuiButton>
+        </EuiSmallButton>
       </EuiText>
     </EuiPanel>
     <EuiSpacer
@@ -214,14 +214,14 @@ exports[`Get started (landing page) renders when backend configuration is disabl
         <p>
           By default, the security plugin caches authenticated users, along with their roles and permissions. This option will purge cached users, roles and permissions.
         </p>
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="purge-cache"
           fill={true}
           iconType="refresh"
           onClick={[Function]}
         >
           Purge cache
-        </EuiButton>
+        </EuiSmallButton>
       </EuiText>
     </EuiPanel>
     <EuiSpacer
@@ -250,21 +250,21 @@ exports[`Get started (landing page) renders when backend configuration is disabl
           <EuiFlexItem
             grow={false}
           >
-            <EuiButton
+            <EuiSmallButton
               fill={true}
               onClick={[Function]}
             >
               Manage Multi-tenancy
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem
             grow={false}
           >
-            <EuiButton
+            <EuiSmallButton
               onClick={[Function]}
             >
               Configure Multi-tenancy
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiText>
@@ -396,12 +396,12 @@ exports[`Get started (landing page) renders when backend configuration is enable
                   <EuiFlexItem
                     grow={false}
                   >
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="review-authentication-and-authorization"
                       onClick={[Function]}
                     >
                       Review authentication and authorization
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
                 <EuiSpacer
@@ -431,23 +431,23 @@ exports[`Get started (landing page) renders when backend configuration is enable
                   <EuiFlexItem
                     grow={false}
                   >
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="explore-existing-roles"
                       fill={true}
                       onClick={[Function]}
                     >
                       Explore existing roles
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem
                     grow={false}
                   >
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="create-new-role"
                       onClick={[Function]}
                     >
                       Create new role
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
                 <EuiSpacer
@@ -477,23 +477,23 @@ exports[`Get started (landing page) renders when backend configuration is enable
                   <EuiFlexItem
                     grow={false}
                   >
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="map-users-to-role"
                       fill={true}
                       onClick={[Function]}
                     >
                       Map users to a role
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                   <EuiFlexItem
                     grow={false}
                   >
-                    <EuiButton
+                    <EuiSmallButton
                       data-test-subj="create-internal-user"
                       onClick={[Function]}
                     >
                       Create internal user
-                    </EuiButton>
+                    </EuiSmallButton>
                   </EuiFlexItem>
                 </EuiFlexGroup>
               </React.Fragment>,
@@ -531,13 +531,13 @@ exports[`Get started (landing page) renders when backend configuration is enable
             href="https://opensearch.org/docs/latest/security-plugin/audit-logs/"
           />
         </p>
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="review-audit-log-configuration"
           fill={true}
           onClick={[Function]}
         >
           Review Audit Log Configuration
-        </EuiButton>
+        </EuiSmallButton>
       </EuiText>
     </EuiPanel>
     <EuiSpacer
@@ -560,14 +560,14 @@ exports[`Get started (landing page) renders when backend configuration is enable
         <p>
           By default, the security plugin caches authenticated users, along with their roles and permissions. This option will purge cached users, roles and permissions.
         </p>
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="purge-cache"
           fill={true}
           iconType="refresh"
           onClick={[Function]}
         >
           Purge cache
-        </EuiButton>
+        </EuiSmallButton>
       </EuiText>
     </EuiPanel>
     <EuiSpacer
@@ -596,21 +596,21 @@ exports[`Get started (landing page) renders when backend configuration is enable
           <EuiFlexItem
             grow={false}
           >
-            <EuiButton
+            <EuiSmallButton
               fill={true}
               onClick={[Function]}
             >
               Manage Multi-tenancy
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
           <EuiFlexItem
             grow={false}
           >
-            <EuiButton
+            <EuiSmallButton
               onClick={[Function]}
             >
               Configure Multi-tenancy
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiText>

--- a/public/apps/configuration/panels/test/__snapshots__/role-list.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/role-list.test.tsx.snap
@@ -61,39 +61,39 @@ exports[`Role list AccessError component should load access error component 1`] 
       <EuiPageContentHeaderSection>
         <EuiFlexGroup>
           <EuiFlexItem>
-            <EuiButtonEmpty
+            <EuiSmallButtonEmpty
               data-test-subj="edit"
               disabled={true}
               key="edit"
               onClick={[Function]}
             >
               Edit
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               data-test-subj="duplicate"
               disabled={true}
               key="duplicate"
               onClick={[Function]}
             >
               Duplicate
-            </EuiButtonEmpty>
-            <EuiButtonEmpty
+            </EuiSmallButtonEmpty>
+            <EuiSmallButtonEmpty
               color="danger"
               disabled={true}
               key="delete"
               onClick={[MockFunction]}
             >
               Delete
-            </EuiButtonEmpty>
+            </EuiSmallButtonEmpty>
           </EuiFlexItem>
           <EuiFlexItem>
-            <EuiButton
+            <EuiSmallButton
               data-test-subj="create-role"
               fill={true}
               href="#/roles/create"
             >
               Create role
-            </EuiButton>
+            </EuiSmallButton>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiPageContentHeaderSection>

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -15,7 +15,7 @@
 
 import {
   EuiBadge,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
@@ -247,13 +247,13 @@ export function UserList(props: AppDependencies) {
               <EuiFlexGroup>
                 <EuiFlexItem>{actionsMenu}</EuiFlexItem>
                 <EuiFlexItem>
-                  <EuiButton
+                  <EuiSmallButton
                     fill
                     href={buildHashUrl(ResourceType.users, Action.create)}
                     data-test-subj="create-user"
                   >
                     Create internal user
-                  </EuiButton>
+                  </EuiSmallButton>
                 </EuiFlexItem>
               </EuiFlexGroup>
             </EuiPageContentHeaderSection>

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -16,7 +16,7 @@
 import {
   EuiBadge,
   EuiSmallButton,
-  EuiButtonEmpty,
+  EuiSmallButtonEmpty,
   EuiFlexGroup,
   EuiFlexItem,
   EuiInMemoryTable,
@@ -156,7 +156,7 @@ export function UserList(props: AppDependencies) {
   );
 
   const actionsMenuItems = [
-    <EuiButtonEmpty
+    <EuiSmallButtonEmpty
       data-test-subj="edit"
       key="edit"
       onClick={() => {
@@ -165,8 +165,8 @@ export function UserList(props: AppDependencies) {
       disabled={selection.length !== 1}
     >
       Edit
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       data-test-subj="duplicate"
       key="duplicate"
       onClick={() => {
@@ -179,8 +179,8 @@ export function UserList(props: AppDependencies) {
       disabled={selection.length !== 1}
     >
       Duplicate
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       key="export"
       disabled={selection.length !== 1}
       href={
@@ -191,15 +191,15 @@ export function UserList(props: AppDependencies) {
       target="_blank"
     >
       Export JSON
-    </EuiButtonEmpty>,
-    <EuiButtonEmpty
+    </EuiSmallButtonEmpty>,
+    <EuiSmallButtonEmpty
       key="delete"
       color="danger"
       onClick={showDeleteConfirmModal}
       disabled={selection.length === 0 || selection.some((e) => e.username === currentUsername)}
     >
       Delete
-    </EuiButtonEmpty>,
+    </EuiSmallButtonEmpty>,
   ];
 
   const [actionsMenu, closeActionsMenu] = useContextMenuState('Actions', {}, actionsMenuItems);

--- a/public/apps/configuration/utils/context-menu.tsx
+++ b/public/apps/configuration/utils/context-menu.tsx
@@ -17,7 +17,7 @@ import {
   EuiButtonProps,
   EuiPopover,
   EuiContextMenuPanel,
-  EuiButton,
+  EuiSmallButton,
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
@@ -33,7 +33,7 @@ export function useContextMenuState(
   const closeContextMenu = () => setContextMenuOpen(false);
 
   const button = (
-    <EuiButton
+    <EuiSmallButton
       iconType="arrowDown"
       iconSide="right"
       onClick={() => {
@@ -42,7 +42,7 @@ export function useContextMenuState(
       {...buttonProps}
     >
       {buttonText}
-    </EuiButton>
+    </EuiSmallButton>
   );
 
   const items = [

--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -20,7 +20,7 @@ import {
   EuiText,
   EuiIcon,
   EuiFlexGroup,
-  EuiButton,
+  EuiSmallButton,
   EuiButtonProps,
   EuiToolTip,
   EuiLink,
@@ -134,9 +134,9 @@ export const displayHeaderWithTooltip = (columnHeader: string, tooltipText: stri
 export function ExternalLinkButton(props: { text: string; href: string } & EuiButtonProps) {
   const { text, ...buttonProps } = props;
   return (
-    <EuiButton iconType="popout" iconSide="right" target="_blank" {...buttonProps}>
+    <EuiSmallButton iconType="popout" iconSide="right" target="_blank" {...buttonProps}>
       {props.text}
-    </EuiButton>
+    </EuiSmallButton>
   );
 }
 

--- a/public/apps/configuration/utils/form-row.tsx
+++ b/public/apps/configuration/utils/form-row.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiFormRow, EuiText } from '@elastic/eui';
+import { EuiCompressedFormRow, EuiText } from '@elastic/eui';
 import React from 'react';
 import { ExternalLink } from './display-utils';
 import { FormRowDeps } from '../types';
@@ -26,7 +26,7 @@ export interface FormRowWithChildComponentDeps extends FormRowDeps {
 
 export function FormRow(props: FormRowWithChildComponentDeps) {
   return (
-    <EuiFormRow
+    <EuiCompressedFormRow
       fullWidth
       label={
         <>
@@ -50,6 +50,6 @@ export function FormRow(props: FormRowWithChildComponentDeps) {
       error={props.error}
     >
       {props.children}
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   );
 }

--- a/public/apps/configuration/utils/name-row.tsx
+++ b/public/apps/configuration/utils/name-row.tsx
@@ -14,7 +14,7 @@
  */
 
 import React from 'react';
-import { EuiFieldText } from '@elastic/eui';
+import { EuiCompressedFieldText } from '@elastic/eui';
 import { FormRow } from './form-row';
 import { resourceNameHelpText, validateResourceName } from './resource-validation-util';
 import { FormRowDeps } from '../types';
@@ -45,7 +45,7 @@ export function NameRow(props: NameRowDeps) {
       isInvalid={errors.length > 0}
       error={errors}
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         data-test-subj="name-text"
         fullWidth={props.fullWidth}
         value={props.resourceName}

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -15,7 +15,7 @@
 
 import React from 'react';
 import { CoreStart } from 'opensearch-dashboards/public';
-import { EuiFieldPassword, EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
+import { EuiFieldPassword, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow } from '@elastic/eui';
 import { FormRow } from './form-row';
 import { PASSWORD_INSTRUCTION } from '../../apps-constants';
 import { getDashboardsInfo } from '../../../utils/dashboards-info-utils';
@@ -71,9 +71,9 @@ export function PasswordEditPanel(props: {
               onChange={passwordChangeHandler}
             />
           </FormRow>
-          <EuiFormRow>
+          <EuiCompressedFormRow>
             <PasswordStrengthBar password={password} />
-          </EuiFormRow>
+          </EuiCompressedFormRow>
         </EuiFlexItem>
       </EuiFlexGroup>
 

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -15,7 +15,7 @@
 
 import React from 'react';
 import { CoreStart } from 'opensearch-dashboards/public';
-import { EuiFieldPassword, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow } from '@elastic/eui';
+import { EuiCompressedFieldPassword, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow } from '@elastic/eui';
 import { FormRow } from './form-row';
 import { PASSWORD_INSTRUCTION } from '../../apps-constants';
 import { getDashboardsInfo } from '../../../utils/dashboards-info-utils';
@@ -65,7 +65,7 @@ export function PasswordEditPanel(props: {
       <EuiFlexGroup direction="row">
         <EuiFlexItem grow={false}>
           <FormRow headerText="Password" helpText={passwordHelpText}>
-            <EuiFieldPassword
+            <EuiCompressedFieldPassword
               data-test-subj="password"
               type="dual"
               onChange={passwordChangeHandler}
@@ -81,7 +81,7 @@ export function PasswordEditPanel(props: {
         headerText="Re-enter password"
         helpText="The password must be identical to what you entered above."
       >
-        <EuiFieldPassword
+        <EuiCompressedFieldPassword
           data-test-subj="re-enter-password"
           type="dual"
           isInvalid={isRepeatPasswordInvalid}

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -15,7 +15,12 @@
 
 import React from 'react';
 import { CoreStart } from 'opensearch-dashboards/public';
-import { EuiCompressedFieldPassword, EuiFlexGroup, EuiFlexItem, EuiCompressedFormRow } from '@elastic/eui';
+import {
+  EuiCompressedFieldPassword,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiCompressedFormRow,
+} from '@elastic/eui';
 import { FormRow } from './form-row';
 import { PASSWORD_INSTRUCTION } from '../../apps-constants';
 import { getDashboardsInfo } from '../../../utils/dashboards-info-utils';

--- a/public/apps/configuration/utils/test/__snapshots__/display-utils.test.tsx.snap
+++ b/public/apps/configuration/utils/test/__snapshots__/display-utils.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`Display utils Render External Link 1`] = `
 `;
 
 exports[`Display utils Render External Link Button 1`] = `
-<EuiButton
+<EuiSmallButton
   fill={true}
   href="http://localhost:5601"
   iconSide="right"
@@ -69,7 +69,7 @@ exports[`Display utils Render External Link Button 1`] = `
   target="_blank"
 >
   Test
-</EuiButton>
+</EuiSmallButton>
 `;
 
 exports[`Display utils Render expression when expression is non-empty 1`] = `

--- a/public/apps/configuration/utils/test/__snapshots__/form-row.test.tsx.snap
+++ b/public/apps/configuration/utils/test/__snapshots__/form-row.test.tsx.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Form row renders 1`] = `
-<EuiFormRow
+<EuiCompressedFormRow
   describedByIds={Array []}
-  display="row"
+  display="rowCompressed"
   error={
     Array [
       "error1",
@@ -46,5 +46,5 @@ exports[`Form row renders 1`] = `
   <div>
     Test
   </div>
-</EuiFormRow>
+</EuiCompressedFormRow>
 `;

--- a/public/apps/configuration/utils/test/__snapshots__/password-edit-panel.test.tsx.snap
+++ b/public/apps/configuration/utils/test/__snapshots__/password-edit-panel.test.tsx.snap
@@ -12,18 +12,15 @@ exports[`Password edit panel repeat password field update 1`] = `
         headerText="Password"
         helpText="Password should be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
       >
-        <EuiFieldPassword
-          compressed={false}
+        <EuiCompressedFieldPassword
           data-test-subj="password"
-          fullWidth={false}
-          isLoading={false}
           onChange={[Function]}
           type="dual"
         />
       </FormRow>
-      <EuiFormRow
+      <EuiCompressedFormRow
         describedByIds={Array []}
-        display="row"
+        display="rowCompressed"
         fullWidth={false}
         hasChildLabel={true}
         hasEmptyLabelSpace={false}
@@ -32,19 +29,16 @@ exports[`Password edit panel repeat password field update 1`] = `
         <PasswordStrengthBar
           password=""
         />
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     </EuiFlexItem>
   </EuiFlexGroup>
   <FormRow
     headerText="Re-enter password"
     helpText="The password must be identical to what you entered above."
   >
-    <EuiFieldPassword
-      compressed={false}
+    <EuiCompressedFieldPassword
       data-test-subj="re-enter-password"
-      fullWidth={false}
       isInvalid={false}
-      isLoading={false}
       onChange={[Function]}
       type="dual"
     />

--- a/public/apps/customerror/custom-error.tsx
+++ b/public/apps/customerror/custom-error.tsx
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { EuiButton, EuiImage, EuiListGroup, EuiSpacer, EuiText } from '@elastic/eui';
+import { EuiSmallButton, EuiImage, EuiListGroup, EuiSpacer, EuiText } from '@elastic/eui';
 import { AppMountParameters, CoreStart } from 'opensearch-dashboards/public';
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -47,14 +47,14 @@ export function CustomErrorPage(props: CustomErrorDeps) {
         {props.subtitle}
       </EuiText>
       <EuiSpacer size="s" />
-      <EuiButton
+      <EuiSmallButton
         fill
         onClick={() => logout(props.http, '')}
         data-test-subj="error-logout-button"
         fullWidth
       >
         Logout
-      </EuiButton>
+      </EuiSmallButton>
     </EuiListGroup>
   );
 }
@@ -81,4 +81,4 @@ export async function renderPage(
   );
   return () => ReactDOM.unmountComponentAtNode(params.element);
 }
-export { EuiButton };
+export { EuiSmallButton };

--- a/public/apps/customerror/test/__snapshots__/custom-error.test.tsx.snap
+++ b/public/apps/customerror/test/__snapshots__/custom-error.test.tsx.snap
@@ -27,13 +27,13 @@ exports[`Custom error page test renders and clicks the button on the error page 
   <EuiSpacer
     size="s"
   />
-  <EuiButton
+  <EuiSmallButton
     data-test-subj="error-logout-button"
     fill={true}
     fullWidth={true}
     onClick={[Function]}
   >
     Logout
-  </EuiButton>
+  </EuiSmallButton>
 </EuiListGroup>
 `;

--- a/public/apps/customerror/test/custom-error.test.tsx
+++ b/public/apps/customerror/test/custom-error.test.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import { CustomErrorPage } from '../custom-error';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { EuiButton } from '../custom-error';
+import { EuiSmallButton } from '../custom-error';
 import { logout } from '../../account/utils';
 
 afterEach(() => {
@@ -29,9 +29,9 @@ describe('Custom error page test', () => {
 
   beforeEach(() => {
     component = shallow(
-      <EuiButton fill onClick={logout} data-test-subj="error-logout-button" fullWidth>
+      <EuiSmallButton fill onClick={logout} data-test-subj="error-logout-button" fullWidth>
         Logout
-      </EuiButton>
+      </EuiSmallButton>
     );
   });
 

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -22,7 +22,7 @@ import {
   EuiImage,
   EuiListGroup,
   EuiForm,
-  EuiFormRow,
+  EuiCompressedFormRow,
   EuiHorizontalRule,
   EuiFieldPassword,
 } from '@elastic/eui';
@@ -149,7 +149,7 @@ export function LoginPage(props: LoginPageDeps) {
     const buttonId = `${authType}_login_button`;
     const loginEndPointWithPath = `${props.http.basePath.serverBasePath}${loginEndPoint}`;
     return (
-      <EuiFormRow>
+      <EuiCompressedFormRow>
         <EuiButton
           data-test-subj="submit"
           aria-label={buttonId}
@@ -161,7 +161,7 @@ export function LoginPage(props: LoginPageDeps) {
         >
           {buttonConfig.buttonname}
         </EuiButton>
-      </EuiFormRow>
+      </EuiCompressedFormRow>
     );
   };
 
@@ -188,7 +188,7 @@ export function LoginPage(props: LoginPageDeps) {
       switch (authOpts[i].toLowerCase()) {
         case AuthType.BASIC: {
           formBody.push(
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiFieldText
                 data-test-subj="user-name"
                 aria-label="username_input"
@@ -198,10 +198,10 @@ export function LoginPage(props: LoginPageDeps) {
                 value={username}
                 isInvalid={usernameValidationFailed}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           );
           formBody.push(
-            <EuiFormRow isInvalid={passwordValidationFailed}>
+            <EuiCompressedFormRow isInvalid={passwordValidationFailed}>
               <EuiFieldPassword
                 data-test-subj="password"
                 aria-label="password_input"
@@ -211,11 +211,11 @@ export function LoginPage(props: LoginPageDeps) {
                 value={password}
                 isInvalid={usernameValidationFailed}
               />
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           );
           const buttonId = `${AuthType.BASIC}_login_button`;
           formBody.push(
-            <EuiFormRow>
+            <EuiCompressedFormRow>
               <EuiButton
                 data-test-subj="submit"
                 aria-label={buttonId}
@@ -227,7 +227,7 @@ export function LoginPage(props: LoginPageDeps) {
               >
                 Log in
               </EuiButton>
-            </EuiFormRow>
+            </EuiCompressedFormRow>
           );
 
           if (props.config.auth.anonymous_auth_enabled) {

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -16,7 +16,7 @@
 import React, { useState } from 'react';
 import {
   EuiText,
-  EuiFieldText,
+  EuiCompressedFieldText,
   EuiSpacer,
   EuiButton,
   EuiImage,
@@ -24,7 +24,7 @@ import {
   EuiForm,
   EuiCompressedFormRow,
   EuiHorizontalRule,
-  EuiFieldPassword,
+  EuiCompressedFieldPassword,
 } from '@elastic/eui';
 import { CoreStart } from '../../../../../src/core/public';
 import { ClientConfigType } from '../../types';
@@ -189,7 +189,7 @@ export function LoginPage(props: LoginPageDeps) {
         case AuthType.BASIC: {
           formBody.push(
             <EuiCompressedFormRow>
-              <EuiFieldText
+              <EuiCompressedFieldText
                 data-test-subj="user-name"
                 aria-label="username_input"
                 placeholder="Username"
@@ -202,7 +202,7 @@ export function LoginPage(props: LoginPageDeps) {
           );
           formBody.push(
             <EuiCompressedFormRow isInvalid={passwordValidationFailed}>
-              <EuiFieldPassword
+              <EuiCompressedFieldPassword
                 data-test-subj="password"
                 aria-label="password_input"
                 placeholder="Password"

--- a/public/apps/login/test/__snapshots__/login-page.test.tsx.snap
+++ b/public/apps/login/test/__snapshots__/login-page.test.tsx.snap
@@ -33,15 +33,15 @@ exports[`Login page renders renders with config value for multiauth 1`] = `
   <EuiForm
     component="form"
   >
-    <EuiFormRow
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       labelType="label"
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         aria-label="username_input"
         data-test-subj="user-name"
         icon="user"
@@ -50,32 +50,29 @@ exports[`Login page renders renders with config value for multiauth 1`] = `
         placeholder="Username"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       isInvalid={false}
       labelType="label"
     >
-      <EuiFieldPassword
+      <EuiCompressedFieldPassword
         aria-label="password_input"
-        compressed={false}
         data-test-subj="password"
-        fullWidth={false}
         isInvalid={false}
-        isLoading={false}
         onChange={[Function]}
         placeholder="Password"
         type="dual"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -92,7 +89,7 @@ exports[`Login page renders renders with config value for multiauth 1`] = `
       >
         Log in
       </EuiButton>
-    </EuiFormRow>
+    </EuiCompressedFormRow>
     <EuiSpacer
       size="xs"
     />
@@ -103,9 +100,9 @@ exports[`Login page renders renders with config value for multiauth 1`] = `
     <EuiSpacer
       size="xs"
     />
-    <EuiFormRow
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -122,10 +119,10 @@ exports[`Login page renders renders with config value for multiauth 1`] = `
       >
         Button1
       </EuiButton>
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -142,7 +139,7 @@ exports[`Login page renders renders with config value for multiauth 1`] = `
       >
         Button2
       </EuiButton>
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   </EuiForm>
 </EuiListGroup>
 `;
@@ -180,15 +177,15 @@ exports[`Login page renders renders with config value for multiauth with anonymo
   <EuiForm
     component="form"
   >
-    <EuiFormRow
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       labelType="label"
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         aria-label="username_input"
         data-test-subj="user-name"
         icon="user"
@@ -197,32 +194,29 @@ exports[`Login page renders renders with config value for multiauth with anonymo
         placeholder="Username"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       isInvalid={false}
       labelType="label"
     >
-      <EuiFieldPassword
+      <EuiCompressedFieldPassword
         aria-label="password_input"
-        compressed={false}
         data-test-subj="password"
-        fullWidth={false}
         isInvalid={false}
-        isLoading={false}
         onChange={[Function]}
         placeholder="Password"
         type="dual"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -239,10 +233,10 @@ exports[`Login page renders renders with config value for multiauth with anonymo
       >
         Log in
       </EuiButton>
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -257,7 +251,7 @@ exports[`Login page renders renders with config value for multiauth with anonymo
         size="s"
         type="prime"
       />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
     <EuiSpacer
       size="xs"
     />
@@ -268,9 +262,9 @@ exports[`Login page renders renders with config value for multiauth with anonymo
     <EuiSpacer
       size="xs"
     />
-    <EuiFormRow
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -287,10 +281,10 @@ exports[`Login page renders renders with config value for multiauth with anonymo
       >
         Button1
       </EuiButton>
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -307,7 +301,7 @@ exports[`Login page renders renders with config value for multiauth with anonymo
       >
         Button2
       </EuiButton>
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   </EuiForm>
 </EuiListGroup>
 `;
@@ -345,15 +339,15 @@ exports[`Login page renders renders with config value with anonymous auth enable
   <EuiForm
     component="form"
   >
-    <EuiFormRow
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       labelType="label"
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         aria-label="username_input"
         data-test-subj="user-name"
         icon="user"
@@ -362,32 +356,29 @@ exports[`Login page renders renders with config value with anonymous auth enable
         placeholder="Username"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       isInvalid={false}
       labelType="label"
     >
-      <EuiFieldPassword
+      <EuiCompressedFieldPassword
         aria-label="password_input"
-        compressed={false}
         data-test-subj="password"
-        fullWidth={false}
         isInvalid={false}
-        isLoading={false}
         onChange={[Function]}
         placeholder="Password"
         type="dual"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -404,10 +395,10 @@ exports[`Login page renders renders with config value with anonymous auth enable
       >
         Log in
       </EuiButton>
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -422,7 +413,7 @@ exports[`Login page renders renders with config value with anonymous auth enable
         size="s"
         type="prime"
       />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   </EuiForm>
 </EuiListGroup>
 `;
@@ -460,15 +451,15 @@ exports[`Login page renders renders with config value with anonymous auth enable
   <EuiForm
     component="form"
   >
-    <EuiFormRow
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       labelType="label"
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         aria-label="username_input"
         data-test-subj="user-name"
         icon="user"
@@ -477,32 +468,29 @@ exports[`Login page renders renders with config value with anonymous auth enable
         placeholder="Username"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       isInvalid={false}
       labelType="label"
     >
-      <EuiFieldPassword
+      <EuiCompressedFieldPassword
         aria-label="password_input"
-        compressed={false}
         data-test-subj="password"
-        fullWidth={false}
         isInvalid={false}
-        isLoading={false}
         onChange={[Function]}
         placeholder="Password"
         type="dual"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -519,10 +507,10 @@ exports[`Login page renders renders with config value with anonymous auth enable
       >
         Log in
       </EuiButton>
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -537,7 +525,7 @@ exports[`Login page renders renders with config value with anonymous auth enable
         size="s"
         type="prime"
       />
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   </EuiForm>
 </EuiListGroup>
 `;
@@ -575,15 +563,15 @@ exports[`Login page renders renders with config value: string 1`] = `
   <EuiForm
     component="form"
   >
-    <EuiFormRow
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       labelType="label"
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         aria-label="username_input"
         data-test-subj="user-name"
         icon="user"
@@ -592,32 +580,29 @@ exports[`Login page renders renders with config value: string 1`] = `
         placeholder="Username"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       isInvalid={false}
       labelType="label"
     >
-      <EuiFieldPassword
+      <EuiCompressedFieldPassword
         aria-label="password_input"
-        compressed={false}
         data-test-subj="password"
-        fullWidth={false}
         isInvalid={false}
-        isLoading={false}
         onChange={[Function]}
         placeholder="Password"
         type="dual"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -634,7 +619,7 @@ exports[`Login page renders renders with config value: string 1`] = `
       >
         Log in
       </EuiButton>
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   </EuiForm>
 </EuiListGroup>
 `;
@@ -672,15 +657,15 @@ exports[`Login page renders renders with config value: string array 1`] = `
   <EuiForm
     component="form"
   >
-    <EuiFormRow
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       labelType="label"
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         aria-label="username_input"
         data-test-subj="user-name"
         icon="user"
@@ -689,32 +674,29 @@ exports[`Login page renders renders with config value: string array 1`] = `
         placeholder="Username"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       isInvalid={false}
       labelType="label"
     >
-      <EuiFieldPassword
+      <EuiCompressedFieldPassword
         aria-label="password_input"
-        compressed={false}
         data-test-subj="password"
-        fullWidth={false}
         isInvalid={false}
-        isLoading={false}
         onChange={[Function]}
         placeholder="Password"
         type="dual"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -731,7 +713,7 @@ exports[`Login page renders renders with config value: string array 1`] = `
       >
         Log in
       </EuiButton>
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   </EuiForm>
 </EuiListGroup>
 `;
@@ -769,15 +751,15 @@ exports[`Login page renders renders with default value: string 1`] = `
   <EuiForm
     component="form"
   >
-    <EuiFormRow
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       labelType="label"
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         aria-label="username_input"
         data-test-subj="user-name"
         icon="user"
@@ -786,32 +768,29 @@ exports[`Login page renders renders with default value: string 1`] = `
         placeholder="Username"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       isInvalid={false}
       labelType="label"
     >
-      <EuiFieldPassword
+      <EuiCompressedFieldPassword
         aria-label="password_input"
-        compressed={false}
         data-test-subj="password"
-        fullWidth={false}
         isInvalid={false}
-        isLoading={false}
         onChange={[Function]}
         placeholder="Password"
         type="dual"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -828,7 +807,7 @@ exports[`Login page renders renders with default value: string 1`] = `
       >
         Log in
       </EuiButton>
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   </EuiForm>
 </EuiListGroup>
 `;
@@ -866,15 +845,15 @@ exports[`Login page renders renders with default value: string array 1`] = `
   <EuiForm
     component="form"
   >
-    <EuiFormRow
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       labelType="label"
     >
-      <EuiFieldText
+      <EuiCompressedFieldText
         aria-label="username_input"
         data-test-subj="user-name"
         icon="user"
@@ -883,32 +862,29 @@ exports[`Login page renders renders with default value: string array 1`] = `
         placeholder="Username"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
       isInvalid={false}
       labelType="label"
     >
-      <EuiFieldPassword
+      <EuiCompressedFieldPassword
         aria-label="password_input"
-        compressed={false}
         data-test-subj="password"
-        fullWidth={false}
         isInvalid={false}
-        isLoading={false}
         onChange={[Function]}
         placeholder="Password"
         type="dual"
         value=""
       />
-    </EuiFormRow>
-    <EuiFormRow
+    </EuiCompressedFormRow>
+    <EuiCompressedFormRow
       describedByIds={Array []}
-      display="row"
+      display="rowCompressed"
       fullWidth={false}
       hasChildLabel={true}
       hasEmptyLabelSpace={false}
@@ -925,7 +901,7 @@ exports[`Login page renders renders with default value: string array 1`] = `
       >
         Log in
       </EuiButton>
-    </EuiFormRow>
+    </EuiCompressedFormRow>
   </EuiForm>
 </EuiListGroup>
 `;


### PR DESCRIPTION
### Description
Replace instances of `EuiButton` that don't have an explicit sizing attribute to `EuiSmallButton*`.
Replace instances of `Eui<form elements>` that don't have density attributes to `EuiCompressed<form elements>`.

### Category
Enhancement

### Why these changes are required?
UX

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).