### PR TITLE
Allow readonly users to access opensearch_dashboards_overview

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -90,7 +90,13 @@ const APP_ID_HOME = 'home';
 const APP_ID_DASHBOARDS = 'dashboards';
 // OpenSearchDashboards app is for legacy url migration
 const APP_ID_OPENSEARCH_DASHBOARDS = 'kibana';
-const APP_LIST_FOR_READONLY_ROLE = [APP_ID_HOME, APP_ID_DASHBOARDS, APP_ID_OPENSEARCH_DASHBOARDS];
+const APP_ID_OVERVIEW = 'opensearch_dashboards_overview';
+const APP_LIST_FOR_READONLY_ROLE = [
+  APP_ID_HOME,
+  APP_ID_DASHBOARDS,
+  APP_ID_OPENSEARCH_DASHBOARDS,
+  APP_ID_OVERVIEW,
+];
 
 const dataAccessUsersCategory: AppCategory & { group?: AppCategory } = {
   id: 'dataAccessAndUsers',


### PR DESCRIPTION
### Description

The readonly app allowlist did not include opensearch_dashboards_overview, so the home page's "Visualize & analyze" button (which targets that app) produced an "Application not found" error for readonly users. This allows read only users to access opensearch_dashboards_overview

### Category

Bug fix

### Why these changes are required?

The Visualize & analyze button is prominent, and users are drawn to it. They could try to use it to access Dashboards, but they are currently shown an "Application not found" error. 


### What is the old behavior before changes and new behavior after changes?

Read-only users couldn't access the visualize and analyze app. Now they can. 

### Issues Resolved

Fixes #2414

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).