### PR TITLE
Update account nav button style when nav group home enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Changes to show all index patterns in index permission panel in role view ([#1303](https://github.com/opensearch-project/security-dashboards-plugin/issues/1303),[#1891](https://github.com/opensearch-project/security-dashboards-plugin/issues/1891))
 * Added missing index permissions in the list ([#1969](https://github.com/opensearch-project/security-dashboards-plugin/issues/1969))
+* Update account nav button style when nav group home enabled ([#2279](https://github.com/opensearch-project/security-dashboards-plugin/issues/2279))
 
 
 ### Bug Fixes

--- a/public/apps/account/account-nav-button.scss
+++ b/public/apps/account/account-nav-button.scss
@@ -1,9 +1,0 @@
-/*
- * Copyright OpenSearch Contributors
- * SPDX-License-Identifier: Apache-2.0
- */
-
-// stylelint-disable-next-line @osd/stylelint/no_modifying_global_selectors
-.euiButtonEmpty.accountNavButton {
-  border: 0;
-}

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -176,7 +176,7 @@ export function AccountNavButton(props: {
   const innerElement = isPlacedInLeftNav ? (
     <LeftBottomActionButton
       title={username}
-      icon={<EuiAvatar name={username} size="s" />}
+      icon={<EuiAvatar name={`${username}${username}`} size="s" />}
       isNavDrawerLocked$={props.coreStart.chrome.getIsNavDrawerLocked$()}
       isChromeVisible$={props.coreStart.chrome.getIsVisible$()}
     />
@@ -198,8 +198,10 @@ export function AccountNavButton(props: {
         onClick={() => {
           setPopoverOpen((prevState) => !prevState);
         }}
-        // Add buffer 2 to avoid popover move to top center of anchor
-        {...(isPlacedInLeftNav ? { anchorPosition: 'rightDown', buffer: 2 } : {})}
+        // Use buffer 0 to avoid popover move to top center of anchor
+        {...(isPlacedInLeftNav
+          ? { anchorPosition: 'rightDown', buffer: 0, repositionOnScroll: true }
+          : {})}
       >
         <EuiContextMenuPanel>{contextMenuPanel}</EuiContextMenuPanel>
       </EuiPopover>

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -176,7 +176,7 @@ export function AccountNavButton(props: {
   const innerElement = isPlacedInLeftNav ? (
     <LeftBottomActionButton
       title={username}
-      icon={<EuiAvatar name={`${username}${username}`} size="s" />}
+      icon={<EuiAvatar name={username} size="s" />}
       isNavDrawerLocked$={props.coreStart.chrome.getIsNavDrawerLocked$()}
       isChromeVisible$={props.coreStart.chrome.getIsVisible$()}
     />

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -37,7 +37,6 @@ import { resolveTenantName } from '../configuration/utils/tenant-utils';
 import { getShouldShowTenantPopup, setShouldShowTenantPopup } from '../../utils/storage-utils';
 import { getDashboardsInfo } from '../../utils/dashboards-info-utils';
 import { LeftBottomActionButton } from '../../../../../src/core/public';
-import './account-nav-button.scss';
 
 export function AccountNavButton(props: {
   coreStart: CoreStart;

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -36,6 +36,7 @@ import { LogoutButton } from './log-out-button';
 import { resolveTenantName } from '../configuration/utils/tenant-utils';
 import { getShouldShowTenantPopup, setShouldShowTenantPopup } from '../../utils/storage-utils';
 import { getDashboardsInfo } from '../../utils/dashboards-info-utils';
+import { LeftBottomActionButton } from '../../../../../src/core/public';
 import './account-nav-button.scss';
 
 export function AccountNavButton(props: {
@@ -173,15 +174,12 @@ export function AccountNavButton(props: {
 
   // ToDo: Add aria-label and tooltip when isPlacedInLeftNav is true
   const innerElement = isPlacedInLeftNav ? (
-    <EuiButtonEmpty
-      size="xs"
-      flush="both"
-      className="accountNavButton"
-      aria-expanded={isPopoverOpen}
-      aria-haspopup="true"
-    >
-      <EuiAvatar name={username} size="s" />
-    </EuiButtonEmpty>
+    <LeftBottomActionButton
+      title={username}
+      icon={<EuiAvatar name={username} size="s" />}
+      isNavDrawerLocked$={props.coreStart.chrome.getIsNavDrawerLocked$()}
+      isChromeVisible$={props.coreStart.chrome.getIsVisible$()}
+    />
   ) : (
     <EuiAvatar name={username} size="m" />
   );
@@ -191,7 +189,6 @@ export function AccountNavButton(props: {
       <EuiPopover
         data-test-subj="account-popover"
         id="actionsMenu"
-        anchorPosition={isPlacedInLeftNav ? 'rightDown' : undefined}
         button={innerElement}
         isOpen={isPopoverOpen}
         closePopover={() => {
@@ -201,6 +198,8 @@ export function AccountNavButton(props: {
         onClick={() => {
           setPopoverOpen((prevState) => !prevState);
         }}
+        // Add buffer 2 to avoid popover move to top center of anchor
+        {...(isPlacedInLeftNav ? { anchorPosition: 'rightDown', buffer: 2 } : {})}
       >
         <EuiContextMenuPanel>{contextMenuPanel}</EuiContextMenuPanel>
       </EuiPopover>


### PR DESCRIPTION
### Description
Update account nav button style when nav group home enabled, the new look & feel should like screenshot below:
<img width="274" height="205" alt="image" src="https://github.com/user-attachments/assets/2b38d9a8-c08f-4b3a-b581-5bcea79f3fff" />
<img width="485" height="187" alt="image" src="https://github.com/user-attachments/assets/d28a06b1-f53c-4445-8c2a-c599a553bfd7" />



### Category
Enhancement

### Why these changes are required?
The [OSD PR](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10132) refactor the left navigation footer and target to released in opensearch 3.2.0. The account nav button UI should be update according the newest design.

### What is the old behavior before changes and new behavior after changes?
Only UI changes, the old behavior like below:
<img width="395" height="237" alt="image" src="https://github.com/user-attachments/assets/e6b1a3e4-7b4f-4e9b-9da4-3fbf8d0e06b6" />


### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).