### PR TITLE
[Backport 2.19] Force resolution of basic-ftp to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "pbkdf2": "^3.1.3",
     "crypto-browserify": "^3.12.1",
     "cipher-base": "^1.0.7",
-    "sha.js": "^2.4.5"
+    "sha.js": "^2.4.5",
+    "basic-ftp": "^5.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -725,10 +725,10 @@ basic-auth@~2.0.1:
   dependencies:
     safe-buffer "5.1.2"
 
-basic-ftp@^5.0.2:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.0.5.tgz#14a474f5fffecca1f4f406f1c26b18f800225ac0"
-  integrity sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==
+basic-ftp@^5.0.2, basic-ftp@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.2.0.tgz#7c2dff63c918bde60e6bad1f2ff93dcf5137a40a"
+  integrity sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
### Description

Backport https://github.com/opensearch-project/security-dashboards-plugin/pull/2374 to 2.19

### Category

Maintenance

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).