### PR TITLE
[2.19] Removes serialize-javascript to fix node-compat issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "sha.js": "^2.4.5",
     "basic-ftp": "^5.2.0",
     "@xmldom/xmldom": "^0.8.13",
-    "xmldom": "npm:@xmldom/xmldom@^0.8.13",
-    "serialize-javascript": "^7.0.3"
+    "xmldom": "npm:@xmldom/xmldom@^0.8.13"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4087,10 +4087,12 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
-serialize-javascript@^4.0.0, serialize-javascript@^7.0.3:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.0.6.tgz#f2f20c8af0757e4d8fa329d0210636da0682ddef"
-  integrity sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==
+serialize-javascript@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-4.0.0.tgz#b525e1238489a5ecfc42afacc3fe99e666f4b1aa"
+  integrity sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+  dependencies:
+    randombytes "^2.1.0"
 
 serve-static@~1.16.2:
   version "1.16.3"


### PR DESCRIPTION
### Description
Fix this:
```
ERROR Error: Command failed with exit code 1: yarn install --production --pure-lockfile
      error serialize-javascript@7.0.6: The engine "node" is incompatible with this module. Expected version ">=20.0.0". Got "18.19.0"
      error Found incompatible module.
```


### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).