### PR TITLE
Increase cypress verify timeout to 60s

### DIFF
--- a/.github/workflows/cypress-test-multiauth-e2e.yml
+++ b/.github/workflows/cypress-test-multiauth-e2e.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           security_config_file: config_multiauth.yml
           dashboards_config_file: opensearch_dashboards_multiauth.yml
-          yarn_command: 'yarn cypress:run --browser chrome --headless --env loginMethod=saml_multiauth,basePath=${{ matrix.basePath }} --spec "test/cypress/e2e/saml/*.js"'
+          yarn_command: 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --env loginMethod=saml_multiauth,basePath=${{ matrix.basePath }} --spec "test/cypress/e2e/saml/*.js"'
           osd_base_path: ${{ matrix.basePath }}
 
       - name: Run Cypress Tests
@@ -118,4 +118,4 @@ jobs:
         with:
           security_config_file: config_multiauth.yml
           dashboards_config_file: opensearch_dashboards_multiauth.yml
-          yarn_command: 'yarn cypress:run --browser chrome --headless --env loginMethod=saml_multiauth --spec "test/cypress/e2e/saml/*.js"'
+          yarn_command: 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --env loginMethod=saml_multiauth --spec "test/cypress/e2e/saml/*.js"'

--- a/.github/workflows/cypress-test-multidatasources-disabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-disabled-e2e.yml
@@ -53,4 +53,4 @@ jobs:
         uses: ./.github/actions/run-cypress-tests
         with:
           dashboards_config_file: opensearch_dashboards_multidatasources.yml
-          yarn_command: 'yarn cypress:run --browser chrome --headless --env LOGIN_AS_ADMIN=true --spec "test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js"'
+          yarn_command: 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --env LOGIN_AS_ADMIN=true --spec "test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js"'

--- a/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
@@ -106,4 +106,4 @@ jobs:
         uses: ./.github/actions/run-cypress-tests
         with:
           dashboards_config_file: opensearch_dashboards_multidatasources.yml
-          yarn_command: 'yarn cypress:run --browser chrome --headless --env LOGIN_AS_ADMIN=true --spec "test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js"'
+          yarn_command: 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --env LOGIN_AS_ADMIN=true --spec "test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js"'

--- a/.github/workflows/cypress-test-oidc-e2e.yml
+++ b/.github/workflows/cypress-test-oidc-e2e.yml
@@ -154,7 +154,7 @@ jobs:
         with:
           security_config_file: config_openid.yml
           dashboards_config_file: opensearch_dashboards_openid.yml
-          yarn_command: 'yarn cypress:run --browser chrome --headless --spec "test/cypress/e2e/oidc/*.js" --env basePath=${{ matrix.basePath }}'
+          yarn_command: 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --spec "test/cypress/e2e/oidc/*.js" --env basePath=${{ matrix.basePath }}'
           osd_base_path: ${{ matrix.basePath }}
 
       - name: Run Cypress Tests
@@ -163,4 +163,4 @@ jobs:
         with:
           security_config_file: config_openid.yml
           dashboards_config_file: opensearch_dashboards_openid.yml
-          yarn_command: 'yarn cypress:run --browser chrome --headless --spec "test/cypress/e2e/oidc/*.js"'
+          yarn_command: 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --spec "test/cypress/e2e/oidc/*.js"'

--- a/.github/workflows/cypress-test-saml-e2e.yml
+++ b/.github/workflows/cypress-test-saml-e2e.yml
@@ -109,7 +109,7 @@ jobs:
         with:
           security_config_file: config_saml.yml
           dashboards_config_file: opensearch_dashboards_saml.yml
-          yarn_command: 'yarn cypress:run --browser chrome --headless --spec "test/cypress/e2e/saml/*.js" --env basePath=${{ matrix.basePath }}'
+          yarn_command: 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --spec "test/cypress/e2e/saml/*.js" --env basePath=${{ matrix.basePath }}'
           osd_base_path: ${{ matrix.basePath }}
 
       - name: Run Cypress Tests
@@ -118,4 +118,4 @@ jobs:
         with:
           security_config_file: config_saml.yml
           dashboards_config_file: opensearch_dashboards_saml.yml
-          yarn_command: 'yarn cypress:run --browser chrome --headless --spec "test/cypress/e2e/saml/*.js"'
+          yarn_command: 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --spec "test/cypress/e2e/saml/*.js"'

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -79,4 +79,4 @@ jobs:
           git clone https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
           cd opensearch-dashboards-functional-test
           npm install cypress --save-dev
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/inaccessible_tenancy_features.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/inaccessible_tenancy_features.js"

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -82,18 +82,18 @@ jobs:
           git clone https://github.com/opensearch-project/opensearch-dashboards-functional-test.git
           cd opensearch-dashboards-functional-test
           npm install cypress --save-dev
-          yarn cypress:run-with-security-and-aggregation-view --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js"
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js"
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/default_tenant.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security-and-aggregation-view --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/aggregation_view.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/multi_tenancy.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security-dashboards-plugin/default_tenant.js"
 
       - name: Configure and Run OpenSearch Dashboards with Cypress Test Cases Release Tests
         run: |
           cd ./OpenSearch-Dashboards
           cd opensearch-dashboards-functional-test
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/audit_log_spec.js"
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/auth_spec.js"
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/get_started_spec.js"
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/internalusers_spec.js"
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/permissions_spec.js"
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/roles_spec.js"
-          yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/tenants_spec.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/audit_log_spec.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/auth_spec.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/get_started_spec.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/internalusers_spec.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/permissions_spec.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/roles_spec.js"
+          CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run-with-security --browser chrome --spec "cypress/integration/plugins/security/tenants_spec.js"


### PR DESCRIPTION
### Description

Fixes the cypress verify errors seen in CI runs like https://github.com/opensearch-project/security-dashboards-plugin/actions/runs/15593291155/job/43917469898?pr=2259

References:

- https://stackoverflow.com/questions/63667880/cypress-verification-timed-out-after-30000-milliseconds
- https://docs.cypress.io/app/references/command-line#cypress-verify

Failure

```
[STARTED] Task without title.
[FAILED] Cypress verification timed out.
[FAILED] 
[FAILED] This command failed with the following output:
[FAILED] 
[FAILED] /home/runner/.cache/Cypress/9.5.4/Cypress/Cypress --no-sandbox --smoke-test --ping=66
[FAILED] 
[FAILED] ----------
[FAILED] 
Cypress verification timed out.

This command failed with the following output:

/home/runner/.cache/Cypress/9.5.4/Cypress/Cypress --no-sandbox --smoke-test --ping=66

[FAILED] Command timed out after 30000 milliseconds: /home/runner/.cache/Cypress/9.5.4/Cypress/Cypress --no-sandbox --smoke-test --ping=66
----------
[FAILED] Timed out

[FAILED] 
Command timed out after 30000 milliseconds: /home/runner/.cache/Cypress/9.5.4/Cypress/Cypress --no-sandbox --smoke-test --ping=66
[FAILED] ----------
Timed out
[FAILED] 

[FAILED] Platform: linux-x64 (Ubuntu - 24.04)
----------
[FAILED] Cypress Version: 9.5.4
```

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Test fix

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).