### PR TITLE
Fix issue: tenant is defaulting incorrectly based on the ordering of: opensearch_security.multitenancy.tenants.preferred #2019

### DIFF
--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -23,7 +23,7 @@ import { GLOBAL_TENANT_SYMBOL, globalTenantName, PRIVATE_TENANT_SYMBOL } from '.
 import { ensureRawRequest } from '../../../../src/core/server/http/router';
 import { GOTO_PREFIX } from '../../../../src/plugins/share/common/short_url_routes';
 
-export const PRIVATE_TENANTS: string[] = [PRIVATE_TENANT_SYMBOL, 'private'];
+export const PRIVATE_TENANTS: string[] = [PRIVATE_TENANT_SYMBOL, 'private', 'Private'];
 export const GLOBAL_TENANTS: string[] = ['global', GLOBAL_TENANT_SYMBOL, 'Global'];
 /**
  * Resovles the tenant the user is using.

--- a/server/multitenancy/test/tenant_resolver.test.ts
+++ b/server/multitenancy/test/tenant_resolver.test.ts
@@ -73,3 +73,77 @@ describe("Resolve tenants when multitenancy is enabled and both 'Global' and 'Pr
     expect(adminResult).toEqual('');
   });
 });
+
+describe("Resolve tenants when multitenancy is enabled and both 'Global' and 'Private' tenants are enabled", () => {
+  function resolveWithConfig(config: any) {
+    return resolve(
+      config.username,
+      config.requestedTenant,
+      config.preferredTenants,
+      config.availableTenants,
+      config.globalTenantEnabled,
+      config.multitenancy_enabled,
+      config.privateTenantEnabled
+    );
+  }
+
+  it('Resolve tenant when requested tenant is Private but preferred tenant is Global', () => {
+    const nonadminConfig = {
+      username: 'testuser',
+      requestedTenant: 'Private',
+      preferredTenants: ['Global', 'Private'],
+      availableTenants: { global_tenant: true, testuser: true },
+      globalTenantEnabled: true,
+      multitenancy_enabled: true,
+      privateTenantEnabled: true,
+    };
+
+    const nonadminResult = resolveWithConfig(nonadminConfig);
+    expect(nonadminResult).toEqual('__user__');
+  });
+
+  it('Resolve tenant when requested tenant is Global but preferred tenant is Private', () => {
+    const nonadminConfig = {
+      username: 'testuser',
+      requestedTenant: 'Global',
+      preferredTenants: ['Private', 'Global'],
+      availableTenants: { global_tenant: true, testuser: true },
+      globalTenantEnabled: true,
+      multitenancy_enabled: true,
+      privateTenantEnabled: true,
+    };
+
+    const nonadminResult = resolveWithConfig(nonadminConfig);
+    expect(nonadminResult).toEqual('');
+  });
+
+  it('Resolve tenant when requested tenant is undefined but preferred tenant is Private', () => {
+    const nonadminConfig = {
+      username: 'testuser',
+      requestedTenant: undefined,
+      preferredTenants: ['Private', 'Global'],
+      availableTenants: { global_tenant: true, testuser: true },
+      globalTenantEnabled: true,
+      multitenancy_enabled: true,
+      privateTenantEnabled: true,
+    };
+
+    const nonadminResult = resolveWithConfig(nonadminConfig);
+    expect(nonadminResult).toEqual('__user__');
+  });
+
+  it('Resolve tenant when requested tenant is undefined but preferred tenant is Global', () => {
+    const nonadminConfig = {
+      username: 'testuser',
+      requestedTenant: undefined,
+      preferredTenants: ['Global', 'Private'],
+      availableTenants: { global_tenant: true, testuser: true },
+      globalTenantEnabled: true,
+      multitenancy_enabled: true,
+      privateTenantEnabled: true,
+    };
+
+    const nonadminResult = resolveWithConfig(nonadminConfig);
+    expect(nonadminResult).toEqual('');
+  });
+});


### PR DESCRIPTION
### Description
Fixes a bug where the tenant was defaulting incorrectly based on the ordering of opensearch_security.multitenancy.tenants.preferred, whereas it should be on the basis of default tenant.

### Category
Bug fix

### Why these changes are required?
Fix: #2019 

### What is the old behavior before changes and new behavior after changes?
Old behavior: 
If `opensearch_security.multitenancy.tenants.preferred: ["Global", "Private"]` and default tenant is `Private` the user will be logged into Global tenant.
New behavior:
The user will be logged in as the default tenant (which is Private in the above example)

### Issues Resolved
Fix: #2019 

### Testing
Manually tested the behavior

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).