### PR TITLE
Changes to remove tenant panels from roles pages when multitenancy is disabled

### DIFF
--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -59,6 +59,7 @@ import { NameRow } from '../../utils/name-row';
 import { DataSourceContext } from '../../app-router';
 import { SecurityPluginTopNavMenu } from '../../top-nav-menu';
 import { PageHeader } from '../../header/header-components';
+import { getDashboardsInfoSafe } from '../../../../utils/dashboards-info-utils';
 
 interface RoleEditDeps extends BreadcrumbsPageDependencies {
   action: 'create' | 'edit' | 'duplicate';
@@ -144,6 +145,22 @@ export function RoleEdit(props: RoleEditDeps) {
 
     fetchTenantNames();
   }, [addToast, props.coreStart.http, dataSource]);
+
+  const [isMultiTenancyEnabled, setIsMultiTenancyEnabled] = useState(true);
+  React.useEffect(() => {
+    const fetchIsMultiTenancyEnabled = async () => {
+      try {
+        const dashboardsInfo = await getDashboardsInfoSafe(props.coreStart.http);
+        setIsMultiTenancyEnabled(
+          dashboardsInfo?.multitenancy_enabled && props.config.multitenancy.enabled
+        );
+      } catch (e) {
+        console.error(e);
+      }
+    };
+
+    fetchIsMultiTenancyEnabled();
+  }, [props.coreStart.http, props.config.multitenancy]);
 
   const updateRoleHandler = async () => {
     try {
@@ -309,12 +326,16 @@ export function RoleEdit(props: RoleEditDeps) {
         optionUniverse={indexWisePermissionOptions}
       />
       <EuiSpacer size="m" />
-      <TenantPanel
-        state={roleTenantPermission}
-        setState={setRoleTenantPermission}
-        optionUniverse={tenantOptions}
-      />
-      <EuiSpacer size="m" />
+      {isMultiTenancyEnabled && (
+        <>
+          <TenantPanel
+            state={roleTenantPermission}
+            setState={setRoleTenantPermission}
+            optionUniverse={tenantOptions}
+          />
+          <EuiSpacer size="m" />
+        </>
+      )}
       <EuiFlexGroup justifyContent="flexEnd">
         <EuiFlexItem grow={false}>
           <EuiSmallButton

--- a/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
@@ -147,129 +147,62 @@ describe('Role Create/Edit base on Multitenancy', () => {
   const mockDepsStart = { navigation: { ui: { HeaderControl: {} } } };
   const actions = ['create', 'edit'] as const;
   describe.each(actions)('when action is %s', (action) => {
-    it('should render tenants panel when multitenancy is enabled', async () => {
-      const mockConfig = {
-        multitenancy: {
-          enabled: true,
-        },
-      };
+    const testScenarios = [
+      {
+        description: 'When multitenancy is disabled in config and enabled in dashboards',
+        configEnabled: false,
+        dashboardsEnabled: true,
+        shouldRenderTenantPanel: false,
+      },
+      {
+        description: 'When multitenancy is disabled in both config and dashboards',
+        configEnabled: false,
+        dashboardsEnabled: false,
+        shouldRenderTenantPanel: false,
+      },
+      {
+        description: 'When multitenancy is enabled in config and disabled in dashboards',
+        configEnabled: true,
+        dashboardsEnabled: false,
+        shouldRenderTenantPanel: false,
+      },
+      {
+        description: 'When multitenancy is enabled in both config and dashboards',
+        configEnabled: true,
+        dashboardsEnabled: true,
+        shouldRenderTenantPanel: true,
+      },
+    ] as const;
 
-      const mockDashboardsInfo = {
-        multitenancy_enabled: true,
-      };
-      (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
-
-      let wrapper;
-      await act(async () => {
-        wrapper = mount(
-          <RoleEdit
-            action={action}
-            sourceRoleName={sampleSourceRole}
-            coreStart={mockCoreStart as any}
-            depsStart={mockDepsStart as any}
-            params={{} as any}
-            config={mockConfig as any}
-          />
-        );
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      wrapper.update();
-      expect(wrapper.find(TenantPanel).exists()).toBe(true);
+    beforeEach(() => {
+      jest.clearAllMocks();
     });
 
-    it('should not render tenants panel when multitenancy is disabled in config', async () => {
-      const mockConfig = {
-        multitenancy: {
-          enabled: false,
-        },
-      };
+    it.each(testScenarios)(
+      '$description → should render TenantPanel: $shouldRenderTenantPanel',
+      async function ({ configEnabled, dashboardsEnabled, shouldRenderTenantPanel }) {
+        const mockConfig = { multitenancy: { enabled: configEnabled } };
+        const mockDashboardsInfo = { multitenancy_enabled: dashboardsEnabled };
+        (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
 
-      const mockDashboardsInfo = {
-        multitenancy_enabled: true,
-      };
-      (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
-
-      let wrapper;
-      await act(async () => {
-        wrapper = mount(
-          <RoleEdit
-            action={action}
-            sourceRoleName={sampleSourceRole}
-            coreStart={mockCoreStart as any}
-            depsStart={mockDepsStart as any}
-            params={{} as any}
-            config={mockConfig as any}
-          />
-        );
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      wrapper.update();
-      expect(wrapper.find(TenantPanel).exists()).toBe(false);
-    });
-
-    it('should not render tenants panel when multitenancy is disabled in dashboards info', async () => {
-      const mockConfig = {
-        multitenancy: {
-          enabled: true,
-        },
-      };
-
-      const mockDashboardsInfo = {
-        multitenancy_enabled: false,
-      };
-      (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
-
-      let wrapper;
-      await act(async () => {
-        wrapper = mount(
-          <RoleEdit
-            action={action}
-            sourceRoleName={sampleSourceRole}
-            coreStart={mockCoreStart as any}
-            depsStart={mockDepsStart as any}
-            params={{} as any}
-            config={mockConfig as any}
-          />
-        );
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      wrapper.update();
-      expect(wrapper.find(TenantPanel).exists()).toBe(false);
-    });
-
-    it('should not render tenants panel when multitenancy is disabled in both config and dashboards info', async () => {
-      const mockConfig = {
-        multitenancy: {
-          enabled: false,
-        },
-      };
-
-      const mockDashboardsInfo = {
-        multitenancy_enabled: false,
-      };
-      (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
-
-      let wrapper;
-      await act(async () => {
-        wrapper = mount(
-          <RoleEdit
-            action={action}
-            sourceRoleName={sampleSourceRole}
-            coreStart={mockCoreStart as any}
-            depsStart={mockDepsStart as any}
-            params={{} as any}
-            config={mockConfig as any}
-          />
-        );
-        await new Promise((resolve) => setTimeout(resolve, 0));
-      });
-
-      wrapper.update();
-      expect(wrapper.find(TenantPanel).exists()).toBe(false);
-    });
+        let wrapper;
+        await act(async () => {
+          wrapper = mount(
+            <RoleEdit
+              action={action}
+              sourceRoleName={sampleSourceRole}
+              coreStart={mockCoreStart as any}
+              depsStart={mockDepsStart as any}
+              params={{} as any}
+              config={mockConfig as any}
+            />
+          );
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        });
+        wrapper.update();
+        expect(wrapper.find(TenantPanel).exists()).toBe(shouldRenderTenantPanel);
+      }
+    );
 
     it('should handle error when fetching dashboards info', async () => {
       (getDashboardsInfoSafe as jest.Mock).mockRejectedValue(new Error());

--- a/public/apps/configuration/panels/role-view/test/role-view.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/role-view.test.tsx
@@ -323,135 +323,69 @@ describe('RoleView base on Multitenancy', () => {
     },
   ];
 
+  const mockRoleTenantPermission = {
+    tenant_patterns: ['dummy'],
+    permissionType: TenantPermissionType.Read,
+  };
+
   beforeEach(() => {
     (transformRoleIndexPermissions as jest.Mock).mockResolvedValue(mockRoleIndexPermission);
-  });
-
-  it('should render tenants panel when multitenancy is enabled', async () => {
-    const mockConfig = {
-      multitenancy: {
-        enabled: true,
-      },
-    };
-
-    const mockDashboardsInfo = {
-      multitenancy_enabled: true,
-    };
-    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
-
-    const mockRoleTenantPermission = {
-      tenant_patterns: ['dummy'],
-      permissionType: TenantPermissionType.Read,
-    };
     (transformRoleTenantPermissions as jest.Mock).mockResolvedValue(mockRoleTenantPermission);
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mount(
-        <RoleView
-          roleName={sampleRole}
-          prevAction=""
-          coreStart={mockCoreStart}
-          depsStart={mockDepsStart as any}
-          params={{}}
-          config={mockConfig}
-        />
-      );
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    wrapper.update();
-    expect(wrapper.find(TenantsPanel).exists()).toBe(true);
   });
 
-  it('should not render tenants panel when multitenancy is disabled in config', async () => {
-    const mockConfig = {
-      multitenancy: {
-        enabled: false,
-      },
-    };
+  const testScenarios = [
+    {
+      description: 'When multitenancy is enabled in both config and dashboards',
+      configEnabled: true,
+      dashboardsEnabled: true,
+      shouldRenderTenantsPanel: true,
+    },
+    {
+      description: 'When multitenancy is disabled in config and enabled in dashboards',
+      configEnabled: false,
+      dashboardsEnabled: true,
+      shouldRenderTenantsPanel: false,
+    },
+    {
+      description: 'When multitenancy is disabled in both config and dashboards',
+      configEnabled: false,
+      dashboardsEnabled: false,
+      shouldRenderTenantsPanel: false,
+    },
+    {
+      description: 'When multitenancy is enabled in config and disabled in dashboards',
+      configEnabled: true,
+      dashboardsEnabled: false,
+      shouldRenderTenantsPanel: false,
+    },
+  ] as const;
 
-    const mockDashboardsInfo = {
-      multitenancy_enabled: true,
-    };
-    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
+  it.each(testScenarios)(
+    '$description → should render TenantsPanel: $shouldRenderTenantsPanel',
+    async function ({ configEnabled, dashboardsEnabled, shouldRenderTenantsPanel }) {
+      // arrange
+      const mockConfig = { multitenancy: { enabled: configEnabled } };
+      const mockDashboardsInfo = { multitenancy_enabled: dashboardsEnabled };
+      (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
 
-    let wrapper;
-    await act(async () => {
-      wrapper = mount(
-        <RoleView
-          roleName={sampleRole}
-          prevAction=""
-          coreStart={mockCoreStart}
-          depsStart={mockDepsStart as any}
-          params={{}}
-          config={mockConfig}
-        />
-      );
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    wrapper.update();
-    expect(wrapper.find(TenantsPanel).exists()).toBe(false);
-  });
-
-  it('should not render tenants panel when multitenancy is disabled in dashboards info', async () => {
-    const mockConfig = {
-      multitenancy: {
-        enabled: true,
-      },
-    };
-
-    const mockDashboardsInfo = {
-      multitenancy_enabled: false,
-    };
-    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mount(
-        <RoleView
-          roleName={sampleRole}
-          prevAction=""
-          coreStart={mockCoreStart}
-          depsStart={mockDepsStart as any}
-          params={{}}
-          config={mockConfig}
-        />
-      );
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    wrapper.update();
-    expect(wrapper.find(TenantsPanel).exists()).toBe(false);
-  });
-
-  it('should not render tenants panel when multitenancy is disabled in both config and dashboards info', async () => {
-    const mockConfig = {
-      multitenancy: {
-        enabled: false,
-      },
-    };
-
-    const mockDashboardsInfo = {
-      multitenancy_enabled: false,
-    };
-    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mount(
-        <RoleView
-          roleName={sampleRole}
-          prevAction=""
-          coreStart={mockCoreStart}
-          depsStart={mockDepsStart as any}
-          params={{}}
-          config={mockConfig}
-        />
-      );
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    wrapper.update();
-    expect(wrapper.find(TenantsPanel).exists()).toBe(false);
-  });
+      let wrapper;
+      await act(async () => {
+        wrapper = mount(
+          <RoleView
+            roleName={sampleRole}
+            prevAction=""
+            coreStart={mockCoreStart}
+            depsStart={mockDepsStart as any}
+            params={{}}
+            config={mockConfig}
+          />
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      wrapper.update();
+      expect(wrapper.find(TenantsPanel).exists()).toBe(shouldRenderTenantsPanel);
+    }
+  );
 
   it('should handle error when fetching dashboards info', async () => {
     (getDashboardsInfoSafe as jest.Mock).mockRejectedValue(new Error());

--- a/public/apps/configuration/panels/test/role-list.test.tsx
+++ b/public/apps/configuration/panels/test/role-list.test.tsx
@@ -74,145 +74,64 @@ describe('Role List based on MultiTenancy', () => {
   mockRoleListUtils.fetchRole = jest.fn().mockResolvedValue(mockRoleListingData);
   mockRoleListUtils.fetchRoleMapping = jest.fn().mockResolvedValue({});
 
-  it('render Tenants column when multitenancy is enabled', async () => {
-    const mockConfig = {
-      multitenancy: {
-        enabled: true,
-      },
-    };
+  const testScenarios = [
+    {
+      description: 'When multitenancy is enabled in both config and dashboards',
+      configEnabled: true,
+      dashboardsEnabled: true,
+      shouldRenderTenantsColumn: true,
+    },
+    {
+      description: 'When multitenancy is disabled in config and enabled in dashboards',
+      configEnabled: false,
+      dashboardsEnabled: true,
+      shouldRenderTenantsColumn: false,
+    },
+    {
+      description: 'When multitenancy is disabled in both config and dashboards',
+      configEnabled: false,
+      dashboardsEnabled: false,
+      shouldRenderTenantsColumn: false,
+    },
+    {
+      description: 'When multitenancy is enabled in config and disabled in dashboards',
+      configEnabled: true,
+      dashboardsEnabled: false,
+      shouldRenderTenantsColumn: false,
+    },
+  ] as const;
 
-    const mockDashboardsInfo = {
-      multitenancy_enabled: true,
-    };
-    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
+  it.each(testScenarios)(
+    '$description → should render Tenants column: $shouldRenderTenantsColumn',
+    async function ({ configEnabled, dashboardsEnabled, shouldRenderTenantsColumn }) {
+      const mockConfig = { multitenancy: { enabled: configEnabled } };
+      const mockDashboardsInfo = { multitenancy_enabled: dashboardsEnabled };
+      (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
 
-    let wrapper;
-    await act(async () => {
-      wrapper = mount(
-        <RoleList
-          coreStart={mockCoreStart}
-          depsStart={mockDepsStart as any}
-          params={{}}
-          config={mockConfig}
-        />
+      let wrapper;
+      await act(async () => {
+        wrapper = mount(
+          <RoleList
+            coreStart={mockCoreStart}
+            depsStart={mockDepsStart as any}
+            params={{}}
+            config={mockConfig}
+          />
+        );
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+      wrapper.update();
+      const roleListTable = wrapper.find('EuiInMemoryTable');
+      const columns = roleListTable.prop('columns');
+      expect(columns.some((column: any) => column.name === 'Tenants')).toBe(
+        shouldRenderTenantsColumn
       );
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    wrapper.update();
-    const roleListtable = wrapper.find('EuiInMemoryTable');
-    const columns = roleListtable.prop('columns');
-    expect(columns.some((column: any) => column.name === 'Tenants')).toBeTruthy();
-    const searchFilters = roleListtable.prop('search');
-    expect(
-      searchFilters.filters.some((searchFilter: any) => searchFilter.name === 'Tenants')
-    ).toBeTruthy();
-    expect(columns.some((column: any) => column.name === 'Tenants')).toBeTruthy();
-  });
-
-  it('does not render Tenants column when multitenancy is disabled in config', async () => {
-    const mockConfig = {
-      multitenancy: {
-        enabled: false,
-      },
-    };
-
-    const mockDashboardsInfo = {
-      multitenancy_enabled: true,
-    };
-    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mount(
-        <RoleList
-          coreStart={mockCoreStart}
-          depsStart={mockDepsStart as any}
-          params={{}}
-          config={mockConfig}
-        />
-      );
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    wrapper.update();
-    const roleListtable = wrapper.find('EuiInMemoryTable');
-    const columns = roleListtable.prop('columns');
-    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
-    const searchFilters = roleListtable.prop('search');
-    expect(
-      searchFilters.filters.some((searchFilter: any) => searchFilter.name === 'Tenants')
-    ).toBeFalsy();
-    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
-  });
-
-  it('does not render Tenants column when multitenancy is disabled in dashboards info', async () => {
-    const mockConfig = {
-      multitenancy: {
-        enabled: true,
-      },
-    };
-
-    const mockDashboardsInfo = {
-      multitenancy_enabled: false,
-    };
-    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mount(
-        <RoleList
-          coreStart={mockCoreStart}
-          depsStart={mockDepsStart as any}
-          params={{}}
-          config={mockConfig}
-        />
-      );
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    wrapper.update();
-    const roleListtable = wrapper.find('EuiInMemoryTable');
-    const columns = roleListtable.prop('columns');
-    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
-    const searchFilters = roleListtable.prop('search');
-    expect(
-      searchFilters.filters.some((searchFilter: any) => searchFilter.name === 'Tenants')
-    ).toBeFalsy();
-    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
-  });
-
-  it('does not render Tenants column when multitenancy is disabled in both config and dashboards info', async () => {
-    const mockConfig = {
-      multitenancy: {
-        enabled: false,
-      },
-    };
-
-    const mockDashboardsInfo = {
-      multitenancy_enabled: false,
-    };
-    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
-
-    let wrapper;
-    await act(async () => {
-      wrapper = mount(
-        <RoleList
-          coreStart={mockCoreStart}
-          depsStart={mockDepsStart as any}
-          params={{}}
-          config={mockConfig}
-        />
-      );
-      await new Promise((resolve) => setTimeout(resolve, 0));
-    });
-    wrapper.update();
-    const roleListtable = wrapper.find('EuiInMemoryTable');
-    const columns = roleListtable.prop('columns');
-    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
-    const searchFilters = roleListtable.prop('search');
-    expect(
-      searchFilters.filters.some((searchFilter: any) => searchFilter.name === 'Tenants')
-    ).toBeFalsy();
-    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
-  });
+      const searchFilters = roleListTable.prop('search');
+      expect(
+        searchFilters.filters.some((searchFilter: any) => searchFilter.name === 'Tenants')
+      ).toBe(shouldRenderTenantsColumn);
+    }
+  );
 
   it('should handle error when fetching dashboards info', async () => {
     (getDashboardsInfoSafe as jest.Mock).mockRejectedValue(new Error());

--- a/public/apps/configuration/panels/test/role-list.test.tsx
+++ b/public/apps/configuration/panels/test/role-list.test.tsx
@@ -22,12 +22,10 @@ import { Action } from '../../types';
 import { ResourceType } from '../../../../../common';
 import { RoleListing } from '../../utils/role-list-utils';
 import { useDeleteConfirmState } from '../../utils/delete-confirm-modal-utils';
+import { getDashboardsInfoSafe } from '../../../../utils/dashboards-info-utils';
+import { act } from 'react-dom/test-utils';
 
 jest.mock('../../utils/role-list-utils');
-jest.mock('../../utils/display-utils', () => ({
-  ...jest.requireActual('../../utils/display-utils'),
-  ExternalLink: jest.fn(),
-}));
 jest.mock('../../utils/context-menu', () => ({
   useContextMenuState: jest
     .fn()
@@ -40,9 +38,204 @@ jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useContext: jest.fn().mockReturnValue({ dataSource: { id: 'test' }, setDataSource: jest.fn() }), // Mock the useContext hook to return dummy datasource and setdatasource function
 }));
+jest.mock('../../../../utils/dashboards-info-utils');
 
 // eslint-disable-next-line
+const mockDisplayUtils = require('../../utils/display-utils');
+// eslint-disable-next-line
 const mockRoleListUtils = require('../../utils/role-list-utils');
+
+describe('Role List based on MultiTenancy', () => {
+  const mockCoreStart = {
+    http: 1,
+    uiSettings: {
+      get: jest.fn().mockReturnValue(false),
+    },
+    chrome: {
+      navGroup: { getNavGroupEnabled: jest.fn().mockReturnValue(false) },
+      setBreadcrumbs: jest.fn(),
+    },
+  };
+  const mockDepsStart = { navigation: { ui: { HeaderControl: {} } } };
+
+  const mockRoleListingData = [
+    {
+      roleName: 'role_1',
+      reserved: true,
+      clusterPermission: ['readonly'],
+      indexPermission: ['data1'],
+      tenantPermission: ['tenant1'],
+      internaluser: [],
+      backendRoles: [],
+    },
+  ];
+
+  mockRoleListUtils.transformRoleData = jest.fn().mockReturnValue(mockRoleListingData);
+  mockRoleListUtils.fetchRole = jest.fn().mockResolvedValue(mockRoleListingData);
+  mockRoleListUtils.fetchRoleMapping = jest.fn().mockResolvedValue({});
+
+  it('render Tenants column when multitenancy is enabled', async () => {
+    const mockConfig = {
+      multitenancy: {
+        enabled: true,
+      },
+    };
+
+    const mockDashboardsInfo = {
+      multitenancy_enabled: true,
+    };
+    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
+
+    let wrapper;
+    await act(async () => {
+      wrapper = mount(
+        <RoleList
+          coreStart={mockCoreStart}
+          depsStart={mockDepsStart as any}
+          params={{}}
+          config={mockConfig}
+        />
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    wrapper.update();
+    const roleListtable = wrapper.find('EuiInMemoryTable');
+    const columns = roleListtable.prop('columns');
+    expect(columns.some((column: any) => column.name === 'Tenants')).toBeTruthy();
+    const searchFilters = roleListtable.prop('search');
+    expect(
+      searchFilters.filters.some((searchFilter: any) => searchFilter.name === 'Tenants')
+    ).toBeTruthy();
+    expect(columns.some((column: any) => column.name === 'Tenants')).toBeTruthy();
+  });
+
+  it('does not render Tenants column when multitenancy is disabled in config', async () => {
+    const mockConfig = {
+      multitenancy: {
+        enabled: false,
+      },
+    };
+
+    const mockDashboardsInfo = {
+      multitenancy_enabled: true,
+    };
+    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
+
+    let wrapper;
+    await act(async () => {
+      wrapper = mount(
+        <RoleList
+          coreStart={mockCoreStart}
+          depsStart={mockDepsStart as any}
+          params={{}}
+          config={mockConfig}
+        />
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    wrapper.update();
+    const roleListtable = wrapper.find('EuiInMemoryTable');
+    const columns = roleListtable.prop('columns');
+    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
+    const searchFilters = roleListtable.prop('search');
+    expect(
+      searchFilters.filters.some((searchFilter: any) => searchFilter.name === 'Tenants')
+    ).toBeFalsy();
+    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
+  });
+
+  it('does not render Tenants column when multitenancy is disabled in dashboards info', async () => {
+    const mockConfig = {
+      multitenancy: {
+        enabled: true,
+      },
+    };
+
+    const mockDashboardsInfo = {
+      multitenancy_enabled: false,
+    };
+    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
+
+    let wrapper;
+    await act(async () => {
+      wrapper = mount(
+        <RoleList
+          coreStart={mockCoreStart}
+          depsStart={mockDepsStart as any}
+          params={{}}
+          config={mockConfig}
+        />
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    wrapper.update();
+    const roleListtable = wrapper.find('EuiInMemoryTable');
+    const columns = roleListtable.prop('columns');
+    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
+    const searchFilters = roleListtable.prop('search');
+    expect(
+      searchFilters.filters.some((searchFilter: any) => searchFilter.name === 'Tenants')
+    ).toBeFalsy();
+    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
+  });
+
+  it('does not render Tenants column when multitenancy is disabled in both config and dashboards info', async () => {
+    const mockConfig = {
+      multitenancy: {
+        enabled: false,
+      },
+    };
+
+    const mockDashboardsInfo = {
+      multitenancy_enabled: false,
+    };
+    (getDashboardsInfoSafe as jest.Mock).mockResolvedValue(mockDashboardsInfo);
+
+    let wrapper;
+    await act(async () => {
+      wrapper = mount(
+        <RoleList
+          coreStart={mockCoreStart}
+          depsStart={mockDepsStart as any}
+          params={{}}
+          config={mockConfig}
+        />
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    wrapper.update();
+    const roleListtable = wrapper.find('EuiInMemoryTable');
+    const columns = roleListtable.prop('columns');
+    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
+    const searchFilters = roleListtable.prop('search');
+    expect(
+      searchFilters.filters.some((searchFilter: any) => searchFilter.name === 'Tenants')
+    ).toBeFalsy();
+    expect(columns.some((column: any) => column.name === 'Tenants')).toBeFalsy();
+  });
+
+  it('should handle error when fetching dashboards info', async () => {
+    (getDashboardsInfoSafe as jest.Mock).mockRejectedValue(new Error());
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementationOnce(() => {});
+
+    let wrapper;
+    await act(async () => {
+      wrapper = mount(
+        <RoleList
+          coreStart={mockCoreStart}
+          depsStart={mockDepsStart as any}
+          params={{}}
+          config={{} as any}
+        />
+      );
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    wrapper.update();
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    consoleErrorSpy.mockRestore();
+  });
+});
 
 describe('Role list', () => {
   const setState = jest.fn();
@@ -277,6 +470,7 @@ describe('Role list', () => {
   describe('AccessError component', () => {
     let component;
     beforeEach(() => {
+      mockDisplayUtils.ExternalLink = jest.fn();
       jest.spyOn(React, 'useState').mockRestore();
       jest
         .spyOn(React, 'useState')


### PR DESCRIPTION
### Description
Changes to remove tenant panels from roles pages when multitenancy is disabled

### Category
Bug fix

### Why these changes are required?
Tenant Panel is not required on role view, edit, and list pages when multitenancy is disabled.

### What is the old behavior before changes and new behavior after changes?
Tenant Panel is present on role view, edit, and list pages when multitenancy is disabled.

### Issues Resolved
- [x] https://github.com/opensearch-project/security-dashboards-plugin/issues/2139

### Testing
- Added unit tests
- Completed manual testing
  - Case 1: When multitenancy is enabled [in config and from dashboards]: Tenant Panel is present on role view, create, edit, duplicate and list pages
  - Case 2: When multitenancy is disabled [ either from config or from dashboards]: Tenant Panel is not present on role view, create, edit, duplicate and list pages

Roles view and Role list page when multitenancy is enabled:
<img width="1727" alt="Screenshot 2025-04-23 at 2 19 34 AM" src="https://github.com/user-attachments/assets/b8362069-0198-45c1-8914-e8abd28d40dc" />
<img width="1724" alt="Screenshot 2025-04-23 at 2 19 59 AM" src="https://github.com/user-attachments/assets/40b27fb2-576d-4486-8272-555c57a5d6b7" />

Roles view and Role list page when multitenancy is disabled:
<img width="1728" alt="Screenshot 2025-04-23 at 2 21 20 AM" src="https://github.com/user-attachments/assets/ee6ed1df-a027-4f44-9254-508c1afc1646" />
<img width="1728" alt="Screenshot 2025-04-23 at 2 21 28 AM" src="https://github.com/user-attachments/assets/8e940b57-fb88-4391-ba83-cb13acaa956f" />

### Check List
- [x] New functionality includes testing 
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).