### PR TITLE
[Backport 2.19] Bump babel (#2200)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "braces": "^3.0.3",
     "body-parser": "^1.20.3",
     "micromatch": "^4.0.8",
-    "cross-spawn": "7.0.5"
+    "cross-spawn": "7.0.5",
+    "xml-crypto": "^2.1.6",
+    "@babel/runtime": "^7.27.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@
   resolved "https://registry.yarnpkg.com/@auth0/xmldom/-/xmldom-0.1.21.tgz#1db0a079c3ddc87bf9c13f35d9d4f0fb1dac3afc"
   integrity sha512-//QqjkvBknF7j0Nf205o5wgUMnq8ioHHxEr61OZQ3J0RXGFvs2rb5GLZ8jdNxMqYz4n/PEsbFIQL5RHBixxq5g==
 
-"@babel/runtime@^7.12.5":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.8.tgz#5d958c3827b13cc6d05e038c07fb2e5e3420d82e"
-  integrity sha512-5F7SDGs1T72ZczbRwbGO9lQi0NLjQxzl6i4lJxLxfW9U5UluCSyEJeniWvnhl3/euNiqQVbo8zruhsDfid0esA==
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.27.0":
+  version "7.27.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.0.tgz#fbee7cf97c709518ecc1f590984481d5460d4762"
+  integrity sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==
   dependencies:
     regenerator-runtime "^0.14.0"
 


### PR DESCRIPTION
Signed-off-by: Derek Ho <dxho@amazon.com>
(cherry picked from commit 5d890b920b6655cdcb71fe12bc89e967831c0f12)

Backport https://github.com/opensearch-project/security-dashboards-plugin/pull/2200 to 2.19.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).