### PR TITLE
Changes to remove tenant panels from roles pages when multitenancy is disabled

### DIFF
--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -59,6 +59,7 @@ import { NameRow } from '../../utils/name-row';
 import { DataSourceContext } from '../../app-router';
 import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
 import { PageHeader } from '../../header/header-components';
+import { getDashboardsInfoSafe } from '../../../../utils/dashboards-info-utils';
 
 interface RoleEditDeps extends BreadcrumbsPageDependencies {
   action: 'create' | 'edit' | 'duplicate';
@@ -144,6 +145,22 @@ export function RoleEdit(props: RoleEditDeps) {
 
     fetchTenantNames();
   }, [addToast, props.coreStart.http, dataSource]);
+
+  const [isMultiTenancyEnabled, setIsMultiTenancyEnabled] = useState(true);
+  React.useEffect(() => {
+    const fetchIsMultiTenancyEnabled = async () => {
+      try {
+        const dashboardsInfo = await getDashboardsInfoSafe(props.coreStart.http);
+        setIsMultiTenancyEnabled(
+          dashboardsInfo?.multitenancy_enabled && props.config.multitenancy.enabled
+        );
+      } catch (e) {
+        console.error(e);
+      }
+    };
+
+    fetchIsMultiTenancyEnabled();
+  }, [props.coreStart.http, props.config.multitenancy]);
 
   const updateRoleHandler = async () => {
     try {
@@ -309,12 +326,16 @@ export function RoleEdit(props: RoleEditDeps) {
         optionUniverse={indexWisePermissionOptions}
       />
       <EuiSpacer size="m" />
-      <TenantPanel
-        state={roleTenantPermission}
-        setState={setRoleTenantPermission}
-        optionUniverse={tenantOptions}
-      />
-      <EuiSpacer size="m" />
+      {isMultiTenancyEnabled && (
+        <>
+          <TenantPanel
+            state={roleTenantPermission}
+            setState={setRoleTenantPermission}
+            optionUniverse={tenantOptions}
+          />
+          <EuiSpacer size="m" />
+        </>
+      )}
       <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
           <EuiSmallButton


### PR DESCRIPTION
### Description
Changes to remove tenant panels from roles pages when multitenancy is disabled

### Category
Bug fix

### Why these changes are required?
Tenant Panel is not required on role view, edit, and list pages when multitenancy is disabled.

### What is the old behavior before changes and new behavior after changes?
Tenant Panel is present on role view, edit, and list pages when multitenancy is disabled.

### Issues Resolved
- [x] https://github.com/opensearch-project/security-dashboards-plugin/issues/2139

### Testing
- Added unit tests
- Completed manual testing
  - Case 1: When multitenancy is enabled [in config and from dashboards]: Tenant Panel is present on role view, create, edit, duplicate and list pages
  - Case 2: When multitenancy is disabled [ either from config or from dashboards]: Tenant Panel is not present on role view, create, edit, duplicate and list pages

Roles view and Role list page when multitenancy is enabled:
<img width="1727" alt="Screenshot 2025-04-23 at 2 19 34 AM" src="https://github.com/user-attachments/assets/b8362069-0198-45c1-8914-e8abd28d40dc" />
<img width="1724" alt="Screenshot 2025-04-23 at 2 19 59 AM" src="https://github.com/user-attachments/assets/40b27fb2-576d-4486-8272-555c57a5d6b7" />

Roles view and Role list page when multitenancy is disabled:
<img width="1728" alt="Screenshot 2025-04-23 at 2 21 20 AM" src="https://github.com/user-attachments/assets/ee6ed1df-a027-4f44-9254-508c1afc1646" />
<img width="1728" alt="Screenshot 2025-04-23 at 2 21 28 AM" src="https://github.com/user-attachments/assets/8e940b57-fb88-4391-ba83-cb13acaa956f" />

### Check List
- [x] New functionality includes testing 
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).