### PR TITLE
Forcibly resolve cross-spawn to 7.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express": "^4.21.1",
     "braces": "^3.0.3",
     "body-parser": "^1.20.3",
-    "micromatch": "^4.0.8"
+    "micromatch": "^4.0.8",
+    "cross-spawn": "7.0.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,10 +1256,10 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-spawn@^7.0.0:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+cross-spawn@7.0.5, cross-spawn@^7.0.0:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.5.tgz#910aac880ff5243da96b728bc6521a5f6c2f2f82"
+  integrity sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"


### PR DESCRIPTION
### Description

The yarn.lock file currently has 7.0.3 which is associated with https://nvd.nist.gov/vuln/detail/CVE-2024-21538.

This dependency comes transitively from `cypress` through `execa:4.1.0`, but there isn't an upgrade available so I'm opting to forcibly resolve it instead.

### Category

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).