### PR TITLE
Added required index permissioms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 - Changes to prevent page reload on entering invalid current password and to disable reset button when current or new password is empty ([#2238](https://github.com/opensearch-project/security-dashboards-plugin/pull/2238))
+- Added missing index permissions in the list ([#1969](https://github.com/opensearch-project/security-dashboards-plugin/issues/1969))
 
 ### Dependencies
 - Bump dev dependencies to resolve CVE-2024-52798 ([#2231](https://github.com/opensearch-project/security-dashboards-plugin/pull/2231))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 ### Changed
-<<<<<<< mainline_1969
-- Changes to prevent page reload on entering invalid current password and to disable reset button when current or new password is empty ([#2238](https://github.com/opensearch-project/security-dashboards-plugin/pull/2238))
 - Added missing index permissions in the list ([#1969](https://github.com/opensearch-project/security-dashboards-plugin/issues/1969))
-=======
-
->>>>>>> main
 
 ### Dependencies
 - Bump `actions/checkout` from 2 to 4 ([#2260](https://github.com/opensearch-project/security-dashboards-plugin/pull/2260))

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -367,6 +367,8 @@ export const INDEX_PERMISSIONS: string[] = [
   'indices:data/read/field_caps',
   'indices:data/read/field_caps*',
   'indices:data/read/get',
+  'indices:data/read/mget*',
+  'indices:data/read/mtv*',
   'indices:data/read/point_in_time/create',
   'indices:data/read/point_in_time/delete',
   'indices:data/read/point_in_time/readall',
@@ -374,6 +376,7 @@ export const INDEX_PERMISSIONS: string[] = [
   'indices:data/read/search*',
   'indices:data/read/search/template',
   'indices:data/read/tv',
+  'indices:data/write/bulk*',
   'indices:data/write/delete',
   'indices:data/write/delete/byquery',
   'indices:data/write/index',
@@ -388,9 +391,6 @@ export const INDEX_PERMISSIONS: string[] = [
   'indices:monitor/stats',
   'indices:monitor/upgrade',
   'system:admin/system_index',
-  'indices:data/read/mget*',
-  'indices:data/read/mtv*',
-  'indices:data/write/bulk*',
 ];
 
 export function includeIndexPermissions(indexPermissionsToInclude: string[]) {

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -388,15 +388,8 @@ export const INDEX_PERMISSIONS: string[] = [
   'indices:monitor/stats',
   'indices:monitor/upgrade',
   'system:admin/system_index',
-  'indices:data/read/scroll',
-  'indices:data/read/scroll/clear',
   'indices:data/read/mget*',
-  'indices:data/read/msearch',
-  'indices:data/read/msearch/template',
-  'indices:data/read/mtv',
   'indices:data/read/mtv*',
-  'indices:data/read/search/template/render',
-  'indices:data/write/bulk',
   'indices:data/write/bulk*',
 ];
 

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -388,6 +388,16 @@ export const INDEX_PERMISSIONS: string[] = [
   'indices:monitor/stats',
   'indices:monitor/upgrade',
   'system:admin/system_index',
+  'indices:data/read/scroll',
+  'indices:data/read/scroll/clear',
+  'indices:data/read/mget*',
+  'indices:data/read/msearch',
+  'indices:data/read/msearch/template',
+  'indices:data/read/mtv',
+  'indices:data/read/mtv*',
+  'indices:data/read/search/template/render',
+  'indices:data/write/bulk',
+  'indices:data/write/bulk*',
 ];
 
 export function includeIndexPermissions(indexPermissionsToInclude: string[]) {


### PR DESCRIPTION
### Description
Added required index permissioms

### Category
[Bug fix]

### Why these changes are required?
The required index permissions are missing from the list
```
"indices:data/read/scroll"
"indices:data/read/scroll/clear"
"indices:data/read/mget*"
"indices:data/read/msearch"
"indices:data/read/msearch/template"
"indices:data/read/mtv"
"indices:data/read/mtv*"
"indices:data/read/search/template/render"
"indices:data/write/bulk*"
"indices:data/write/bulk"
```

### What is the old behavior before changes and new behavior after changes?
All these permissions are now available in index permissions list.

### Issues Resolved
- [x] https://github.com/opensearch-project/security-dashboards-plugin/issues/1969

### Testing
- Completed Manual Testing
<img width="1728" alt="Screenshot 2025-06-11 at 2 06 59 AM" src="https://github.com/user-attachments/assets/6a5da944-1829-4bac-b312-c3c027eacb44" />


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).