### PR TITLE
Return checkHasApiPermission as a method that can be used by other dashboards-plugins

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -459,7 +459,9 @@ export class SecurityPlugin
     }
 
     // Return methods that should be available to other plugins
-    return {};
+    return {
+      checkHasApiPermission: async () => hasApiPermission(core),
+    };
   }
 
   public start(core: CoreStart, deps: SecurityPluginStartDependencies): SecurityPluginStart {

--- a/public/types.ts
+++ b/public/types.ts
@@ -22,8 +22,9 @@ import { ManagementOverViewPluginSetup } from '../../../src/plugins/management_o
 import { DataSourcePluginStart } from '../../../src/plugins/data_source/public/types';
 import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_source_management/public';
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SecurityPluginSetup {}
+export interface SecurityPluginSetup {
+  checkHasApiPermission: () => Promise<boolean | undefined>;
+}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SecurityPluginStart {}
 


### PR DESCRIPTION
### Description

Companion OSD core PR: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11620

Example usage in a dashboards-plugin (in this case reporting): https://github.com/cwperks/dashboards-reporting/pull/2

This PR returns checkHasApiPermission from security-dashboards-plugin for use by other dashboards plugins to conditionally hide/reveal from the main menu. The intended consumer of this is a new [dashboards-job-scheduler plugin](https://github.com/opensearch-project/.github/issues/393).

### Category

Enhancement

### Issues Resolved

Related to https://github.com/opensearch-project/security/issues/5635, but limited in scope to hiding/revealing a menu item only if the logged in user is a security admin.

### Testing

See companion PRs:

1. Login as admin and see all menu items
2. Login as non-admin (i.e. readall:readall) and verify the menu items do not appear for plugins that use the updater and should only be displayed for admins

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).