### PR TITLE
[2.19] Specify cypress version in run-cypress-tests action to v13 for node compatibility

### DIFF
--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -110,5 +110,5 @@ runs:
         attempt_delay: 2000
         command: |
           cd OpenSearch-Dashboards/plugins/security-dashboards-plugin
-          yarn add cypress --save-dev
+          yarn add cypress@13 --save-dev
           eval ${{ inputs.yarn_command }} 


### PR DESCRIPTION
### Description

Specify cypress version in run-cypress-tests action to v13 for node compatibility

### Category
[Enhancement, New feature, Bug fix, Test fix, Refactoring, Maintenance, Documentation]

Maintenance

### Issues Resolved

Resolves error seen on https://github.com/opensearch-project/security-dashboards-plugin/actions/runs/17978381267/job/51137498114?pr=2310

```
yarn add v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
error cypress@15.3.0: The engine "node" is incompatible with this module. Expected version "^20.1.0 || ^22.0.0 || >=24.0.0". Got "18.19.0"
error Found incompatible module.
```

Seen during version increment to 2.19.4.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).