### PR TITLE
Add cat shard api permission

### DIFF
--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -261,6 +261,7 @@ export const CLUSTER_PERMISSIONS: string[] = [
   'cluster:monitor/nodes/stats',
   'cluster:monitor/nodes/usage',
   'cluster:monitor/remote/info',
+  'cluster:monitor/shards',
   'cluster:monitor/state',
   'cluster:monitor/stats',
   'cluster:monitor/task',


### PR DESCRIPTION
### Description
With introduction of [CatShardsAction](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/admin/cluster/shards/CatShardsAction.java#L20), the _cat/shard call requires extra cluster permission cluster:monitor/shards for a non-admin user to call the API which was not required for versions prior to 2.17. 
Adding the new action to list of cluster permission that can be granted to a user.


### Category
 Bug fix

### Why these changes are required?
Add granular cluster:monitor/shards permission to list of cluster permission that can be granted to a user via opensearch dashboard.


### What is the old behavior before changes and new behavior after changes?
None. A wildcard permission cluster:monitor/* could be given to non-admin user to access _cat/shards API.


### Issues Resolved
N/A

### Testing
N/A

### Check List
- [N/A ] New functionality includes testing
- [N/A] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).