### PR TITLE
Move Stephen to Emeritus maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cwperks @DarshitChanpura @derek-ho @RyanL1997 @stephen-crawford
+* @cwperks @DarshitChanpura @derek-ho @RyanL1997

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,17 +9,18 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Darshit Chanpura | [DarshitChanpura](https://github.com/DarshitChanpura) | Amazon      |
 | Craig Perkins    | [cwperks](https://github.com/cwperks)                 | Amazon      |
 | Ryan Liang       | [RyanL1997](https://github.com/RyanL1997)             | Amazon      |
-| Stephen Crawford | [scrawfor99](https://github.com/stephen-crawford)     | Amazon      |
 | Derek Ho         | [derek-ho](https://github.com/derek-ho)               | Amazon      |
 
 ## Emeritus
 
-| Maintainer    | GitHub ID                                           | Affiliation |
-| ------------- | --------------------------------------------------- | ----------- |
-| Yan Zeng      | [zengyan-amazon](https://github.com/zengyan-amazon) | Amazon      |
-| Bandini Bhopi | [bandinib-amzn](https://github.com/bandinib-amzn)   | Amazon      |
-| Tianle Huang  | [tianleh](https://github.com/tianleh)               | Amazon      |
-| Dave Lago     | [davidlago](https://github.com/davidlago)           | Contributor |
-| Peter Nied    | [peternied](https://github.com/peternied)           | Amazon      |
-| Chang Liu     | [cliu123](https://github.com/cliu123)               | Amazon      |
+| Maintainer       | GitHub ID                                           | Affiliation |
+| --------------   | --------------------------------------------------- | ----------- |
+| Yan Zeng         | [zengyan-amazon](https://github.com/zengyan-amazon) | Amazon      |
+| Bandini Bhopi    | [bandinib-amzn](https://github.com/bandinib-amzn)   | Amazon      |
+| Tianle Huang     | [tianleh](https://github.com/tianleh)               | Amazon      |
+| Dave Lago        | [davidlago](https://github.com/davidlago)           | Contributor |
+| Peter Nied       | [peternied](https://github.com/peternied)           | Amazon      |
+| Chang Liu        | [cliu123](https://github.com/cliu123)               | Amazon      |
+| Stephen Crawford | [scrawfor99](https://github.com/stephen-crawford)   | Contributor |
+
 


### PR DESCRIPTION
### Description
Move @stephen-crawford to emeritus maintainer

### Category
Maintenance
### Why these changes are required?
@stephen-crawford 

### What is the old behavior before changes and new behavior after changes?
@stephen-crawford 

### Issues Resolved
None
### Testing
None
### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).