### PR TITLE
Fix a bug where basepath nextUrl is invalid when it should be valid

### DIFF
--- a/server/utils/next_url.test.ts
+++ b/server/utils/next_url.test.ts
@@ -106,7 +106,7 @@ describe('test validateNextUrl', () => {
 
   test('allow basePath', () => {
     const url = '/osd';
-    expect(validateNextUrl(url, 'osd')).toEqual(undefined);
+    expect(validateNextUrl(url, '/osd')).toEqual(undefined);
   });
 
   test('allow dashboard url', () => {

--- a/server/utils/next_url.test.ts
+++ b/server/utils/next_url.test.ts
@@ -104,6 +104,11 @@ describe('test validateNextUrl', () => {
     expect(validateNextUrl(url, '')).toEqual(undefined);
   });
 
+  test('allow basePath', () => {
+    const url = '/osd';
+    expect(validateNextUrl(url, 'osd')).toEqual(undefined);
+  });
+
   test('allow dashboard url', () => {
     const url =
       '/_plugin/opensearch-dashboards/app/opensearch-dashboards#dashbard/dashboard-id?_g=(param=a&p=b)';

--- a/server/utils/next_url.ts
+++ b/server/utils/next_url.ts
@@ -73,7 +73,7 @@ export function validateNextUrl(
     }
     const pathMinusBase = path.replace(bp, '');
     if (
-      !pathMinusBase.startsWith('/') ||
+      (pathMinusBase && !pathMinusBase.startsWith('/')) ||
       (pathMinusBase.length >= 2 && !/^\/[a-zA-Z_][\/a-zA-Z0-9-_]+$/.test(pathMinusBase))
     ) {
       return INVALID_NEXT_URL_PARAMETER_MESSAGE;


### PR DESCRIPTION
### Description
Fixes a bug when OSD is run with a basepath that basepath is an invalid nexturl, when it should be allowed

### Category
Bug fix
### Why these changes are required?
Fix: #2097 

### What is the old behavior before changes and new behavior after changes?
now basepath is a valid nexturl

### Issues Resolved
Fix: Fix: #2097 
### Testing
Added a unit test
### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).