### PR TITLE
Add labels to dependabot prs that upgrade github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependabot"
+      - "dependencies"


### PR DESCRIPTION
### Description

Add labels to dependabot prs that upgrade github actions

### Issues Resolved

Resolves an issue that prevents the `dependabot_pr.yml` workflow to run and add a changelog entry for this category of dependabot updates.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).