### PR TITLE
Use `preferred_tenants` from dashboardinfo when resolving tenant

### DIFF
--- a/public/types.ts
+++ b/public/types.ts
@@ -54,6 +54,7 @@ export interface AuthInfo {
 export interface DashboardsInfo {
   multitenancy_enabled?: boolean;
   private_tenant_enabled?: boolean;
+  preferred_tenants?: string[];
   default_tenant: string;
   password_validation_error_message: string;
   resource_sharing_enabled?: boolean;

--- a/server/auth/types/authentication_type.test.ts
+++ b/server/auth/types/authentication_type.test.ts
@@ -17,6 +17,7 @@ import { SecurityPluginConfigType } from '../..';
 import { AuthenticationType } from './authentication_type';
 import { httpServerMock } from '../../../../../src/core/server/mocks';
 import { OpenSearchDashboardsRequest } from '../../../../../src/core/server';
+import * as tenantResolver from '../../multitenancy/tenant_resolver';
 
 class DummyAuthType extends AuthenticationType {
   authNotRequired(request: OpenSearchDashboardsRequest): boolean {
@@ -163,5 +164,124 @@ describe('test capabilities request authinfo', () => {
     };
     const result = await dummyAuthType.authHandler(request, response, toolkit);
     expect(result.state.authInfo.username).toEqual('capabilities-username');
+  });
+});
+
+describe('resolveTenant preferred_tenants precedence', () => {
+  const config = {
+    multitenancy: {
+      enabled: true,
+      tenants: {
+        preferred: ['Private', 'Global'],
+      },
+    },
+    auth: {
+      unauthenticated_routes: [] as string[],
+    },
+    session: {
+      keepalive: false,
+      ttl: 1000,
+    },
+    readonly_mode: {
+      roles: [],
+    },
+  } as SecurityPluginConfigType;
+
+  const sessionStorageFactory = {
+    asScoped: jest.fn(() => ({
+      clear: jest.fn(),
+      get: jest.fn().mockResolvedValue({}),
+      set: jest.fn(),
+    })),
+  };
+
+  const router = jest.fn();
+  const esClient = {
+    asScoped: jest.fn().mockImplementation(() => ({
+      callAsCurrentUser: jest.fn(),
+    })),
+  };
+  const coreSetup = jest.fn();
+  const logger = {
+    error: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('prefers dynamic preferred_tenants from dashboardsinfo', async () => {
+    const dummyAuthType = new DummyAuthType(
+      config,
+      sessionStorageFactory,
+      router,
+      esClient as any,
+      coreSetup as any,
+      logger as any
+    );
+
+    const resolveSpy = jest.spyOn(tenantResolver, 'resolveTenant').mockReturnValue('__user__');
+
+    jest.spyOn((dummyAuthType as any).securityClient, 'dashboardsinfo').mockResolvedValue({
+      multitenancy_enabled: true,
+      private_tenant_enabled: true,
+      default_tenant: '',
+      preferred_tenants: ['tenant1', 'tenant2'],
+    });
+
+    const request = httpServerMock.createOpenSearchDashboardsRequest({ path: '/app/home' });
+
+    await AuthenticationType.prototype.resolveTenant.call(
+      dummyAuthType,
+      request,
+      { tenant: undefined } as any,
+      {},
+      {
+        user_name: 'testuser',
+        roles: ['all_access'],
+        tenants: { global_tenant: true, testuser: true },
+      }
+    );
+
+    expect(resolveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ preferredTenants: ['tenant1', 'tenant2'] })
+    );
+  });
+
+  it('falls back to config preferred tenants when dashboardsinfo field is missing', async () => {
+    const dummyAuthType = new DummyAuthType(
+      config,
+      sessionStorageFactory,
+      router,
+      esClient as any,
+      coreSetup as any,
+      logger as any
+    );
+
+    const resolveSpy = jest.spyOn(tenantResolver, 'resolveTenant').mockReturnValue('__user__');
+
+    jest.spyOn((dummyAuthType as any).securityClient, 'dashboardsinfo').mockResolvedValue({
+      multitenancy_enabled: true,
+      private_tenant_enabled: true,
+      default_tenant: '',
+    });
+
+    const request = httpServerMock.createOpenSearchDashboardsRequest({ path: '/app/home' });
+
+    await AuthenticationType.prototype.resolveTenant.call(
+      dummyAuthType,
+      request,
+      { tenant: undefined } as any,
+      {},
+      {
+        user_name: 'testuser',
+        roles: ['all_access'],
+        tenants: { global_tenant: true, testuser: true },
+      }
+    );
+
+    expect(resolveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ preferredTenants: ['Private', 'Global'] })
+    );
   });
 });

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -272,6 +272,8 @@ export abstract class AuthenticationType implements IAuthenticationType {
       multitenancyEnabled: dashboardsInfo.multitenancy_enabled,
       privateTenantEnabled: dashboardsInfo.private_tenant_enabled,
       defaultTenant: dashboardsInfo.default_tenant,
+      preferredTenants:
+        dashboardsInfo.preferred_tenants ?? this.config.multitenancy?.tenants.preferred,
     });
   }
 

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -140,6 +140,7 @@ export class BasicAuthRoutes {
             multitenancyEnabled: user.multitenancy_enabled,
             privateTenantEnabled: user.private_tenant_enabled,
             defaultTenant: user.default_tenant,
+            preferredTenants: user.preferred_tenants ?? this.config.multitenancy?.tenants.preferred,
           });
           // const selectTenant = user.default_tenant;
           sessionStorage.tenant = selectTenant;
@@ -230,6 +231,8 @@ export class BasicAuthRoutes {
               multitenancyEnabled: user.multitenancy_enabled,
               privateTenantEnabled: user.private_tenant_enabled,
               defaultTenant: user.default_tenant,
+              preferredTenants:
+                user.preferred_tenants ?? this.config.multitenancy?.tenants.preferred,
             });
             sessionStorage.tenant = selectTenant;
           }

--- a/server/auth/user.ts
+++ b/server/auth/user.ts
@@ -24,4 +24,5 @@ export interface User {
   multitenancy_enabled?: boolean;
   private_tenant_enabled?: boolean;
   default_tenant?: string;
+  preferred_tenants?: string[];
 }

--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -51,6 +51,7 @@ export function resolveTenant({
   multitenancyEnabled,
   privateTenantEnabled,
   defaultTenant,
+  preferredTenants,
 }: {
   request: any;
   username: string;
@@ -61,6 +62,7 @@ export function resolveTenant({
   multitenancyEnabled: boolean;
   privateTenantEnabled: boolean | undefined;
   defaultTenant: string | undefined;
+  preferredTenants: string[] | undefined;
 }): string | undefined {
   const DEFAULT_READONLY_ROLES = ['kibana_read_only'];
   let selectedTenant: string | undefined;
@@ -89,7 +91,6 @@ export function resolveTenant({
     (role) => config.readonly_mode?.roles.includes(role) || DEFAULT_READONLY_ROLES.includes(role)
   );
 
-  const preferredTenants = config.multitenancy?.tenants.preferred;
   const globalTenantEnabled = config.multitenancy?.tenants.enable_global;
 
   return resolve(


### PR DESCRIPTION
### Description
Related PR - https://github.com/opensearch-project/security/pull/5986
This PR resolves `preferred_tenants` from the DashboardInfo API; if unavailable, it falls back to the config file. This enabes dynamic configuration of `preferred_tenants`

### Category
Enhancement

### Why these changes are required?
This PR resolves `preferred_tenants` from the DashboardInfo API; if unavailable, it falls back to the config file. This enabes dynamic configuration of `preferred_tenants`

### What is the old behavior before changes and new behavior after changes?
preferred_tenants are read from config file, and requires a restart to configure this property.

### Issues Resolved
Resolves https://github.com/opensearch-project/security/issues/5969  (from opensearch-project/security)

### Testing
I have performed manual testing and added unit tests.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).