### PR TITLE
Fixes CVE-2025-29774 CVE-2025-29775 and GHSA-vjh7-7g9h-fjfh

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "braces": "^3.0.3",
     "body-parser": "^1.20.3",
     "micromatch": "^4.0.8",
-    "cross-spawn": "7.0.5"
+    "cross-spawn": "7.0.5",
+    "elliptic": "^6.6.1",
+    "xml-crypto": "^2.1.6"
   }
 }

--- a/release-notes/opensearch-security-dashboards-plugin.release-notes-3.0.0.0-alpha1.md
+++ b/release-notes/opensearch-security-dashboards-plugin.release-notes-3.0.0.0-alpha1.md
@@ -4,3 +4,4 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.0.0-alpha1
 
 ### Maintenance
 * Fix alpha bump ([#2190](https://github.com/opensearch-project/security-dashboards-plugin/pull/2190))
+* Bump xlm-crypto and elliptic ([#2196](https://github.com/opensearch-project/security-dashboards-plugin/pull/2196))

--- a/yarn.lock
+++ b/yarn.lock
@@ -1511,10 +1511,10 @@ ejs@2.5.5, ejs@^3.1.10:
   dependencies:
     jake "^10.8.5"
 
-elliptic@^6.5.3, elliptic@^6.5.5:
-  version "6.5.6"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.6.tgz#ee5f7c3a00b98a2144ac84d67d01f04d438fa53e"
-  integrity sha512-mpzdtpeCLuS3BmE3pO3Cpp5bbjlOPY2Q0PgoF+Od1XZrHLYI28Xe3ossCmYCQt11FQKEYd9+PF8jymTvtWJSHQ==
+elliptic@^6.5.3, elliptic@^6.5.5, elliptic@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"
@@ -4744,10 +4744,10 @@ ws@>=8.13.0:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
   integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
-xml-crypto@^2.0.0, xml-crypto@^2.1.3:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/xml-crypto/-/xml-crypto-2.1.5.tgz#e201ee51dca18dd9ae158ac101b6e995c983dca8"
-  integrity sha512-xOSJmGFm+BTXmaPYk8pPV3duKo6hJuZ5niN4uMzoNcTlwYs0jAu/N3qY+ud9MhE4N7eMRuC1ayC7Yhmb7MmAWg==
+xml-crypto@^2.0.0, xml-crypto@^2.1.3, xml-crypto@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/xml-crypto/-/xml-crypto-2.1.6.tgz#c51a016cc8391fc1d9ebd9abc589e4c08b62d652"
+  integrity sha512-jjvpO8vHNV8QFhW5bMypP+k4BjBqHe/HrpIwpPcdUnUTIJakSIuN96o3Sdah4tKu2z64kM/JHEH8iEHGCc6Gyw==
   dependencies:
     "@xmldom/xmldom" "^0.7.9"
     xpath "0.0.32"


### PR DESCRIPTION

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).