### PR TITLE
Updates changelog structure to adhere to opensearch release-notes guideline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,28 +4,35 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to the [Semantic Versioning](https://semver.org/spec/v2.0.0.html). See the [CONTRIBUTING guide](./CONTRIBUTING.md#Changelog) for instructions on how to add changelog entries.
 
 ## [Unreleased 3.x]
-### Added
+
+### Features
 
 
-### Changed
-- Changes to show all index patterns in index permission panel in role view ([#1303](https://github.com/opensearch-project/security-dashboards-plugin/issues/1303),[#1891](https://github.com/opensearch-project/security-dashboards-plugin/issues/1891))
-- Added missing index permissions in the list ([#1969](https://github.com/opensearch-project/security-dashboards-plugin/issues/1969))
+### Enhancements
 
-### Dependencies
-- Bump `actions/checkout` from 2 to 4 ([#2260](https://github.com/opensearch-project/security-dashboards-plugin/pull/2260))
-- Bump `codecov/codecov-action` from 4 to 5 ([#2263](https://github.com/opensearch-project/security-dashboards-plugin/pull/2263))
-- Bump `SvanBoxel/delete-merged-branch` from b77e873cee00b09f55cc553bd24aae5f8dfc9157 to 2b5b058e3db41a3328fd9a6a58fd4c2545a14353 ([#2265](https://github.com/opensearch-project/security-dashboards-plugin/pull/2265))
-- Bump `actions/github-script` from 6 to 7 ([#2259](https://github.com/opensearch-project/security-dashboards-plugin/pull/2259))
-- Bump `tibdex/github-app-token` from 1.5.0 to 2.1.0 ([#2262](https://github.com/opensearch-project/security-dashboards-plugin/pull/2262))
-- Bump `stefanzweifel/git-auto-commit-action` from 5 to 6 ([#2268](https://github.com/opensearch-project/security-dashboards-plugin/pull/2268))
-- Bump `derek-ho/start-opensearch` from 6 to 7 ([#2267](https://github.com/opensearch-project/security-dashboards-plugin/pull/2267))
+* Changes to show all index patterns in index permission panel in role view ([#1303](https://github.com/opensearch-project/security-dashboards-plugin/issues/1303),[#1891](https://github.com/opensearch-project/security-dashboards-plugin/issues/1891))
+* Added missing index permissions in the list ([#1969](https://github.com/opensearch-project/security-dashboards-plugin/issues/1969))
 
-### Deprecated
 
-### Removed
+### Bug Fixes
 
-### Fixed
 
-### Security
+### Refactoring
 
-[Unreleased 3.x]: https://github.com/opensearch-project/security-dashboards-plugin/compare/3.0...main
+
+### Maintenance
+
+* Bump `actions/checkout` from 2 to 4 ([#2260](https://github.com/opensearch-project/security-dashboards-plugin/pull/2260))
+* Bump `codecov/codecov-action` from 4 to 5 ([#2263](https://github.com/opensearch-project/security-dashboards-plugin/pull/2263))
+* Bump `SvanBoxel/delete-merged-branch` from b77e873cee00b09f55cc553bd24aae5f8dfc9157 to 2b5b058e3db41a3328fd9a6a58fd4c2545a14353 ([#2265](https://github.com/opensearch-project/security-dashboards-plugin/pull/2265))
+* Bump `actions/github-script` from 6 to 7 ([#2259](https://github.com/opensearch-project/security-dashboards-plugin/pull/2259))
+* Bump `tibdex/github-app-token` from 1.5.0 to 2.1.0 ([#2262](https://github.com/opensearch-project/security-dashboards-plugin/pull/2262))
+* Bump `stefanzweifel/git-auto-commit-action` from 5 to 6 ([#2268](https://github.com/opensearch-project/security-dashboards-plugin/pull/2268))
+* Bump `derek-ho/start-opensearch` from 6 to 7 ([#2267](https://github.com/opensearch-project/security-dashboards-plugin/pull/2267))
+
+
+### Documentation
+
+
+
+[Unreleased 3.x]: https://github.com/opensearch-project/security-dashboards-plugin/compare/3.1...main


### PR DESCRIPTION
Updates changelog layout to be in-line with the guideline stated here:
https://github.com/opensearch-project/opensearch-plugins/blob/main/RELEASE_NOTES.md

### Check List

- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).