### PR TITLE
Ux fixes for page header

### DIFF
--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -108,9 +108,10 @@ export const allNavPanelUrls = (multitenancyEnabled: boolean) =>
       ...(multitenancyEnabled ? [buildUrl(ResourceType.tenantsConfigureTab)] : []),
     ]);
 
-function decodeParams(params: { [k: string]: string }): any {
-  return Object.keys(params).reduce((obj: { [k: string]: string }, key: string) => {
-    obj[key] = decodeURIComponent(params[key]);
+function decodeParams(params: { [k: string]: string | undefined }): any {
+  return Object.keys(params).reduce((obj: { [k: string]: string | undefined }, key: string) => {
+    const value = params[key];
+    obj[key] = value !== undefined ? decodeURIComponent(value) : undefined;
     return obj;
   }, {});
 }

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -263,15 +263,17 @@ export function AuditLogging(props: AuditLoggingProps) {
         coreStart={props.coreStart}
         navigation={props.depsStart.navigation}
         fallBackComponent={
-          <EuiPageHeader>
-            <EuiText size="s">
-              <h1>Audit logging</h1>
-            </EuiText>
-          </EuiPageHeader>
+          <>
+            <EuiPageHeader>
+              <EuiText size="s">
+                <h1>Audit logging</h1>
+              </EuiText>
+            </EuiPageHeader>
+            <EuiSpacer />
+          </>
         }
         resourceType={ResourceType.auditLogging}
       />
-      <EuiSpacer />
       {loading ? <EuiLoadingContent /> : content}
     </div>
   );

--- a/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
+++ b/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
@@ -273,20 +273,22 @@ exports[`Audit logs render when AuditLoggingSettings.enabled is true 1`] = `
       }
     }
     fallBackComponent={
-      <EuiPageHeader>
-        <EuiText
-          size="s"
-        >
-          <h1>
-            Audit logging
-          </h1>
-        </EuiText>
-      </EuiPageHeader>
+      <React.Fragment>
+        <EuiPageHeader>
+          <EuiText
+            size="s"
+          >
+            <h1>
+              Audit logging
+            </h1>
+          </EuiText>
+        </EuiPageHeader>
+        <EuiSpacer />
+      </React.Fragment>
     }
     navigation={Object {}}
     resourceType="auditLogging"
   />
-  <EuiSpacer />
   <EuiPanel>
     <EuiForm>
       <EuiDescribedFormGroup
@@ -705,20 +707,22 @@ exports[`Audit logs should load access error component 1`] = `
       }
     }
     fallBackComponent={
-      <EuiPageHeader>
-        <EuiText
-          size="s"
-        >
-          <h1>
-            Audit logging
-          </h1>
-        </EuiText>
-      </EuiPageHeader>
+      <React.Fragment>
+        <EuiPageHeader>
+          <EuiText
+            size="s"
+          >
+            <h1>
+              Audit logging
+            </h1>
+          </EuiText>
+        </EuiPageHeader>
+        <EuiSpacer />
+      </React.Fragment>
     }
     navigation={Object {}}
     resourceType="auditLogging"
   />
-  <EuiSpacer />
   <AccessErrorComponent
     loading={false}
     message="You do not have permissions to configure audit logging settings"

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -194,6 +194,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
         }
         resourceType={ResourceType.users}
         subAction={TITLE_TEXT_DICT[props.action]}
+        pageTitle={props.sourceUserName}
       />
       <PanelWithHeader headerText="Credentials">
         <EuiForm>

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -281,6 +281,7 @@ export function RoleEdit(props: RoleEditDeps) {
         descriptionControls={descriptionData}
         resourceType={ResourceType.roles}
         subAction={TITLE_TEXT_DICT[props.action]}
+        pageTitle={props.sourceRoleName}
       />
       <PanelWithHeader headerText="Name">
         <EuiForm>


### PR DESCRIPTION
### Description
This PR fixes a few issues with the UX for the new page header/home feature flag. 
It does the following:
- Removes Extra spacing on the audit log page
- Adds the role/user name into the breadcrumbs on the edit page to give context using the breadcrumbs

### Category
Enhancement
### Why these changes are required?
Fix: #2106 

### What is the old behavior before changes and new behavior after changes?
See screenshots

### Issues Resolved
Fix: #2106 
### Testing
Existing tests pass, updated snapshots
### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).