### PR TITLE
[2.19] Fix build by downloading security zip from s3 instead of central.sonatype

### DIFF
--- a/.github/actions/download-plugin/action.yml
+++ b/.github/actions/download-plugin/action.yml
@@ -23,7 +23,7 @@ runs:
   steps:
     - run: |
         mvn dependency:get \
-        -DremoteRepositories=https://central.sonatype.com/repository/maven-snapshots/ \
+        -DremoteRepositories=https://ci.opensearch.org/ci/dbc/snapshots/maven/ \
         -Dartifact=org.opensearch.plugin:${{ inputs.plugin-name }}:${{ inputs.plugin-version }}-SNAPSHOT:zip \
         -Dtransitive=false
         cp ~/.m2/repository/org/opensearch/plugin/${{ inputs.plugin-name }}/${{ inputs.plugin-version }}-SNAPSHOT/${{ inputs.plugin-name }}-${{ inputs.plugin-version }}-SNAPSHOT.zip ${{ inputs.download-location }}.zip


### PR DESCRIPTION
### Description

Backporting this fix from https://github.com/opensearch-project/security-dashboards-plugin/pull/2343

### Category

Maintenance

### Issues Resolved

Resolves https://github.com/opensearch-project/security-dashboards-plugin/issues/2375

Unblocks https://github.com/opensearch-project/security-dashboards-plugin/pull/2373

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).