### PR TITLE
Explicitly cd to security-dashboards-plugin directory before running cypress tests

### DIFF
--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -106,5 +106,6 @@ runs:
         attempt_limit: 5
         attempt_delay: 2000
         command: |
+          cd ./OpenSearch-Dashboards/plugins/security-dashboards-plugin
           yarn add cypress --save-dev
           eval ${{ inputs.yarn_command }} 


### PR DESCRIPTION
### Description

Forward ports a change made on the version increment to 2.19.2.0 in the 2.19 branch to resolve an issue running cypress tests. Details here: https://github.com/opensearch-project/security-dashboards-plugin/pull/2208#issuecomment-2824235128

It was failing to find `tsconfigs.json` from `OpenSearch-Dashboards` and the solution is to explicitly switch directories to the security-dashboards-plugin directory before running the cypress tests.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Test fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).