### PR TITLE
Fix button label

### DIFF
--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -86,13 +86,13 @@ runs:
       run: |
         cd ./OpenSearch-Dashboards
         echo "Start checking OpenSearch Dashboards."
-        for i in {1..60}; do
-          if grep -q "bundles compiled successfully after" "dashboard.log"; then
-            echo "OpenSearch Dashboards compiled successfully."
+        for i in {1..6}; do
+          if grep -q "http server running" "dashboard.log"; then
+            echo "OpenSearch Dashboards started successfully."
             break
           fi
-          if [ $i -eq 60 ]; then
-            echo "Timeout for 900 seconds reached. OpenSearch Dashboards did not finish compiling."
+          if [ $i -eq 6 ]; then
+            echo "Timeout for 60 seconds reached. OpenSearch Dashboards did not start."
             exit 1
           fi
           sleep 10

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -80,8 +80,8 @@ runs:
       run: |
         cd ./OpenSearch-Dashboards
         echo "Start checking OpenSearch Dashboards."
-        for i in {1..60}; do
-          if grep -q "http server running at" "dashboard.log"; then
+        for i in {1..90}; do
+          if grep -q "bundles compiled successfully after" "dashboard.log"; then
             echo "OpenSearch Dashboards compiled successfully."
             break
           fi

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -67,6 +67,7 @@ runs:
       run: |
         cd OpenSearch-Dashboards
         node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10 --verbose
+      shell: bash
 
     - name: Run OpenSearch Dashboards with provided configuration
       if: ${{ runner.os == 'Linux' }}

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -68,9 +68,9 @@ runs:
       run: |
         cd ./OpenSearch-Dashboards
         if [ -z "${{ inputs.osd_base_path }}" ]; then
-          yarn start --no-base-path --csp.warnLegacyBrowsers=false
+          nohup yarn start --no-base-path --no-watch --csp.warnLegacyBrowsers=false | tee dashboard.log &
         else
-          yarn start --csp.warnLegacyBrowsers=false
+          nohup yarn start --no-watch --csp.warnLegacyBrowsers=false | tee dashboard.log &
         fi
       shell: bash
 
@@ -81,7 +81,7 @@ runs:
         cd ./OpenSearch-Dashboards
         echo "Start checking OpenSearch Dashboards."
         for i in {1..60}; do
-          if grep -q "bundles compiled successfully after" "dashboard.log"; then
+          if grep -q "http server running at" "dashboard.log"; then
             echo "OpenSearch Dashboards compiled successfully."
             break
           fi

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -63,6 +63,11 @@ runs:
         fi
       shell: bash
 
+    - name: Compile OpenSearch Dashboards
+      run: |
+        cd OpenSearch-Dashboards
+        node scripts/build_opensearch_dashboards_platform_plugins --no-examples --workers=10 --verbose
+
     - name: Run OpenSearch Dashboards with provided configuration
       if: ${{ runner.os == 'Linux' }}
       run: |
@@ -80,12 +85,12 @@ runs:
       run: |
         cd ./OpenSearch-Dashboards
         echo "Start checking OpenSearch Dashboards."
-        for i in {1..90}; do
+        for i in {1..60}; do
           if grep -q "bundles compiled successfully after" "dashboard.log"; then
             echo "OpenSearch Dashboards compiled successfully."
             break
           fi
-          if [ $i -eq 90 ]; then
+          if [ $i -eq 60 ]; then
             echo "Timeout for 900 seconds reached. OpenSearch Dashboards did not finish compiling."
             exit 1
           fi

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -68,9 +68,9 @@ runs:
       run: |
         cd ./OpenSearch-Dashboards
         if [ -z "${{ inputs.osd_base_path }}" ]; then
-          nohup yarn start --no-base-path --no-watch --csp.warnLegacyBrowsers=false | tee dashboard.log &
+          yarn start --no-base-path --csp.warnLegacyBrowsers=false
         else
-          nohup yarn start --no-watch --csp.warnLegacyBrowsers=false | tee dashboard.log &
+          yarn start --csp.warnLegacyBrowsers=false
         fi
       shell: bash
 

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -85,8 +85,8 @@ runs:
             echo "OpenSearch Dashboards compiled successfully."
             break
           fi
-          if [ $i -eq 60 ]; then
-            echo "Timeout for 600 seconds reached. OpenSearch Dashboards did not finish compiling."
+          if [ $i -eq 90 ]; then
+            echo "Timeout for 900 seconds reached. OpenSearch Dashboards did not finish compiling."
             exit 1
           fi
           sleep 10

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -61,7 +61,7 @@ const addBackendStep = {
           <ExternalLinkButton
             fill
             href={DocLinks.BackendConfigurationDoc}
-            text="Create config.yml"
+            text="Config.yml documentation"
           />
         </EuiFlexItem>
         <EuiFlexItem grow={false}>

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -431,7 +431,7 @@ exports[`Get started (landing page) renders when backend configuration is enable
                     <ExternalLinkButton
                       fill={true}
                       href="https://opensearch.org/docs/latest/security-plugin/configuration/configuration/"
-                      text="Create config.yml"
+                      text="Config.yml documentation"
                     />
                   </EuiFlexItem>
                   <EuiFlexItem


### PR DESCRIPTION
### Description
Fixes the button label for config.yml documentation on the "Get Started" page

### Category
Bug fix
### Why these changes are required?
Fix: #2129 

### What is the old behavior before changes and new behavior after changes?
Used to say "Create config.yml", now it says "Config.yml documentation"

### Issues Resolved
Fix: #2129
### Testing
Existing tests pass
### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).