### PR TITLE
Changes to prevent page reload on entering invalid current password and   to disable reset button when current or new password is empty

### DIFF
--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -34,7 +34,7 @@ import { FormRow } from '../configuration/utils/form-row';
 import { logout, updateNewPassword } from './utils';
 import { PASSWORD_INSTRUCTION } from '../apps-constants';
 import { constructErrorMessageAndLog } from '../error-utils';
-import { validateCurrentPassword } from '../../utils/login-utils';
+import { validateCurrentPassword } from '../../utils/password-reset-panel-utils';
 import { getDashboardsInfo } from '../../utils/dashboards-info-utils';
 import { PasswordStrengthBar } from '../configuration/utils/password-strength-bar';
 
@@ -85,7 +85,8 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
       await validateCurrentPassword(http, props.username, currentPassword);
     } catch (e) {
       setIsCurrentPasswordInvalid(true);
-      setCurrentPasswordError([constructErrorMessageAndLog(e, 'Invalid current password.')]);
+      setCurrentPasswordError([`Invalid current password. ${e.message}`]);
+      return;
     }
 
     // update new password

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -34,7 +34,10 @@ import { FormRow } from '../configuration/utils/form-row';
 import { logout, updateNewPassword } from './utils';
 import { PASSWORD_INSTRUCTION } from '../apps-constants';
 import { constructErrorMessageAndLog } from '../error-utils';
-import { validateCurrentPassword } from '../../utils/password-reset-panel-utils';
+import {
+  isResetButtonDisabled,
+  validateCurrentPassword,
+} from '../../utils/password-reset-panel-utils';
 import { getDashboardsInfo } from '../../utils/dashboards-info-utils';
 import { PasswordStrengthBar } from '../configuration/utils/password-strength-bar';
 
@@ -185,7 +188,11 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
           <EuiSmallButton
             data-test-subj="reset"
             fill
-            disabled={isRepeatNewPasswordInvalid}
+            disabled={isResetButtonDisabled(
+              currentPassword,
+              newPassword,
+              isRepeatNewPasswordInvalid
+            )}
             onClick={handleReset}
           >
             Reset

--- a/public/apps/account/test/password-reset-panel.test.tsx
+++ b/public/apps/account/test/password-reset-panel.test.tsx
@@ -15,7 +15,7 @@
 
 import { shallow } from 'enzyme';
 import React from 'react';
-import { validateCurrentPassword } from '../../../utils/login-utils';
+import { validateCurrentPassword } from '../../../utils/password-reset-panel-utils';
 import { PasswordResetPanel } from '../password-reset-panel';
 import { logout, updateNewPassword } from '../utils';
 
@@ -24,7 +24,7 @@ jest.mock('../utils', () => ({
   updateNewPassword: jest.fn(),
 }));
 
-jest.mock('../../../utils/login-utils', () => ({
+jest.mock('../../../utils/password-reset-panel-utils', () => ({
   validateCurrentPassword: jest.fn(),
 }));
 
@@ -71,7 +71,7 @@ describe('Account menu - Password reset panel', () => {
 
   it('invalid current password', (done) => {
     (validateCurrentPassword as jest.Mock).mockImplementationOnce(() => {
-      throw new Error();
+      throw new Error('Unauthorized');
     });
 
     // Hide the error message
@@ -79,7 +79,8 @@ describe('Account menu - Password reset panel', () => {
 
     component.find('[data-test-subj="reset"]').simulate('click');
     process.nextTick(() => {
-      expect(setState).toHaveBeenCalledWith(true);
+      expect(setState).toHaveBeenNthCalledWith(1, true);
+      expect(setState).toHaveBeenNthCalledWith(2, ['Invalid current password. Unauthorized']);
       expect(setState).toBeTruthy();
       done();
     });

--- a/public/apps/account/test/password-reset-panel.test.tsx
+++ b/public/apps/account/test/password-reset-panel.test.tsx
@@ -25,6 +25,7 @@ jest.mock('../utils', () => ({
 }));
 
 jest.mock('../../../utils/password-reset-panel-utils', () => ({
+  isResetButtonDisabled: jest.fn(),
   validateCurrentPassword: jest.fn(),
 }));
 

--- a/public/utils/password-reset-panel-utils.tsx
+++ b/public/utils/password-reset-panel-utils.tsx
@@ -36,3 +36,11 @@ export async function validateCurrentPassword(
     throw new Error(data.message);
   }
 }
+
+export function isResetButtonDisabled(
+  currentPassword: string,
+  newPassword: string,
+  isRepeatNewPasswordInvalid: boolean
+): boolean {
+  return !currentPassword || !newPassword || isRepeatNewPasswordInvalid;
+}

--- a/public/utils/password-reset-panel-utils.tsx
+++ b/public/utils/password-reset-panel-utils.tsx
@@ -1,0 +1,38 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { HttpStart } from 'opensearch-dashboards/public';
+
+export async function validateCurrentPassword(
+  http: HttpStart,
+  userName: string,
+  currentPassword: string
+) {
+  const url = http.basePath.prepend('/auth/login');
+  const res = await fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    headers: {
+      'Content-Type': 'application/json',
+      'osd-xsrf': 'true',
+    },
+    body: JSON.stringify({ username: userName, password: currentPassword }),
+  });
+
+  if (!res.ok) {
+    const data = await res.json();
+    throw new Error(data.message);
+  }
+}

--- a/public/utils/test/password-reset-panel-utils.test.ts
+++ b/public/utils/test/password-reset-panel-utils.test.ts
@@ -1,0 +1,64 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { validateCurrentPassword } from '../password-reset-panel-utils';
+import { HttpStart } from 'opensearch-dashboards/public';
+
+describe('Test Password Reset Panel Utlis', () => {
+  const mockUrl = 'http://localhost:5601/auth/login';
+  let http: HttpStart;
+  beforeEach(() => {
+    http = {
+      basePath: {
+        prepend: jest.fn(() => mockUrl),
+      },
+    } as any;
+    global.fetch = jest.fn();
+  });
+
+  it('validate current password resolves when the server returns 2xx', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+    });
+
+    await expect(validateCurrentPassword(http, 'user', 'password')).resolves.toBeUndefined();
+
+    expect(global.fetch).toHaveBeenCalledWith(
+      mockUrl,
+      expect.objectContaining({
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'osd-xsrf': 'true',
+        },
+        body: JSON.stringify({ username: 'user', password: 'password' }),
+      })
+    );
+  });
+
+  it('validate current password rejects with the server message on 4xx', async () => {
+    const serverBody = { message: 'Unauthorized' };
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: jest.fn().mockResolvedValue(serverBody),
+      status: 401,
+    });
+
+    await expect(validateCurrentPassword(http, 'user', 'incorrectpassword')).rejects.toThrow(
+      'Unauthorized'
+    );
+  });
+});

--- a/public/utils/test/password-reset-panel-utils.test.ts
+++ b/public/utils/test/password-reset-panel-utils.test.ts
@@ -13,7 +13,7 @@
  *   permissions and limitations under the License.
  */
 
-import { validateCurrentPassword } from '../password-reset-panel-utils';
+import { isResetButtonDisabled, validateCurrentPassword } from '../password-reset-panel-utils';
 import { HttpStart } from 'opensearch-dashboards/public';
 
 describe('Test Password Reset Panel Utlis', () => {
@@ -60,5 +60,55 @@ describe('Test Password Reset Panel Utlis', () => {
     await expect(validateCurrentPassword(http, 'user', 'incorrectpassword')).rejects.toThrow(
       'Unauthorized'
     );
+  });
+});
+
+describe('Validates password reset button state based on input conditions', () => {
+  const testScenarios = [
+    {
+      description: 'should be disabled when currentPassword is empty',
+      currentPassword: '',
+      newPassword: 'newpass',
+      isRepeatNewPasswordInvalid: false,
+      expected: true,
+    },
+    {
+      description: 'should be disabled when newPassword is empty',
+      currentPassword: 'current',
+      newPassword: '',
+      isRepeatNewPasswordInvalid: false,
+      expected: true,
+    },
+    {
+      description: 'should be disabled when isRepeatNewPasswordInvalid is true',
+      currentPassword: 'current',
+      newPassword: 'newpass',
+      isRepeatNewPasswordInvalid: true,
+      expected: true,
+    },
+    {
+      description: 'should be enabled when all conditions are valid',
+      currentPassword: 'current',
+      newPassword: 'newpass',
+      isRepeatNewPasswordInvalid: false,
+      expected: false,
+    },
+    {
+      description: 'should be disabled when all fields are invalid',
+      currentPassword: '',
+      newPassword: '',
+      isRepeatNewPasswordInvalid: true,
+      expected: true,
+    },
+  ] as const;
+
+  it.each(testScenarios)('$description', async function ({
+    currentPassword,
+    newPassword,
+    isRepeatNewPasswordInvalid,
+    expected,
+  }) {
+    const result = isResetButtonDisabled(currentPassword, newPassword, isRepeatNewPasswordInvalid);
+    expect(result).toBe(expected);
   });
 });


### PR DESCRIPTION
### Description
- Changes to disable reset button when current or new password is empty
- Changes to prevent page reload on invalid current password validation during reset password

Notes: This function is used currently to validate current password: https://github.com/nishthm/security-dashboards-plugin/blob/main/public/utils/login-utils.tsx#L19 which is causing the issue. Using the actual login endpoint (/auth/login) might triggers browser authentication behavior
through the normal HTTP client, a 401 Unauthorized will trigger the built-in auth‐interceptor—which assumes session has expired and does a full page reload. So when validateCurrentPassword gets a bad password back (401), the client reloads dashboards page.

### Category
Bug fix

### Why these changes are required?
- The Reset password button should be disabled if the user doesn't input any password (current or new)
- The application should not reload the page and should display the error in the form If the current password validation fails

### What is the old behavior before changes and new behavior after changes?
- User can click on reset button without entering current or new password
- The application reloads the page when a user enters invalid current password during reset the password

### Issues Resolved
- [x] https://github.com/opensearch-project/security-dashboards-plugin/issues/2189

### Testing
- Added unit tests
- Completed manual testing
  - Case 1: The Reset button is disabled if user does not enter current or new password
<img width="778" alt="Screenshot 2025-05-02 at 9 24 34 PM" src="https://github.com/user-attachments/assets/b5d32f58-87eb-413d-9091-fff70bdd49af" />
<img width="779" alt="Screenshot 2025-05-02 at 9 24 44 PM" src="https://github.com/user-attachments/assets/3927e631-a160-490d-a55b-51888fa63b37" />
<img width="778" alt="Screenshot 2025-05-02 at 9 24 58 PM" src="https://github.com/user-attachments/assets/1b80ec4f-8b20-448b-894d-84c08b3ee68d" />
<img width="776" alt="Screenshot 2025-05-02 at 9 25 10 PM" src="https://github.com/user-attachments/assets/0b35c43f-9eb2-4c6b-899a-57c92998e93c" />
  - Case 2: The application does not reload the page when a user enters invalid current password during reset the password and shows error
<img width="774" alt="Screenshot 2025-05-02 at 9 25 18 PM" src="https://github.com/user-attachments/assets/1564784d-ca71-40ea-b6e0-e4257b3d71bf" />

### Check List
- [x] New functionality includes testing 
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).