### PR TITLE
Get OPENSEARCH_VERSION from upstream package.json file

### DIFF
--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -1,9 +1,6 @@
 name: Run Cypress Tests
 description: 'Runs Cypress tests for the security-dashboards-plugin with opensearch_dashboards.yml and security configuration provided'
 
-env:
-  OPENSEARCH_VERSION: '3.1.0'
-
 inputs:
   security_config_file:
     description: 'Name of the security plugin config file'
@@ -24,7 +21,9 @@ runs:
   steps:
     - name: Set env
       run: |
+        opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
         plugin_version=$(node -p "require('./package.json').version")
+        echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
         echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
       shell: bash
 

--- a/.github/workflows/cypress-test-multiauth-e2e.yml
+++ b/.github/workflows/cypress-test-multiauth-e2e.yml
@@ -3,7 +3,6 @@ name: Snapshot based E2E SAML multi-auth tests workflow
 on: [ push, pull_request ]
 
 env:
-  OPENSEARCH_VERSION: '3.1.0'
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
@@ -23,6 +22,14 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
+
+      - name: Set env
+        run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
+          plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
+          echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+        shell: bash
       
       # Add SAML Configuration
       - name: Injecting SAML Configuration for Linux

--- a/.github/workflows/cypress-test-multidatasources-disabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-disabled-e2e.yml
@@ -3,7 +3,6 @@ name: E2E multi datasources disabled workflow
 on: [ push, pull_request ]
 
 env:
-  OPENSEARCH_VERSION: '3.1.0'
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
@@ -22,6 +21,14 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
+
+      - name: Set env
+        run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
+          plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
+          echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+        shell: bash
 
       # Configure the Dashboard for multi datasources disabled (default)
       - name: Create OpenSearch Dashboards Config

--- a/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
@@ -3,7 +3,6 @@ name: E2E multi datasources enabled workflow
 on: [ push, pull_request ]
 
 env:
-  OPENSEARCH_VERSION: '3.1.0'
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
@@ -25,7 +24,9 @@ jobs:
 
       - name: Set env
         run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
           plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
           echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash
 

--- a/.github/workflows/cypress-test-oidc-e2e.yml
+++ b/.github/workflows/cypress-test-oidc-e2e.yml
@@ -3,7 +3,6 @@ name: Snapshot based E2E OIDC tests workflow
 on: [ push, pull_request ]
 
 env:
-  OPENSEARCH_VERSION: '3.1.0'
   KEYCLOAK_VERSION: '21.0.1'
   TEST_KEYCLOAK_CLIENT_SECRET: 'oacHfNaXyy81r2uHq1A9RY4ASryre4rZ'
   CI: 1
@@ -27,6 +26,14 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
+
+      - name: Set env
+        run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
+          plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
+          echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+        shell: bash
 
       # Download and Check Keycloak Version
       - name: Download and Check Keyloak Version on Linux

--- a/.github/workflows/cypress-test-saml-e2e.yml
+++ b/.github/workflows/cypress-test-saml-e2e.yml
@@ -3,7 +3,6 @@ name: Snapshot based E2E SAML tests workflow
 on: [ push, pull_request ]
 
 env:
-  OPENSEARCH_VERSION: '3.1.0'
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
@@ -23,6 +22,14 @@ jobs:
     steps:
       - name: Checkout Branch
         uses: actions/checkout@v3
+
+      - name: Set env
+        run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
+          plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
+          echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
+        shell: bash
       
       # Add SAML Configuration
       - name: Create SAML Configuration for Linux

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -11,7 +11,6 @@ env:
   SPEC: 'cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js,'
   PLUGIN_NAME: opensearch-security
   OPENSEARCH_INITIAL_ADMIN_PASSWORD: myStrongPassword123!
-  OPENSEARCH_VERSION: '3.1.0'
 
 jobs:
   cypress-tests-multitenancy-disabled:
@@ -28,7 +27,9 @@ jobs:
 
       - name: Set env
         run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
           plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
           echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash
 

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -12,7 +12,6 @@ env:
   PLUGIN_NAME: opensearch-security
   OPENSEARCH_INITIAL_ADMIN_PASSWORD: myStrongPassword123!
   CYPRESS_NO_COMMAND_LOG: 1
-  OPENSEARCH_VERSION: '3.1.0'
 
 jobs:
   cypress-tests:
@@ -29,7 +28,9 @@ jobs:
 
       - name: Set env
         run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
           plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
           echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -7,7 +7,6 @@ env:
   CI: 1
   PLUGIN_NAME: opensearch-security
   OPENSEARCH_INITIAL_ADMIN_PASSWORD: myStrongPassword123!
-  OPENSEARCH_VERSION: '3.1.0'
 
 jobs:
   tests:
@@ -24,7 +23,9 @@ jobs:
 
       - name: Set env
         run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
           plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
           echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash
 

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -2,7 +2,6 @@ name: 'Install Dashboards with Plugin via Binary'
 
 on: [push, pull_request]
 env:
-  OPENSEARCH_VERSION: '3.1.0'
   CI: 1
   # avoid warnings like "tput: No value for $TERM and no -T specified"
   TERM: xterm
@@ -24,7 +23,9 @@ jobs:
 
       - name: Set env
         run: |
+          opensearch_version=$(node -p "require('./package.json').opensearchDashboards.version")
           plugin_version=$(node -p "require('./package.json').version")
+          echo "OPENSEARCH_VERSION=$opensearch_version" >> $GITHUB_ENV
           echo "PLUGIN_VERSION=$plugin_version" >> $GITHUB_ENV
         shell: bash
 


### PR DESCRIPTION
### Description

This PR undoes some of the changes from https://github.com/opensearch-project/security-dashboards-plugin/pull/2190 to get this version centrally from opensearch-dashboard's package.json file.

This PR resolves an issue seen on version increment PRs where the automation is not getting these hardcoded instances of the version.

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).