### PR TITLE
Use opensearch-build setup actions

### DIFF
--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -52,7 +52,7 @@ runs:
 
     # OSD bootstrap
     - name: Run Dashboard with Security Dashboards Plugin
-      uses: derek-ho/setup-opensearch-dashboards@f64b331c58fe5b0a6533e76da1b46cb9d11bcaef # v1
+      uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
       with:
         plugin_name: security-dashboards-plugin
         opensearch_dashboards_yml: ${{ inputs.dashboards_config_file }}
@@ -108,11 +108,21 @@ runs:
       shell: bash
 
     - name: Run Cypress Tests with retry
-      uses: Wandalen/wretry.action@5b5bc4a583aa96930143361439d69bbe672a4a7d # v3.3.0
-      with:
-        attempt_limit: 5
-        attempt_delay: 2000
-        command: |
-          cd ./OpenSearch-Dashboards/plugins/security-dashboards-plugin
-          yarn add cypress --save-dev
-          eval ${{ inputs.yarn_command }} 
+      run: |
+        cd ./OpenSearch-Dashboards/plugins/security-dashboards-plugin
+        yarn add cypress --save-dev
+
+        for attempt in {1..5}; do
+          echo "Running Cypress attempt ${attempt}/5."
+          if eval ${{ inputs.yarn_command }}; then
+            exit 0
+          fi
+
+          if [ "${attempt}" -eq 5 ]; then
+            echo "Cypress failed after ${attempt} attempts."
+            exit 1
+          fi
+
+          sleep 2
+        done
+      shell: bash

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -40,7 +40,7 @@ runs:
         download-location: ${{ env.PLUGIN_NAME }}
     
     - name: Run Opensearch with A Single Plugin
-      uses: derek-ho/start-opensearch@v9
+      uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@58029ed0db12929e8e920eb875925335583f9490
       with:
         opensearch-version: ${{ env.OPENSEARCH_VERSION }}
         plugins: "file:$(pwd)/opensearch-security.zip"
@@ -52,7 +52,7 @@ runs:
 
     # OSD bootstrap
     - name: Run Dashboard with Security Dashboards Plugin
-      uses: derek-ho/setup-opensearch-dashboards@v1
+      uses: derek-ho/setup-opensearch-dashboards@f64b331c58fe5b0a6533e76da1b46cb9d11bcaef # v1
       with:
         plugin_name: security-dashboards-plugin
         opensearch_dashboards_yml: ${{ inputs.dashboards_config_file }}
@@ -108,7 +108,7 @@ runs:
       shell: bash
 
     - name: Run Cypress Tests with retry
-      uses: Wandalen/wretry.action@v3.3.0
+      uses: Wandalen/wretry.action@5b5bc4a583aa96930143361439d69bbe672a4a7d # v3.3.0
       with:
         attempt_limit: 5
         attempt_delay: 2000

--- a/.github/actions/run-cypress-tests/action.yml
+++ b/.github/actions/run-cypress-tests/action.yml
@@ -52,7 +52,7 @@ runs:
 
     # OSD bootstrap
     - name: Run Dashboard with Security Dashboards Plugin
-      uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+      uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
       with:
         plugin_name: security-dashboards-plugin
         opensearch_dashboards_yml: ${{ inputs.dashboards_config_file }}

--- a/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
@@ -66,7 +66,7 @@ jobs:
           download-location: ${{env.PLUGIN_NAME}}
       
       - name: Run Opensearch with A Single Plugin
-        uses: derek-ho/start-opensearch@d686795cd945a1cd702ab4237227045300505e09 # v10
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@58029ed0db12929e8e920eb875925335583f9490
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/opensearch-security.zip"

--- a/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
@@ -78,7 +78,7 @@ jobs:
 
 
       - name: Run Opensearch with security + sample resource plugin
-        uses: derek-ho/start-opensearch@d686795cd945a1cd702ab4237227045300505e09 # v10
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@58029ed0db12929e8e920eb875925335583f9490
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/opensearch-security.zip,file:${{ env.SAMPLE_PLUGIN_ZIP }}"

--- a/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
@@ -94,7 +94,7 @@ jobs:
 
       # OSD bootstrap
       - name: Setup Dashboard with Security Dashboards Plugin
-        uses: derek-ho/setup-opensearch-dashboards@623a4c478a9075486bb1db7eaffa7046524992a4 # v3
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
         with:
           plugin_name: security-dashboards-plugin
 
@@ -170,12 +170,21 @@ jobs:
 
 
       - name: Run Cypress Tests with retry
-        uses: Wandalen/wretry.action@e68c23e6309f2871ca8ae4763e7629b9c258e1ea # v3.8.0
-        with:
-          attempt_limit: 5
-          attempt_delay: 2000
-          command: |
-            cd ./OpenSearch-Dashboards/plugins/security-dashboards-plugin
-            yarn add cypress --save-dev
-            eval 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --env LOGIN_AS_ADMIN=true --spec "test/cypress/e2e/resource-sharing/resource_access_management.spec.js"' 
+        run: |
+          cd ./OpenSearch-Dashboards/plugins/security-dashboards-plugin
+          yarn add cypress --save-dev
 
+          for attempt in {1..5}; do
+            echo "Running Cypress attempt ${attempt}/5."
+            if CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --env LOGIN_AS_ADMIN=true --spec "test/cypress/e2e/resource-sharing/resource_access_management.spec.js"; then
+              exit 0
+            fi
+
+            if [ "${attempt}" -eq 5 ]; then
+              echo "Cypress failed after ${attempt} attempts."
+              exit 1
+            fi
+
+            sleep 2
+          done
+        shell: bash

--- a/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
@@ -94,7 +94,7 @@ jobs:
 
       # OSD bootstrap
       - name: Setup Dashboard with Security Dashboards Plugin
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
           plugin_name: security-dashboards-plugin
 

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -66,7 +66,7 @@ jobs:
           EOT
 
       - name: Run Dashboard with Security Dashboards Plugin
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
           plugin_name: security-dashboards-plugin
           opensearch_dashboards_yml: tenancy-disabled-opensearch-dashboards-config.yml

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -42,7 +42,7 @@ jobs:
           download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@d686795cd945a1cd702ab4237227045300505e09 # v10
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@58029ed0db12929e8e920eb875925335583f9490
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"

--- a/.github/workflows/cypress-test-tenancy-disabled.yml
+++ b/.github/workflows/cypress-test-tenancy-disabled.yml
@@ -66,7 +66,7 @@ jobs:
           EOT
 
       - name: Run Dashboard with Security Dashboards Plugin
-        uses: derek-ho/setup-opensearch-dashboards@623a4c478a9075486bb1db7eaffa7046524992a4 # v3
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
         with:
           plugin_name: security-dashboards-plugin
           opensearch_dashboards_yml: tenancy-disabled-opensearch-dashboards-config.yml

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -43,7 +43,7 @@ jobs:
           download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@d686795cd945a1cd702ab4237227045300505e09 # v10
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@58029ed0db12929e8e920eb875925335583f9490
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -69,7 +69,7 @@ jobs:
           EOT
 
       - name: Run Dashboard with Security Dashboards Plugin
-        uses: derek-ho/setup-opensearch-dashboards@623a4c478a9075486bb1db7eaffa7046524992a4 # v3
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
         with:
           plugin_name: security-dashboards-plugin
           opensearch_dashboards_yml: cypress-opensearch-dashboards-config.yml

--- a/.github/workflows/cypress-test.yml
+++ b/.github/workflows/cypress-test.yml
@@ -69,7 +69,7 @@ jobs:
           EOT
 
       - name: Run Dashboard with Security Dashboards Plugin
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
           plugin_name: security-dashboards-plugin
           opensearch_dashboards_yml: cypress-opensearch-dashboards-config.yml

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -105,7 +105,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - id: install-dashboards
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
           plugin_name: security-dashboards-plugin
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -105,7 +105,7 @@ jobs:
           sudo rm -rf "$AGENT_TOOLSDIRECTORY"
 
       - id: install-dashboards
-        uses: derek-ho/setup-opensearch-dashboards@623a4c478a9075486bb1db7eaffa7046524992a4 # v3
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
         with:
           plugin_name: security-dashboards-plugin
 

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -71,7 +71,7 @@ jobs:
 
       
       - name: Run OpenSearch with A Single Plugin Remote Cluster
-        uses: derek-ho/start-opensearch@d686795cd945a1cd702ab4237227045300505e09 # v10
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@58029ed0db12929e8e920eb875925335583f9490
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: ${{ env.REMOTE_PLUGIN_URI }}
@@ -88,7 +88,7 @@ jobs:
         shell: bash
   
       - name: Run OpenSearch with security
-        uses: derek-ho/start-opensearch@d686795cd945a1cd702ab4237227045300505e09 # v10
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@58029ed0db12929e8e920eb875925335583f9490
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: ${{ env.PLUGIN_URI }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - id: install-dashboards
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
            plugin_name: security-dashboards-plugin
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - id: install-dashboards
-        uses: derek-ho/setup-opensearch-dashboards@623a4c478a9075486bb1db7eaffa7046524992a4 # v3
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
         with:
            plugin_name: security-dashboards-plugin
 

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run Dashboard with Security Dashboards Plugin
         id: setup-dashboards
-        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@72a7a8a167ed06d83ba65b4d9f60acd08232cd56
         with:
           plugin_name: security-dashboards-plugin
           built_plugin_name: security-dashboards

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Run Dashboard with Security Dashboards Plugin
         id: setup-dashboards
-        uses: derek-ho/setup-opensearch-dashboards@623a4c478a9075486bb1db7eaffa7046524992a4 # v3
+        uses: opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d
         with:
           plugin_name: security-dashboards-plugin
           built_plugin_name: security-dashboards
@@ -84,4 +84,3 @@ jobs:
         run: |
           timeout 300 bash -c 'while [[ "$(curl -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} -k http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
         shell: bash
-

--- a/.github/workflows/verify-binary-installation.yml
+++ b/.github/workflows/verify-binary-installation.yml
@@ -38,7 +38,7 @@ jobs:
           download-location: ${{ env.PLUGIN_NAME }}
 
       - name: Run Opensearch with security
-        uses: derek-ho/start-opensearch@d686795cd945a1cd702ab4237227045300505e09 # v10
+        uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@58029ed0db12929e8e920eb875925335583f9490
         with:
           opensearch-version: ${{ env.OPENSEARCH_VERSION }}
           plugins: "file:$(pwd)/${{ env.PLUGIN_NAME }}.zip"


### PR DESCRIPTION
## Description

Replaces active workflow usage of externally maintained OpenSearch/OpenSearch Dashboards setup actions with OpenSearch-owned composite actions from `opensearch-build`.

OpenSearch startup now uses:

`opensearch-project/opensearch-build/.github/actions/start-opensearch@58029ed0db12929e8e920eb875925335583f9490`

OpenSearch Dashboards setup now uses the newly merged shared action:

`opensearch-project/opensearch-build/.github/actions/setup-opensearch-dashboards@3fe95a610492df770c414c135ae2abd31b9c219d`

This keeps test environment setup on actions maintained by the OpenSearch project while satisfying the workflow requirement that action references are pinned to immutable commit SHAs.

Also removes `Wandalen/wretry.action` from the active Cypress workflow paths. Its composite wrapper uses nested tag-based action references, which still violates the SHA-pinning policy even when the outer action is pinned. The affected Cypress retries are now implemented directly with local bash retry loops.

Historical release note references to `derek-ho/start-opensearch` are left unchanged.

## Testing

- Parsed all `.github/workflows/*.yml` and `.github/actions/*/action.yml` files with Ruby's YAML parser.
- Confirmed active `.github` `start-opensearch` references point to the SHA-pinned `opensearch-build` action.
- Confirmed active `.github` `setup-opensearch-dashboards` references point to the SHA-pinned `opensearch-build` action.
- Confirmed no active `derek-ho/setup-opensearch-dashboards` references remain under `.github`.
- Confirmed no `Wandalen/wretry.action` references remain under `.github`.
- Confirmed every non-local `.github` `uses:` reference ends with a 40-character commit SHA.