### PR TITLE
Replace _opendistro route to _plugins

### DIFF
--- a/.github/workflows/cypress-test-multiauth-e2e.yml
+++ b/.github/workflows/cypress-test-multiauth-e2e.yml
@@ -83,7 +83,7 @@ jobs:
           opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
           opensearch_security.readonly_mode.roles: ["kibana_read_only"]
           opensearch_security.cookie.secure: false
-          server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/acs/idpinitiated", "/_opendistro/_security/saml/logout"]
+          server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/acs/idpinitiated", "/_plugins/_security/saml/logout"]
           opensearch_security.auth.type: ["basicauth","saml"]
           opensearch_security.auth.multiple_auth_enabled: true
           opensearch_security.auth.anonymous_auth_enabled: false

--- a/.github/workflows/cypress-test-saml-e2e.yml
+++ b/.github/workflows/cypress-test-saml-e2e.yml
@@ -83,7 +83,7 @@ jobs:
           opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
           opensearch_security.readonly_mode.roles: ["kibana_read_only"]
           opensearch_security.cookie.secure: false
-          server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/acs/idpinitiated", "/_opendistro/_security/saml/logout"]
+          server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/acs/idpinitiated", "/_plugins/_security/saml/logout"]
           opensearch_security.auth.type: ["saml"]
           opensearch_security.auth.multiple_auth_enabled: true
           opensearch_security.auth.anonymous_auth_enabled: false

--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -101,7 +101,7 @@ export class SamlAuthRoutes {
 
     this.router.post(
       {
-        path: `/_opendistro/_security/saml/acs`,
+        path: `/_plugins/_security/saml/acs`,
         validate: {
           body: schema.any(),
         },
@@ -200,7 +200,7 @@ export class SamlAuthRoutes {
 
     this.router.post(
       {
-        path: `/_opendistro/_security/saml/acs/idpinitiated`,
+        path: `/_plugins/_security/saml/acs/idpinitiated`,
         validate: {
           body: schema.any(),
         },
@@ -209,7 +209,7 @@ export class SamlAuthRoutes {
         },
       },
       async (context, request, response) => {
-        const acsEndpoint = `${this.coreSetup.http.basePath.serverBasePath}/_opendistro/_security/saml/acs/idpinitiated`;
+        const acsEndpoint = `${this.coreSetup.http.basePath.serverBasePath}/_plugins/_security/saml/acs/idpinitiated`;
         try {
           const credentials = await this.securityClient.authToken({
             requestId: undefined,
@@ -328,7 +328,7 @@ export class SamlAuthRoutes {
       }
     );
 
-    //  Once the User is authenticated via the '_opendistro/_security/saml/acs' route,
+    //  Once the User is authenticated via the '_plugins/_security/saml/acs' route,
     //  the browser will be redirected to '/auth/saml/redirectUrlFragment' route,
     //  which will execute the redirectUrlFragment.js.
     this.coreSetup.http.resources.register(

--- a/test/jest_integration/runIdpServer.js
+++ b/test/jest_integration/runIdpServer.js
@@ -31,7 +31,7 @@ const argv = minimist(process.argv.slice(2), {
 
 // Create certificate pair on the fly and pass it to runServer
 runServer({
-  acsUrl: `http://localhost:5601${argv.basePath}/_opendistro/_security/saml/acs`,
+  acsUrl: `http://localhost:5601${argv.basePath}/_plugins/_security/saml/acs`,
   audience: 'https://localhost:9200',
   cert: pems.cert,
   key: pems.private.toString().replace(/\r\n/, '\n'),


### PR DESCRIPTION
### Description
The change is related to https://github.com/opensearch-project/security/pull/5066 in the security plugin, which removes `_opendisto` route

### What is the old behavior before changes and new behavior after changes?
### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).