### PR TITLE
Fix CI failures related to security plugin download

### DIFF
--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -26,6 +26,7 @@ runs:
         -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots/ \
         -Dartifact=org.opensearch.plugin:${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip \
         -Dtransitive=false
+        ls ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/
         ls ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}/
         cp ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}-*.zip ${{ inputs.download-location }}.zip
       shell: bash

--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -27,7 +27,7 @@ runs:
         -Dartifact=org.opensearch.plugin:${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip \
         -Dtransitive=false
         ls ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/
-        ls ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}/
-        cp ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}-*.zip ${{ inputs.download-location }}.zip
+        ls ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}-SNAPSHOT/
+        cp ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}-SNAPSHOT/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}-*.zip ${{ inputs.download-location }}.zip
       shell: bash
       

--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -26,6 +26,6 @@ runs:
         -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots/ \
         -Dartifact=org.opensearch.plugin:${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip \
         -Dtransitive=false
-        cp ./${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip ${{ inputs.download-location }}.zip
+        cp ./${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-*.zip ${{ inputs.download-location }}.zip
       shell: bash
       

--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -25,7 +25,7 @@ runs:
         mvn dependency:get \
         -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots/ \
         -Dartifact=org.opensearch.plugin:${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip \
-        -Dtransitive=false \
-        -Ddest=${{ inputs.download-location }}.zip
+        -Dtransitive=false
+        cp ./${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip ${{ inputs.download-location }}.zip
       shell: bash
       

--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -26,8 +26,6 @@ runs:
         -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots/ \
         -Dartifact=org.opensearch.plugin:${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip \
         -Dtransitive=false
-        ls ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/
-        ls ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}-SNAPSHOT/
         cp ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}-SNAPSHOT/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}-SNAPSHOT.zip ${{ inputs.download-location }}.zip
       shell: bash
       

--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -28,6 +28,6 @@ runs:
         -Dtransitive=false
         ls ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/
         ls ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}-SNAPSHOT/
-        cp ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}-SNAPSHOT/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}-*.zip ${{ inputs.download-location }}.zip
+        cp ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}-SNAPSHOT/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}-SNAPSHOT.zip ${{ inputs.download-location }}.zip
       shell: bash
       

--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -26,6 +26,7 @@ runs:
         -DremoteRepositories=https://aws.oss.sonatype.org/content/repositories/snapshots/ \
         -Dartifact=org.opensearch.plugin:${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip \
         -Dtransitive=false
-        cp ./${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-*.zip ${{ inputs.download-location }}.zip
+        ls ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}/
+        cp ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}-*.zip ${{ inputs.download-location }}.zip
       shell: bash
       

--- a/.github/workflows/cypress-test-multiauth-e2e.yml
+++ b/.github/workflows/cypress-test-multiauth-e2e.yml
@@ -59,7 +59,7 @@ jobs:
                     config:
                       idp:
                         entity_id: urn:example:idp
-                        metadata_url: http://localhost:7000/metadata
+                        metadata_url: http://[::1]:7000/metadata
                       sp:
                         entity_id: https://localhost:9200
                       kibana_url: http://localhost:5601${{ matrix.basePath }}

--- a/.github/workflows/cypress-test-saml-e2e.yml
+++ b/.github/workflows/cypress-test-saml-e2e.yml
@@ -59,7 +59,7 @@ jobs:
                     config:
                       idp:
                         entity_id: urn:example:idp
-                        metadata_url: http://localhost:7000/metadata
+                        metadata_url: http://[::1]:7000/metadata
                       sp:
                         entity_id: https://localhost:9200
                       kibana_url: http://localhost:5601${{ matrix.basePath }}

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -32,7 +32,7 @@ before(() => {
   if (Cypress.env('loginMethod') === 'saml_multiauth') {
     cy.visit(`http://localhost:5601${basePath}`);
   } else {
-    cy.origin('http://[::1]:7000', () => {
+    cy.origin('http://[::1]:7000', { args: { basePath } }, ({ basePath }) => {
       cy.visit(`http://localhost:5601${basePath}`);
     });
   }

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -47,7 +47,7 @@ beforeEach(() => {
       req.url = req.url.replace(/\[::1\]/g, 'localhost');
     }
 
-    req.continue((res) => {
+    req.on('response', (res) => {
       if (res && res.headers) {
         Object.keys(res.headers).forEach((key) => {
           if (typeof res.headers[key] === 'string' && res.headers[key].includes('[::1]')) {

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -68,8 +68,8 @@ afterEach(() => {
 describe('Log in via SAML', () => {
   const loginWithSamlMultiauth = () => {
     cy.get('a[aria-label="saml_login_button"]').should('be.visible');
+    cy.get('a[aria-label="saml_login_button"]').should('be.visible').click();
     cy.origin('http://localhost:7000', () => {
-      cy.get('a[aria-label="saml_login_button"]').should('be.visible').click();
       cy.get('input[id=userName]').should('be.visible');
       cy.get('button[id=btn-sign-in]').should('be.visible').click();
     });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -42,21 +42,18 @@ before(() => {
 
 beforeEach(() => {
   cy.intercept('GET', '**/**', (req) => {
-    // Replace [::1] with localhost in the request URL
+    // Replace [::1] with localhost in the request URL and headers
     if (req.url.includes('[::1]')) {
       req.url = req.url.replace(/\[::1\]/g, 'localhost');
     }
 
     req.continue((res) => {
       if (res && res.headers) {
-        // Loop through all headers and replace [::1] with localhost where applicable
         Object.keys(res.headers).forEach((key) => {
           if (typeof res.headers[key] === 'string' && res.headers[key].includes('[::1]')) {
             res.headers[key] = res.headers[key].replace(/\[::1\]/g, 'localhost');
           }
         });
-
-        console.log(`Modified res.headers: ${JSON.stringify(res.headers)}`);
       }
       return res;
     });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -28,7 +28,7 @@ before(() => {
   cy.intercept('https://localhost:9200');
 
   // Avoid Cypress lock onto the ipv4 range, so fake `visit()` before `request()`.
-      // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
+  // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
   if (Cypress.env('loginMethod') === 'saml_multiauth') {
     cy.visit(`http://localhost:5601${basePath}`);
   } else {

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -46,7 +46,7 @@ beforeEach(() => {
     if (req.url.includes('[::1]')) {
       req.url = req.url.replace(/\[::1\]/g, 'localhost');
     }
-  
+
     req.continue((res) => {
       if (res && res.headers) {
         // Loop through all headers and replace [::1] with localhost where applicable
@@ -55,7 +55,7 @@ beforeEach(() => {
             res.headers[key] = res.headers[key].replace(/\[::1\]/g, 'localhost');
           }
         });
-  
+
         console.log(`Modified res.headers: ${JSON.stringify(res.headers)}`);
       }
       return res;
@@ -82,7 +82,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
     cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
-      failOnStatusCode: false
+      failOnStatusCode: false,
     });
 
     samlLogin();
@@ -96,7 +96,7 @@ describe('Log in via SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
     cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
-      failOnStatusCode: false
+      failOnStatusCode: false,
     });
 
     samlLogin();

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -27,6 +27,16 @@ const basePath = Cypress.env('basePath') || '';
 before(() => {
   cy.intercept('https://localhost:9200');
 
+  // Avoid Cypress lock onto the ipv4 range, so fake `visit()` before `request()`.
+      // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
+  if (Cypress.env('loginMethod') === 'saml_multiauth') {
+    cy.visit(`http://localhost:5601${basePath}`);
+  } else {
+    cy.origin('http://[::1]:7000', () => {
+      cy.visit(`http://localhost:5601${basePath}`);
+    });
+  }
+
   cy.createRoleMapping(ALL_ACCESS_ROLE, samlUserRoleMapping);
   cy.clearCookies();
   cy.clearLocalStorage();

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -66,23 +66,33 @@ afterEach(() => {
 });
 
 describe('Log in via SAML', () => {
-  const samlLogin = () => {
-    if (Cypress.env('loginMethod') === 'saml_multiauth') {
-      cy.loginWithSamlMultiauth();
-    } else {
-      cy.loginWithSaml();
-    }
+  const loginWithSamlMultiauth = () => {
+    cy.get('a[aria-label="saml_login_button"]').should('be.visible');
+    cy.origin('http://localhost:7000', () => {
+      cy.get('a[aria-label="saml_login_button"]').should('be.visible').click();
+      cy.get('input[id=userName]').should('be.visible');
+      cy.get('button[id=btn-sign-in]').should('be.visible').click();
+    });
   };
 
   it('Login to app/opensearch_dashboards_overview#/ when SAML is enabled', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
-      failOnStatusCode: false,
-    });
-
-    samlLogin();
+    if (Cypress.env('loginMethod') === 'saml_multiauth') {
+      cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+        failOnStatusCode: false,
+      });
+      loginWithSamlMultiauth();
+    } else {
+      cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
+        cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+          failOnStatusCode: false,
+        });
+        cy.get('input[id=userName]').should('be.visible');
+        cy.get('button[id=btn-sign-in]').should('be.visible').click();
+      });
+    }
 
     cy.get('#osdOverviewPageHeader__title').should('be.visible');
     cy.getCookie('security_authentication').should('exist');
@@ -92,11 +102,20 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
-      failOnStatusCode: false,
-    });
-
-    samlLogin();
+    if (Cypress.env('loginMethod') === 'saml_multiauth') {
+      cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
+        failOnStatusCode: false,
+      });
+      loginWithSamlMultiauth();
+    } else {
+      cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
+        cy.visit(`http://localhost:5601${basePath}/app/dev_tools#/console`, {
+          failOnStatusCode: false,
+        });
+        cy.get('input[id=userName]').should('be.visible');
+        cy.get('button[id=btn-sign-in]').should('be.visible').click();
+      });
+    }
 
     cy.get('a.euiBreadcrumb--last').contains('Dev Tools');
     cy.getCookie('security_authentication').should('exist');
@@ -108,11 +127,20 @@ describe('Log in via SAML', () => {
 
     const urlWithHash = `http://localhost:5601${basePath}/app/security-dashboards-plugin#/getstarted`;
 
-    cy.visit(urlWithHash, {
-      failOnStatusCode: false,
-    });
-
-    samlLogin();
+    if (Cypress.env('loginMethod') === 'saml_multiauth') {
+      cy.visit(urlWithHash, {
+        failOnStatusCode: false,
+      });
+      loginWithSamlMultiauth();
+    } else {
+      cy.origin('http://localhost:7000', { args: { urlWithHash } }, ({ urlWithHash }) => {
+        cy.visit(urlWithHash, {
+          failOnStatusCode: false,
+        });
+        cy.get('input[id=userName]').should('be.visible');
+        cy.get('button[id=btn-sign-in]').should('be.visible').click();
+      });
+    }
 
     cy.get('h1').contains('Get started');
     cy.getCookie('security_authentication').should('exist');
@@ -121,11 +149,20 @@ describe('Log in via SAML', () => {
   it('Tenancy persisted after logout in SAML', () => {
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
-      failOnStatusCode: false,
-    });
-
-    samlLogin();
+    if (Cypress.env('loginMethod') === 'saml_multiauth') {
+      cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+        failOnStatusCode: false,
+      });
+      loginWithSamlMultiauth();
+    } else {
+      cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
+        cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+          failOnStatusCode: false,
+        });
+        cy.get('input[id=userName]').should('be.visible');
+        cy.get('button[id=btn-sign-in]').should('be.visible').click();
+      });
+    }
 
     cy.get('#private').should('be.enabled');
     cy.get('#private').click({ force: true });
@@ -138,7 +175,20 @@ describe('Log in via SAML', () => {
 
     cy.get('button[data-test-subj^="log-out-"]').click();
 
-    samlLogin();
+    if (Cypress.env('loginMethod') === 'saml_multiauth') {
+      cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+        failOnStatusCode: false,
+      });
+      loginWithSamlMultiauth();
+    } else {
+      cy.origin('http://localhost:7000', { args: { basePath } }, ({ basePath }) => {
+        cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+          failOnStatusCode: false,
+        });
+        cy.get('input[id=userName]').should('be.visible');
+        cy.get('button[id=btn-sign-in]').should('be.visible').click();
+      });
+    }
 
     cy.get('#user-icon-btn').should('be.visible');
     cy.get('#user-icon-btn').click();
@@ -155,8 +205,20 @@ describe('Log in via SAML', () => {
       // since the Shorten URL api is return's set-cookie header for admin user.
       cy.clearCookies().then(() => {
         const gotoUrl = `http://localhost:5601${basePath}/goto/${response.urlId}?security_tenant=global`;
-        cy.visit(gotoUrl);
-        samlLogin();
+        if (Cypress.env('loginMethod') === 'saml_multiauth') {
+          cy.visit(gotoUrl, {
+            failOnStatusCode: false,
+          });
+          loginWithSamlMultiauth();
+        } else {
+          cy.origin('http://localhost:7000', { args: { gotoUrl } }, ({ gotoUrl }) => {
+            cy.visit(gotoUrl, {
+              failOnStatusCode: false,
+            });
+            cy.get('input[id=userName]').should('be.visible');
+            cy.get('button[id=btn-sign-in]').should('be.visible').click();
+          });
+        }
         cy.getCookie('security_authentication').should('exist');
       });
     });

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -27,10 +27,6 @@ const basePath = Cypress.env('basePath') || '';
 before(() => {
   cy.intercept('https://localhost:9200');
 
-  // Avoid Cypress lock onto the ipv4 range, so fake `visit()` before `request()`.
-  // See: https://github.com/cypress-io/cypress/issues/25397#issuecomment-1402556488
-  cy.visit(`http://localhost:5601${basePath}`);
-
   cy.createRoleMapping(ALL_ACCESS_ROLE, samlUserRoleMapping);
   cy.clearCookies();
   cy.clearLocalStorage();

--- a/test/cypress/e2e/saml/saml_auth_test.spec.js
+++ b/test/cypress/e2e/saml/saml_auth_test.spec.js
@@ -60,9 +60,17 @@ describe('Log in via SAML', () => {
     localStorage.setItem('opendistro::security::tenant::saved', '"__user__"');
     localStorage.setItem('home:newThemeModal:show', 'false');
 
-    cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
-      failOnStatusCode: false,
-    });
+    if (Cypress.env('loginMethod') === 'saml_multiauth') {
+      cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+        failOnStatusCode: false,
+      });
+    } else {
+      cy.origin('http://[::1]:7000', { args: { basePath } }, ({ basePath }) => {
+        cy.visit(`http://localhost:5601${basePath}/app/opensearch_dashboards_overview`, {
+          failOnStatusCode: false,
+        });
+      });
+    }
 
     samlLogin();
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -88,8 +88,8 @@ Cypress.Commands.add('loginWithSaml', () => {
 
 Cypress.Commands.add('loginWithSamlMultiauth', () => {
   cy.get('a[aria-label="saml_login_button"]').should('be.visible');
-  cy.get('a[aria-label="saml_login_button"]').should('be.visible').click();
   cy.origin('http://[::1]:7000', () => {
+    cy.get('a[aria-label="saml_login_button"]').should('be.visible').click();
     cy.get('input[id=userName]').should('be.visible');
     cy.get('button[id=btn-sign-in]').should('be.visible').click();
   });

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -80,19 +80,15 @@ Cypress.Commands.add('createRoleMapping', (roleID, rolemappingJson) => {
 });
 
 Cypress.Commands.add('loginWithSaml', () => {
-  cy.origin('http://[::1]:7000', () => {
-    cy.get('input[id=userName]').should('be.visible');
-    cy.get('button[id=btn-sign-in]').should('be.visible').click();
-  });
+  cy.get('input[id=userName]').should('be.visible');
+  cy.get('button[id=btn-sign-in]').should('be.visible').click();
 });
 
 Cypress.Commands.add('loginWithSamlMultiauth', () => {
   cy.get('a[aria-label="saml_login_button"]').should('be.visible');
-  cy.origin('http://[::1]:7000', () => {
-    cy.get('a[aria-label="saml_login_button"]').should('be.visible').click();
-    cy.get('input[id=userName]').should('be.visible');
-    cy.get('button[id=btn-sign-in]').should('be.visible').click();
-  });
+  cy.get('a[aria-label="saml_login_button"]').should('be.visible').click();
+  cy.get('input[id=userName]').should('be.visible');
+  cy.get('button[id=btn-sign-in]').should('be.visible').click();
 });
 
 if (Cypress.env('LOGIN_AS_ADMIN')) {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -79,18 +79,6 @@ Cypress.Commands.add('createRoleMapping', (roleID, rolemappingJson) => {
   });
 });
 
-Cypress.Commands.add('loginWithSaml', () => {
-  cy.get('input[id=userName]').should('be.visible');
-  cy.get('button[id=btn-sign-in]').should('be.visible').click();
-});
-
-Cypress.Commands.add('loginWithSamlMultiauth', () => {
-  cy.get('a[aria-label="saml_login_button"]').should('be.visible');
-  cy.get('a[aria-label="saml_login_button"]').should('be.visible').click();
-  cy.get('input[id=userName]').should('be.visible');
-  cy.get('button[id=btn-sign-in]').should('be.visible').click();
-});
-
 if (Cypress.env('LOGIN_AS_ADMIN')) {
   // Define custom cy.visit() only if LOGIN_AS_ADMIN is true
   Cypress.Commands.overwrite('visit', (orig, url, options = {}) => {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -80,15 +80,19 @@ Cypress.Commands.add('createRoleMapping', (roleID, rolemappingJson) => {
 });
 
 Cypress.Commands.add('loginWithSaml', () => {
-  cy.get('input[id=userName]').should('be.visible');
-  cy.get('button[id=btn-sign-in]').should('be.visible').click();
+  cy.origin('http://[::1]:7000', () => {
+    cy.get('input[id=userName]').should('be.visible');
+    cy.get('button[id=btn-sign-in]').should('be.visible').click();
+  });
 });
 
 Cypress.Commands.add('loginWithSamlMultiauth', () => {
   cy.get('a[aria-label="saml_login_button"]').should('be.visible');
   cy.get('a[aria-label="saml_login_button"]').should('be.visible').click();
-  cy.get('input[id=userName]').should('be.visible');
-  cy.get('button[id=btn-sign-in]').should('be.visible').click();
+  cy.origin('http://[::1]:7000', () => {
+    cy.get('input[id=userName]').should('be.visible');
+    cy.get('button[id=btn-sign-in]').should('be.visible').click();
+  });
 });
 
 if (Cypress.env('LOGIN_AS_ADMIN')) {


### PR DESCRIPTION
### Description

There were 2 issues that needed fixing:

1. The download of the security plugin was failing due to using a deprecated -Ddest setting in the mvn command
2. SAML Tests were failing because the backend couldn't fetch metadata. I had to switch to IPv6 address for the metadata url, but then ran into another issue where cypress couldn't understand IPv6. To fix that I wrote an interceptor to convert between IPv6 and localhost

### Category

Maintenance

### Issues Resolved

Resolves: https://github.com/opensearch-project/security-dashboards-plugin/issues/2168

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).