### PR TITLE
Migrate Jest test suite to Jest 30 + jsdom 26

### DIFF
--- a/public/apps/account/account-app.tsx
+++ b/public/apps/account/account-app.tsx
@@ -56,8 +56,9 @@ export async function setupTopNavButton(coreStart: CoreStart, config: ClientConf
   if (accountInfo) {
     // Missing role error
     if (accountInfo.roles.length === 0 && !window.location.href.includes(CUSTOM_ERROR_PAGE_URI)) {
-      window.location.href =
-        coreStart.http.basePath.serverBasePath + CUSTOM_ERROR_PAGE_URI + ERROR_MISSING_ROLE_PATH;
+      window.location.assign(
+        coreStart.http.basePath.serverBasePath + CUSTOM_ERROR_PAGE_URI + ERROR_MISSING_ROLE_PATH
+      );
     }
 
     let tenant: string | undefined;

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -235,5 +235,5 @@ export function reloadAfterTenantSwitch(): void {
 
   // rather than just reload when we switch tenants, we set the URL to the pathname. i.e. the portion like: '/app/dashboards'
   // therefore, the copied URL will now allow tenancy changes.
-  window.location.href = window.location.pathname;
+  window.location.assign(window.location.pathname);
 }

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -178,7 +178,7 @@ export function PasswordResetPanel(props: PasswordResetPanelProps) {
           <EuiSpacer />
 
           {errorCallOut && (
-            <EuiCallOut color="danger" iconType="alert">
+            <EuiCallOut announceOnMount color="danger" iconType="alert">
               {errorCallOut}
             </EuiCallOut>
           )}

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -270,7 +270,7 @@ export function TenantSwitchPanel(props: TenantSwitchPanelProps) {
         <EuiSpacer />
 
         {errorCallOut && (
-          <EuiCallOut color="danger" iconType="alert">
+          <EuiCallOut announceOnMount color="danger" iconType="alert">
             {errorCallOut}
           </EuiCallOut>
         )}

--- a/public/apps/account/test/__snapshots__/account-nav-button.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/account-nav-button.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Account navigation button renders 1`] = `
 <EuiHeaderSectionItemButton

--- a/public/apps/account/test/__snapshots__/log-out-button.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/log-out-button.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Account menu - Log out button renders renders when auth type is MultiAuth: basicauth 1`] = `
 <div>

--- a/public/apps/account/test/__snapshots__/role-info-panel.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/role-info-panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Account menu - Role info panel renders 1`] = `
 <EuiOverlayMask>

--- a/public/apps/account/test/__snapshots__/tenant-switch-panel.test.tsx.snap
+++ b/public/apps/account/test/__snapshots__/tenant-switch-panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Account menu -tenant switch panel confirm button and renders renders when both global and private tenant enabled 1`] = `
 <EuiOverlayMask>

--- a/public/apps/account/test/account-app.test.tsx
+++ b/public/apps/account/test/account-app.test.tsx
@@ -78,16 +78,14 @@ describe('Account app', () => {
   });
 
   it('Should skip if auto swich if securitytenant in url', (done) => {
-    // Trick to mock window.location
-    const originalLocation = window.location;
-    delete window.location;
-    window.location = new URL('http://www.example.com?securitytenant=abc') as any;
+    // jest-location-mock: assign a URL with securitytenant instead of replacing window.location.
+    window.location.assign('http://www.example.com?securitytenant=abc');
 
     setupTopNavButton(mockCoreStart, mockConfig as any);
 
     process.nextTick(() => {
-      expect(setShouldShowTenantPopup).toBeCalledWith(false);
-      window.location = originalLocation;
+      expect(setShouldShowTenantPopup).toHaveBeenCalledWith(false);
+      window.location.assign('http://localhost:5601/');
       done();
     });
   });
@@ -98,11 +96,11 @@ describe('Account app', () => {
     setupTopNavButton(mockCoreStart, mockConfig as any);
 
     process.nextTick(() => {
-      expect(getSavedTenant).toBeCalledTimes(1);
+      expect(getSavedTenant).toHaveBeenCalledTimes(1);
     });
 
     process.nextTick(() => {
-      expect(setShouldShowTenantPopup).toBeCalledWith(false);
+      expect(setShouldShowTenantPopup).toHaveBeenCalledWith(false);
       done();
     });
   });
@@ -113,8 +111,8 @@ describe('Account app', () => {
     setupTopNavButton(mockCoreStart, mockConfig as any);
 
     process.nextTick(() => {
-      expect(getSavedTenant).toBeCalledTimes(1);
-      expect(setShouldShowTenantPopup).toBeCalledWith(true);
+      expect(getSavedTenant).toHaveBeenCalledTimes(1);
+      expect(setShouldShowTenantPopup).toHaveBeenCalledWith(true);
       done();
     });
   });
@@ -128,8 +126,8 @@ describe('Account app', () => {
     setupTopNavButton(mockCoreStart, mockConfig as any);
 
     process.nextTick(() => {
-      expect(getSavedTenant).toBeCalledTimes(0);
-      expect(setShouldShowTenantPopup).toBeCalledWith(false);
+      expect(getSavedTenant).toHaveBeenCalledTimes(0);
+      expect(setShouldShowTenantPopup).toHaveBeenCalledWith(false);
       done();
     });
   });
@@ -144,8 +142,8 @@ describe('Account app', () => {
     setupTopNavButton(mockCoreStart, multiTenancyDisabledConfig as any);
 
     process.nextTick(() => {
-      expect(getSavedTenant).toBeCalledTimes(0);
-      expect(setShouldShowTenantPopup).toBeCalledWith(false);
+      expect(getSavedTenant).toHaveBeenCalledTimes(0);
+      expect(setShouldShowTenantPopup).toHaveBeenCalledWith(false);
       done();
     });
   });
@@ -159,8 +157,8 @@ describe('Account app', () => {
     setupTopNavButton(mockCoreStart, mockConfig as any);
 
     process.nextTick(() => {
-      expect(getSavedTenant).toBeCalledTimes(0);
-      expect(setShouldShowTenantPopup).toBeCalledWith(false);
+      expect(getSavedTenant).toHaveBeenCalledTimes(0);
+      expect(setShouldShowTenantPopup).toHaveBeenCalledWith(false);
       done();
     });
   });

--- a/public/apps/account/test/account-nav-button.test.tsx
+++ b/public/apps/account/test/account-nav-button.test.tsx
@@ -109,27 +109,27 @@ describe('Account navigation button', () => {
         currAuthType={'dummy'}
       />
     );
-    expect(setState).toBeCalledTimes(1);
+    expect(setState).toHaveBeenCalledTimes(1);
   });
 
   it('should set modal when click on "View roles and identities" button', () => {
     component.find('[data-test-subj="view-roles-and-identities"]').simulate('click');
-    expect(setState).toBeCalledTimes(1);
+    expect(setState).toHaveBeenCalledTimes(1);
   });
 
   it('should set modal when click on "Switch tenants" button', () => {
     component.find('[data-test-subj="switch-tenants"]').simulate('click');
-    expect(setState).toBeCalledTimes(1);
+    expect(setState).toHaveBeenCalledTimes(1);
   });
 
   it('should set modal when click on "Reset password" button', () => {
     component.find('[data-test-subj="reset-password"]').simulate('click');
-    expect(setState).toBeCalledTimes(1);
+    expect(setState).toHaveBeenCalledTimes(1);
   });
 
   it('should set isPopoverOpen to true when click on Avatar in header section', () => {
     component.find('[data-test-subj="account-popover"]').simulate('click');
-    expect(setState).toBeCalledTimes(1);
+    expect(setState).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -172,7 +172,7 @@ describe('Account navigation button, multitenancy disabled', () => {
         currAuthType={'dummy'}
       />
     );
-    expect(setState).toBeCalledTimes(0);
+    expect(setState).toHaveBeenCalledTimes(0);
   });
 });
 
@@ -247,34 +247,12 @@ describe('Shows tenant info when multitenancy enabled, and hides it if disabled'
 });
 
 describe('Reload window after tenant switch', () => {
-  const originalLocation = window.location;
-  const mockSetWindowHref = jest.fn();
-  let pathname: string = '';
-  beforeAll(() => {
-    pathname = '/app/myapp';
-    Object.defineProperty(window, 'location', {
-      value: {
-        get pathname() {
-          return pathname;
-        },
-        get href() {
-          return '/app/dashboards?security_tenant=admin_tenant';
-        },
-        set href(value: string) {
-          mockSetWindowHref(value);
-        },
-      },
-    });
-  });
-
-  afterAll(() => {
-    window.location = originalLocation;
-  });
-
   it('should remove the tenant query parameter before reloading', () => {
-    pathname = '/app/pathname-only';
+    // jest-location-mock: reloadAfterTenantSwitch() calls window.location.assign(pathname).
+    window.location.assign('http://localhost:5601/app/pathname-only?security_tenant=admin_tenant');
+    const assignSpy = jest.spyOn(window.location, 'assign');
     reloadAfterTenantSwitch();
-    expect(mockSetWindowHref).toHaveBeenCalledWith(pathname);
+    expect(assignSpy).toHaveBeenCalledWith('/app/pathname-only');
   });
 });
 

--- a/public/apps/account/test/log-out-button.test.tsx
+++ b/public/apps/account/test/log-out-button.test.tsx
@@ -87,6 +87,6 @@ describe('Account menu - Log out button', () => {
     );
     component.find('[data-test-subj="log-out-3"]').simulate('click');
 
-    expect(logout).toBeCalled();
+    expect(logout).toHaveBeenCalled();
   });
 });

--- a/public/apps/account/test/password-reset-panel.test.tsx
+++ b/public/apps/account/test/password-reset-panel.test.tsx
@@ -52,12 +52,12 @@ describe('Account menu - Password reset panel', () => {
 
   it('handle modal close', () => {
     component.find('[data-test-subj="reset-password-modal"]').simulate('close');
-    expect(handleClose).toBeCalled();
+    expect(handleClose).toHaveBeenCalled();
   });
 
   it('click cancel button', () => {
     component.find('[data-test-subj="cancel"]').simulate('click');
-    expect(handleClose).toBeCalled();
+    expect(handleClose).toHaveBeenCalled();
   });
 
   it('click reset button', (done) => {
@@ -107,8 +107,8 @@ describe('Account menu - Password reset panel', () => {
       target: { value: 'dummy' },
     } as React.ChangeEvent<HTMLInputElement>;
     component.find('[data-test-subj="current-password"]').simulate('change', event);
-    expect(setState).toBeCalledWith('dummy');
-    expect(setState).toBeCalledWith(false);
+    expect(setState).toHaveBeenCalledWith('dummy');
+    expect(setState).toHaveBeenCalledWith(false);
   });
 
   it('New password field update', () => {
@@ -116,9 +116,9 @@ describe('Account menu - Password reset panel', () => {
       target: { value: 'dummy' },
     } as React.ChangeEvent<HTMLInputElement>;
     component.find('[data-test-subj="new-password"]').simulate('change', event);
-    expect(setState).toBeCalledWith('dummy');
-    expect(setState).toBeCalledWith(false);
-    expect(setState).toBeCalledWith(false);
+    expect(setState).toHaveBeenCalledWith('dummy');
+    expect(setState).toHaveBeenCalledWith(false);
+    expect(setState).toHaveBeenCalledWith(false);
   });
 
   it('Re-enter new password field update', () => {
@@ -126,7 +126,7 @@ describe('Account menu - Password reset panel', () => {
       target: { value: 'dummy' },
     } as React.ChangeEvent<HTMLInputElement>;
     component.find('[data-test-subj="reenter-new-password"]').simulate('change', event);
-    expect(setState).toBeCalledWith('dummy');
-    expect(setState).toBeCalledWith(true);
+    expect(setState).toHaveBeenCalledWith('dummy');
+    expect(setState).toHaveBeenCalledWith(true);
   });
 });

--- a/public/apps/account/test/plugin.test.tsx
+++ b/public/apps/account/test/plugin.test.tsx
@@ -61,25 +61,25 @@ describe('Intercept error handler', () => {
   it('Intercept error handler should call setShouldShowTenantPopup on session timeout', () => {
     const sessionTimeoutFn = interceptError(LOGIN_PAGE_URI, window);
     sessionTimeoutFn(fakeError401, null);
-    expect(setShouldShowTenantPopup).toBeCalledTimes(1);
-    expect(sessionStorage.clear).toBeCalledTimes(1);
+    expect(setShouldShowTenantPopup).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.clear).toHaveBeenCalledTimes(1);
   });
 
   it('Intercept error handler should clear the session', () => {
     const sessionTimeoutFn = interceptError(LOGIN_PAGE_URI, window);
     sessionTimeoutFn(fakeError401, null);
-    expect(sessionStorage.clear).toBeCalledTimes(1);
+    expect(sessionStorage.clear).toHaveBeenCalledTimes(1);
   });
 
   it('Intercept error handler should not call setShouldShowTenantPopup on session timeout', () => {
     const sessionTimeoutFn = interceptError(LOGIN_PAGE_URI, window);
     sessionTimeoutFn(fakeError400, null);
-    expect(setShouldShowTenantPopup).toBeCalledTimes(0);
+    expect(setShouldShowTenantPopup).toHaveBeenCalledTimes(0);
   });
 
   it('Intercept error handler should not clear the session', () => {
     const sessionTimeoutFn = interceptError(LOGIN_PAGE_URI, window);
     sessionTimeoutFn(fakeError400, null);
-    expect(sessionStorage.clear).toBeCalledTimes(0);
+    expect(sessionStorage.clear).toHaveBeenCalledTimes(0);
   });
 });

--- a/public/apps/account/test/role-info-panel.test.tsx
+++ b/public/apps/account/test/role-info-panel.test.tsx
@@ -63,7 +63,7 @@ describe('Account menu - Role info panel', () => {
     jest.spyOn(console, 'log').mockImplementationOnce(() => {});
     shallow(<RoleInfoPanel coreStart={mockCoreStart as any} handleClose={handleClose} />);
     process.nextTick(() => {
-      expect(setState).toBeCalledTimes(0);
+      expect(setState).toHaveBeenCalledTimes(0);
       done();
     });
   });
@@ -73,7 +73,7 @@ describe('Account menu - Role info panel', () => {
       <RoleInfoPanel coreStart={mockCoreStart as any} handleClose={handleClose} />
     );
     component.find('[data-test-subj="role-info-modal"]').simulate('close');
-    expect(handleClose).toBeCalled();
+    expect(handleClose).toHaveBeenCalled();
   });
 
   it('renders', () => {

--- a/public/apps/account/test/switch-tenants.test.tsx
+++ b/public/apps/account/test/switch-tenants.test.tsx
@@ -16,34 +16,12 @@
 import { reloadAfterTenantSwitch } from '../account-nav-button';
 
 describe('Reload window after tenant switch', () => {
-  const originalLocation = window.location;
-  const mockSetWindowHref = jest.fn();
-  let pathname: string = '';
-  beforeAll(() => {
-    pathname = '/app/myapp';
-    Object.defineProperty(window, 'location', {
-      value: {
-        get pathname() {
-          return pathname;
-        },
-        get href() {
-          return '/app/dashboards?security_tenant=admin_tenant';
-        },
-        set href(value: string) {
-          mockSetWindowHref(value);
-        },
-      },
-    });
-  });
-
-  afterAll(() => {
-    window.location = originalLocation;
-  });
-
   it('should remove the tenant query parameter before reloading', () => {
-    pathname = '/app/pathname-only';
+    // jest-location-mock: reloadAfterTenantSwitch() calls window.location.assign(pathname).
+    window.location.assign('http://localhost:5601/app/pathname-only?security_tenant=admin_tenant');
+    const assignSpy = jest.spyOn(window.location, 'assign');
     reloadAfterTenantSwitch();
-    expect(mockSetWindowHref).toHaveBeenCalledWith(pathname);
+    expect(assignSpy).toHaveBeenCalledWith('/app/pathname-only');
   });
 });
 

--- a/public/apps/account/test/tenant-switch-panel.test.tsx
+++ b/public/apps/account/test/tenant-switch-panel.test.tsx
@@ -214,7 +214,7 @@ describe('Account menu -tenant switch panel', () => {
       />
     );
     component.find('[data-test-subj="tenant-switch-modal"]').simulate('close');
-    expect(handleClose).toBeCalled();
+    expect(handleClose).toHaveBeenCalled();
   });
 
   it('Confirm button should be disabled when multitenancy is disabled in Config', () => {
@@ -264,8 +264,8 @@ describe('Account menu -tenant switch panel', () => {
       .find('[data-test-subj="tenant-switch-radios"]')
       .simulate('change', GLOBAL_TENANT_RADIO_ID);
 
-    expect(setState).toBeCalledWith(GLOBAL_TENANT_RADIO_ID);
-    expect(setState).toBeCalledWith('');
+    expect(setState).toHaveBeenCalledWith(GLOBAL_TENANT_RADIO_ID);
+    expect(setState).toHaveBeenCalledWith('');
   });
 
   it('should set error call out when tenant name is undefined', () => {
@@ -281,7 +281,7 @@ describe('Account menu -tenant switch panel', () => {
       />
     );
     component.find('[data-test-subj="confirm"]').simulate('click');
-    expect(setState).toBeCalledWith('No target tenant is specified!');
+    expect(setState).toHaveBeenCalledWith('No target tenant is specified!');
   });
 
   describe('confirm button and renders', () => {

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -46,15 +46,16 @@ export async function logout(http: HttpStart, logoutUrl?: string): Promise<void>
   // When no basepath is set, we can take '/' as the basepath.
   const basePath = http.basePath.serverBasePath ? http.basePath.serverBasePath : '/';
   const nextUrl = encodeURIComponent(basePath);
-  window.location.href =
-    logoutUrl || `${http.basePath.serverBasePath}/app/login?nextUrl=${nextUrl}`;
+  window.location.assign(
+    logoutUrl || `${http.basePath.serverBasePath}/app/login?nextUrl=${nextUrl}`
+  );
 }
 
 export async function externalLogout(http: HttpStart, logoutEndpoint: string): Promise<void> {
   // This will ensure tenancy is picked up from local storage in the next login.
   setShouldShowTenantPopup(null);
   sessionStorage.clear();
-  window.location.href = `${http.basePath.serverBasePath}${logoutEndpoint}`;
+  window.location.assign(`${http.basePath.serverBasePath}${logoutEndpoint}`);
 }
 
 export async function updateNewPassword(

--- a/public/apps/configuration/header/test/header-components.test.tsx
+++ b/public/apps/configuration/header/test/header-components.test.tsx
@@ -71,7 +71,7 @@ describe('PageHeader', () => {
     );
     expect(wrapper.contains(props.fallBackComponent)).toBe(true);
 
-    expect(props.navigation.ui.HeaderControl).not.toBeCalled();
+    expect(props.navigation.ui.HeaderControl).not.toHaveBeenCalled();
   });
 
   it('renders with the feature flag on', () => {

--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -88,7 +88,7 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
             <EuiSmallButton
               data-test-subj="cancel"
               onClick={() => {
-                window.location.href = buildHashUrl(ResourceType.auditLogging);
+                window.location.assign(buildHashUrl(ResourceType.auditLogging));
               }}
             >
               Cancel
@@ -135,7 +135,7 @@ export function AuditLoggingEditSettings(props: AuditLoggingEditSettingProps) {
         );
       }
 
-      window.location.href = buildHashUrl(ResourceType.auditLogging);
+      window.location.assign(buildHashUrl(ResourceType.auditLogging));
     } catch (e) {
       const failureToast: Toast = {
         id: 'update-result',

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -210,8 +210,9 @@ export function AuditLogging(props: AuditLoggingProps) {
               <EuiSmallButton
                 data-test-subj="general-settings-configure"
                 onClick={() => {
-                  window.location.href =
-                    buildHashUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT;
+                  window.location.assign(
+                    buildHashUrl(ResourceType.auditLogging) + SUB_URL_FOR_GENERAL_SETTINGS_EDIT
+                  );
                 }}
               >
                 Configure
@@ -235,8 +236,9 @@ export function AuditLogging(props: AuditLoggingProps) {
               <EuiSmallButton
                 data-test-subj="compliance-settings-configure"
                 onClick={() => {
-                  window.location.href =
-                    buildHashUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT;
+                  window.location.assign(
+                    buildHashUrl(ResourceType.auditLogging) + SUB_URL_FOR_COMPLIANCE_SETTINGS_EDIT
+                  );
                 }}
               >
                 Configure

--- a/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
+++ b/public/apps/configuration/panels/audit-logging/test/__snapshots__/audit-logging.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Audit logs render compliance settings 1`] = `
 <Fragment>

--- a/public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
@@ -124,7 +124,7 @@ describe('Audit logs edit', () => {
     );
 
     process.nextTick(() => {
-      expect(spy).toBeCalled();
+      expect(spy).toHaveBeenCalled();
       done();
     });
   });
@@ -143,7 +143,7 @@ describe('Audit logs edit', () => {
     expect(window.location.hash).toBe(buildHashUrl(ResourceType.auditLogging));
   });
 
-  it('should save or update audit logging when click on Save button and setting is compliance', () => {
+  it('should save or update audit logging when click on Save button and setting is compliance', async () => {
     const component = shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
@@ -154,11 +154,13 @@ describe('Audit logs edit', () => {
       />
     );
     component.find('[data-test-subj="save"]').simulate('click');
-    expect(mockAuditLoggingUtils.updateAuditLogging).toBeCalled();
+    expect(mockAuditLoggingUtils.updateAuditLogging).toHaveBeenCalled();
+    // saveConfig() awaits updateAuditLogging before navigating; flush microtasks.
+    await Promise.resolve();
     expect(window.location.hash).toBe(buildHashUrl(ResourceType.auditLogging));
   });
 
-  it('should save or update audit logging when click on Save button and setting is general', () => {
+  it('should save or update audit logging when click on Save button and setting is general', async () => {
     const component = shallow(
       <AuditLoggingEditSettings
         coreStart={mockCoreStart as any}
@@ -169,7 +171,9 @@ describe('Audit logs edit', () => {
       />
     );
     component.find('[data-test-subj="save"]').simulate('click');
-    expect(mockAuditLoggingUtils.updateAuditLogging).toBeCalled();
+    expect(mockAuditLoggingUtils.updateAuditLogging).toHaveBeenCalled();
+    // saveConfig() awaits updateAuditLogging before navigating; flush microtasks.
+    await Promise.resolve();
     expect(window.location.hash).toBe(buildHashUrl(ResourceType.auditLogging));
   });
 });

--- a/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
@@ -105,7 +105,7 @@ describe('Audit logs', () => {
 
     process.nextTick(() => {
       expect(mockAuditLoggingUtils.getAuditLogging).toHaveBeenCalledTimes(1);
-      expect(setState).toBeCalledTimes(0);
+      expect(setState).toHaveBeenCalledTimes(0);
 
       done();
     });
@@ -145,8 +145,8 @@ describe('Audit logs', () => {
     );
     component.find('[data-test-subj="audit-logging-enabled-switch"]').simulate('change');
 
-    expect(spy).toBeCalled();
-    expect(setState).toBeCalledTimes(0);
+    expect(spy).toHaveBeenCalled();
+    expect(setState).toHaveBeenCalledTimes(0);
   });
 
   it('render when AuditLoggingSettings.enabled is true', () => {

--- a/public/apps/configuration/panels/auth-view/test/__snapshots__/auth-view.test.tsx.snap
+++ b/public/apps/configuration/panels/auth-view/test/__snapshots__/auth-view.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Auth view should load access error component 1`] = `
 <Fragment>

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -68,7 +68,7 @@ const addBackendStep = {
           <EuiSmallButton
             data-test-subj="review-authentication-and-authorization"
             onClick={() => {
-              window.location.href = buildHashUrl(ResourceType.auth);
+              window.location.assign(buildHashUrl(ResourceType.auth));
             }}
           >
             Review authentication and authorization
@@ -99,7 +99,7 @@ const setOfSteps = [
             <EuiSmallButton
               data-test-subj="explore-existing-roles"
               onClick={() => {
-                window.location.href = buildHashUrl(ResourceType.roles);
+                window.location.assign(buildHashUrl(ResourceType.roles));
               }}
             >
               Explore existing roles
@@ -109,7 +109,7 @@ const setOfSteps = [
             <EuiSmallButton
               data-test-subj="create-new-role"
               onClick={() => {
-                window.location.href = buildHashUrl(ResourceType.roles, Action.create);
+                window.location.assign(buildHashUrl(ResourceType.roles, Action.create));
               }}
             >
               Create new role
@@ -138,7 +138,7 @@ const setOfSteps = [
             <EuiSmallButton
               data-test-subj="map-users-to-role"
               onClick={() => {
-                window.location.href = buildHashUrl(ResourceType.users);
+                window.location.assign(buildHashUrl(ResourceType.users));
               }}
             >
               Map users to a role
@@ -148,7 +148,7 @@ const setOfSteps = [
             <EuiSmallButton
               data-test-subj="create-internal-user"
               onClick={() => {
-                window.location.href = buildHashUrl(ResourceType.users, Action.create);
+                window.location.assign(buildHashUrl(ResourceType.users, Action.create));
               }}
             >
               Create internal user
@@ -239,7 +239,7 @@ export function GetStarted(props: AppDependencies) {
             <EuiSmallButton
               data-test-subj="review-audit-log-configuration"
               onClick={() => {
-                window.location.href = buildHashUrl(ResourceType.auditLogging);
+                window.location.assign(buildHashUrl(ResourceType.auditLogging));
               }}
             >
               Review Audit Log Configuration
@@ -306,7 +306,7 @@ export function GetStarted(props: AppDependencies) {
                 <EuiFlexItem grow={false}>
                   <EuiSmallButton
                     onClick={() => {
-                      window.location.href = buildHashUrl(ResourceType.tenants);
+                      window.location.assign(buildHashUrl(ResourceType.tenants));
                     }}
                   >
                     Manage Multi-tenancy
@@ -315,7 +315,7 @@ export function GetStarted(props: AppDependencies) {
                 <EuiFlexItem grow={false}>
                   <EuiSmallButton
                     onClick={() => {
-                      window.location.href = buildHashUrl(ResourceType.tenantsConfigureTab);
+                      window.location.assign(buildHashUrl(ResourceType.tenantsConfigureTab));
                     }}
                   >
                     Configure Multi-tenancy

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -139,7 +139,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
         )}`,
       });
       // Redirect to user listing
-      window.location.href = buildHashUrl(ResourceType.users);
+      window.location.assign(buildHashUrl(ResourceType.users));
     } catch (e) {
       addToast(
         createErrorToast('updateUserFailed', 'Update error', constructErrorMessageAndLog(e, ''))
@@ -223,7 +223,7 @@ export function InternalUserEdit(props: InternalUserEditDeps) {
         <EuiFlexItem grow={false}>
           <EuiSmallButton
             onClick={() => {
-              window.location.href = buildHashUrl(ResourceType.users);
+              window.location.assign(buildHashUrl(ResourceType.users));
             }}
           >
             Cancel

--- a/public/apps/configuration/panels/internal-user-edit/test/__snapshots__/backend-role-panel.test.tsx.snap
+++ b/public/apps/configuration/panels/internal-user-edit/test/__snapshots__/backend-role-panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`User editing - backend role panel BackendRolePanel add backend role when one of the previous roles is blank 1`] = `
 <PanelWithHeader

--- a/public/apps/configuration/panels/internal-user-edit/test/attribute-panel.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/attribute-panel.test.tsx
@@ -59,7 +59,7 @@ describe('User editing - attribute panel', () => {
     it('render an empty row when no data', () => {
       shallow(<AttributePanel state={[]} setState={setState} />);
 
-      expect(setState).toBeCalledWith([{ key: '', value: '' }]);
+      expect(setState).toHaveBeenCalledWith([{ key: '', value: '' }]);
     });
 
     it('render data', () => {
@@ -76,28 +76,28 @@ describe('User editing - attribute panel', () => {
       const component = shallow(<AttributePanel state={sampleState} setState={setState} />);
       component.find('#add-row').simulate('click');
 
-      expect(appendElementToArray).toBeCalledWith(setState, [], { key: '', value: '' });
+      expect(appendElementToArray).toHaveBeenCalledWith(setState, [], { key: '', value: '' });
     });
 
     it('change attribute name', () => {
       const component = shallow(<AttributePanel state={sampleState} setState={setState} />);
       component.find('#attribute-0').simulate('change', { target: { value: '' } });
 
-      expect(updateElementInArrayHandler).toBeCalledWith(setState, [0, 'key']);
+      expect(updateElementInArrayHandler).toHaveBeenCalledWith(setState, [0, 'key']);
     });
 
     it('change attribute value', () => {
       const component = shallow(<AttributePanel state={sampleState} setState={setState} />);
       component.find('#value-0').simulate('change', { target: { value: '' } });
 
-      expect(updateElementInArrayHandler).toBeCalledWith(setState, [0, 'value']);
+      expect(updateElementInArrayHandler).toHaveBeenCalledWith(setState, [0, 'value']);
     });
 
     it('delete row', () => {
       const component = shallow(<AttributePanel state={sampleState} setState={setState} />);
       component.find('#delete-0').simulate('click');
 
-      expect(removeElementFromArray).toBeCalledWith(setState, [], 0);
+      expect(removeElementFromArray).toHaveBeenCalledWith(setState, [], 0);
     });
   });
 });

--- a/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
@@ -41,7 +41,7 @@ describe('User editing - backend role panel', () => {
     it('render an empty row when no data', () => {
       shallow(<BackendRolePanel state={[]} setState={setState} />);
 
-      expect(setState).toBeCalledWith(['']);
+      expect(setState).toHaveBeenCalledWith(['']);
     });
 
     it('render data', () => {
@@ -56,21 +56,21 @@ describe('User editing - backend role panel', () => {
       const component = shallow(<BackendRolePanel state={sampleState} setState={setState} />);
       component.find('#backend-role-add-row').simulate('click');
 
-      expect(appendElementToArray).toBeCalledWith(setState, [], '');
+      expect(appendElementToArray).toHaveBeenCalledWith(setState, [], '');
     });
 
     it('change backend role value', () => {
       const component = shallow(<BackendRolePanel state={sampleState} setState={setState} />);
       component.find('#backend-role-0').simulate('change', { target: { value: '' } });
 
-      expect(updateElementInArrayHandler).toBeCalledWith(setState, [0]);
+      expect(updateElementInArrayHandler).toHaveBeenCalledWith(setState, [0]);
     });
 
     it('delete row', () => {
       const component = shallow(<BackendRolePanel state={sampleState} setState={setState} />);
       component.find('#backend-role-delete-0').simulate('click');
 
-      expect(removeElementFromArray).toBeCalledWith(setState, [], 0);
+      expect(removeElementFromArray).toHaveBeenCalledWith(setState, [], 0);
     });
 
     // TODO: Fix the tests for backend role error message

--- a/public/apps/configuration/panels/internal-user-edit/test/internal-user-edit.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/internal-user-edit.test.tsx
@@ -81,7 +81,7 @@ describe('Internal user edit', () => {
       />
     );
 
-    expect(getUserDetail).toBeCalledWith(mockCoreStart.http, sampleUsername, 'test');
+    expect(getUserDetail).toHaveBeenCalledWith(mockCoreStart.http, sampleUsername, 'test');
   });
 
   it('should not submit if password is empty on creation', () => {
@@ -101,8 +101,8 @@ describe('Internal user edit', () => {
     );
     component.find('#submit').simulate('click');
 
-    expect(createErrorToast).toBeCalled();
-    expect(updateUser).toBeCalledTimes(0);
+    expect(createErrorToast).toHaveBeenCalled();
+    expect(updateUser).toHaveBeenCalledTimes(0);
   });
 
   it('submit change', () => {
@@ -121,7 +121,7 @@ describe('Internal user edit', () => {
     );
     component.find('#submit').simulate('click');
 
-    expect(updateUser).toBeCalled();
+    expect(updateUser).toHaveBeenCalled();
     const userUpdateObj: InternalUserUpdate = updateUser.mock.calls[0][0];
     expect(userUpdateObj.password).toEqual(undefined);
   });
@@ -143,7 +143,7 @@ describe('Internal user edit', () => {
     );
     component.find('#submit').simulate('click');
 
-    expect(createErrorToast).toBeCalled();
-    expect(updateUser).toBeCalledTimes(0);
+    expect(createErrorToast).toHaveBeenCalled();
+    expect(updateUser).toHaveBeenCalledTimes(0);
   });
 });

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -69,7 +69,7 @@ import { PageHeader } from '../../header/header-components';
 import { ResourceType } from '../../../../../common';
 
 export function renderBooleanToCheckMark(value: boolean): React.ReactNode {
-  return value ? <EuiIcon type="check" /> : '';
+  return value ? <EuiIcon type="check" aria-hidden={true} /> : '';
 }
 
 export function toggleRowDetails(

--- a/public/apps/configuration/panels/permission-list/test/__snapshots__/permission-list.test.tsx.snap
+++ b/public/apps/configuration/panels/permission-list/test/__snapshots__/permission-list.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Permission list page  AccessError component should load access error component 1`] = `
 <Fragment>

--- a/public/apps/configuration/panels/permission-list/test/edit-modal.test.tsx
+++ b/public/apps/configuration/panels/permission-list/test/edit-modal.test.tsx
@@ -33,6 +33,6 @@ describe('Permission edit modal', () => {
     );
     component.find('#submit').simulate('click');
 
-    expect(handleSave).toBeCalled();
+    expect(handleSave).toHaveBeenCalled();
   });
 });

--- a/public/apps/configuration/panels/permission-list/test/permission-list.test.tsx
+++ b/public/apps/configuration/panels/permission-list/test/permission-list.test.tsx
@@ -129,7 +129,7 @@ describe('Permission list page ', () => {
         />
       );
 
-      expect(fetchActionGroups).toBeCalledWith(mockCoreStart.http, 'test');
+      expect(fetchActionGroups).toHaveBeenCalledWith(mockCoreStart.http, 'test');
     });
 
     it('fetch data error', () => {
@@ -152,7 +152,7 @@ describe('Permission list page ', () => {
       );
 
       // Expect error log
-      expect(consoleLog).toBeCalledWith(error);
+      expect(consoleLog).toHaveBeenCalledWith(error);
     });
 
     it('submit change', () => {
@@ -168,7 +168,7 @@ describe('Permission list page ', () => {
       const submitFunc = component.find(PermissionEditModal).prop('handleSave');
       submitFunc('group1', []);
 
-      expect(updateActionGroup).toBeCalledWith(
+      expect(updateActionGroup).toHaveBeenCalledWith(
         mockCoreStart.http,
         'group1',
         { allowed_actions: [] },
@@ -196,7 +196,7 @@ describe('Permission list page ', () => {
       submitFunc('group1', []);
 
       // Expect error log
-      expect(consoleLog).toBeCalledWith(error);
+      expect(consoleLog).toHaveBeenCalledWith(error);
     });
 
     it('delete action group', (done) => {
@@ -213,7 +213,7 @@ describe('Permission list page ', () => {
       deleteFunc();
 
       process.nextTick(() => {
-        expect(requestDeleteActionGroups).toBeCalledWith(mockCoreStart.http, [], 'test');
+        expect(requestDeleteActionGroups).toHaveBeenCalledWith(mockCoreStart.http, [], 'test');
         done();
       });
     });

--- a/public/apps/configuration/panels/permission-tree/test/__snapshots__/permission-tree.test.tsx.snap
+++ b/public/apps/configuration/panels/permission-tree/test/__snapshots__/permission-tree.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Permission tree renders 1`] = `
 <div

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -195,7 +195,7 @@ export function RoleEdit(props: RoleEditDeps) {
         )}`,
       });
       // Redirect to role view
-      window.location.href = buildHashUrl(ResourceType.roles, Action.view, roleName);
+      window.location.assign(buildHashUrl(ResourceType.roles, Action.view, roleName));
     } catch (e) {
       addToast(createUnknownErrorToast('updateRole', `${props.action} role`));
       console.error(e);
@@ -340,7 +340,7 @@ export function RoleEdit(props: RoleEditDeps) {
         <EuiFlexItem grow={false}>
           <EuiSmallButton
             onClick={() => {
-              window.location.href = buildHashUrl(ResourceType.roles);
+              window.location.assign(buildHashUrl(ResourceType.roles));
             }}
           >
             Cancel

--- a/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
@@ -100,7 +100,7 @@ describe('Role edit', () => {
       />
     );
 
-    expect(fetchTenantNameList).toBeCalledTimes(1);
+    expect(fetchTenantNameList).toHaveBeenCalledTimes(1);
   });
 
   it('submit update', (done) => {
@@ -125,7 +125,7 @@ describe('Role edit', () => {
     // click update
     component.find(EuiSmallButton).last().simulate('click');
 
-    expect(updateRole).toBeCalledWith(
+    expect(updateRole).toHaveBeenCalledWith(
       mockCoreStart.http,
       '',
       {

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -188,7 +188,9 @@ export function RoleList(props: AppDependencies) {
       data-test-subj="edit"
       key="edit"
       onClick={() => {
-        window.location.href = buildHashUrl(ResourceType.roles, Action.edit, selection[0].roleName);
+        window.location.assign(
+          buildHashUrl(ResourceType.roles, Action.edit, selection[0].roleName)
+        );
       }}
       disabled={selection.length !== 1 || selection[0].reserved}
     >
@@ -199,10 +201,8 @@ export function RoleList(props: AppDependencies) {
       data-test-subj="duplicate"
       key="duplicate"
       onClick={() => {
-        window.location.href = buildHashUrl(
-          ResourceType.roles,
-          Action.duplicate,
-          selection[0].roleName
+        window.location.assign(
+          buildHashUrl(ResourceType.roles, Action.duplicate, selection[0].roleName)
         );
       }}
       disabled={selection.length !== 1}

--- a/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
+++ b/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
@@ -137,11 +137,8 @@ export function RoleEditMappedUser(props: RoleEditMappedUserProps) {
           )}`,
         }
       );
-      window.location.href = buildHashUrl(
-        ResourceType.roles,
-        Action.view,
-        props.roleName,
-        SubAction.mapuser
+      window.location.assign(
+        buildHashUrl(ResourceType.roles, Action.view, props.roleName, SubAction.mapuser)
       );
     } catch (e) {
       if (e.message) {
@@ -199,7 +196,7 @@ export function RoleEditMappedUser(props: RoleEditMappedUserProps) {
         <EuiFlexItem grow={false}>
           <EuiSmallButton
             onClick={() => {
-              window.location.href = buildHashUrl(ResourceType.roles, Action.view, props.roleName);
+              window.location.assign(buildHashUrl(ResourceType.roles, Action.view, props.roleName));
             }}
           >
             Cancel

--- a/public/apps/configuration/panels/role-mapping/test/external-identities-panel.test.tsx
+++ b/public/apps/configuration/panels/role-mapping/test/external-identities-panel.test.tsx
@@ -104,7 +104,7 @@ describe('Role mapping - external identities panel', () => {
       );
       component.find('#add-row').simulate('click');
 
-      expect(appendElementToArray).toBeCalledWith(setExternalIdentities, [], {
+      expect(appendElementToArray).toHaveBeenCalledWith(setExternalIdentities, [], {
         externalIdentity: '',
       });
     });
@@ -118,7 +118,7 @@ describe('Role mapping - external identities panel', () => {
       );
       component.find('#externalIdentity-0').simulate('change', { target: { value: '' } });
 
-      expect(updateElementInArrayHandler).toBeCalledWith(setExternalIdentities, [
+      expect(updateElementInArrayHandler).toHaveBeenCalledWith(setExternalIdentities, [
         0,
         'externalIdentity',
       ]);
@@ -133,7 +133,7 @@ describe('Role mapping - external identities panel', () => {
       );
       component.find('#remove-0').simulate('click');
 
-      expect(removeElementFromArray).toBeCalledWith(setExternalIdentities, [], 0);
+      expect(removeElementFromArray).toHaveBeenCalledWith(setExternalIdentities, [], 0);
     });
   });
 });

--- a/public/apps/configuration/panels/role-mapping/test/role-edit-mapped-user.test.tsx
+++ b/public/apps/configuration/panels/role-mapping/test/role-edit-mapped-user.test.tsx
@@ -83,8 +83,8 @@ describe('Role mapping edit', () => {
       />
     );
     process.nextTick(() => {
-      expect(getRoleMappingData).toBeCalledTimes(1);
-      expect(fetchUserNameList).toBeCalledTimes(1);
+      expect(getRoleMappingData).toHaveBeenCalledTimes(1);
+      expect(fetchUserNameList).toHaveBeenCalledTimes(1);
       expect(setState).toHaveBeenCalledWith([{ label: 'user1' }]);
       expect(setState).toHaveBeenCalledWith([{ externalIdentity: 'externalIdentity1' }]);
       expect(setState).toHaveBeenCalledWith([]);
@@ -105,7 +105,7 @@ describe('Role mapping edit', () => {
     // click update
     component.find('#map').last().simulate('click');
 
-    expect(updateRoleMapping).toBeCalledWith(
+    expect(updateRoleMapping).toHaveBeenCalledWith(
       mockCoreStart.http,
       sampleRole,
       {
@@ -136,6 +136,6 @@ describe('Role mapping edit', () => {
     );
     // click update
     component.find('#map').last().simulate('click');
-    expect(consoleError).toBeCalledWith(error);
+    expect(consoleError).toHaveBeenCalledWith(error);
   });
 });

--- a/public/apps/configuration/panels/role-view/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/cluster-permission-panel.tsx
@@ -41,7 +41,7 @@ export function ClusterPermissionPanel(props: ClusterPermissionPanelProps) {
           data-test-subj="addClusterPermission"
           disabled={props.isReserved}
           onClick={() => {
-            window.location.href = buildHashUrl(ResourceType.roles, Action.edit, props.roleName);
+            window.location.assign(buildHashUrl(ResourceType.roles, Action.edit, props.roleName));
           }}
         >
           Add cluster permission

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -140,7 +140,7 @@ export function IndexPermissionPanel(props: IndexPermissionPanelProps) {
           data-test-subj="addIndexPermission"
           disabled={props.isReserved}
           onClick={() => {
-            window.location.href = buildHashUrl(ResourceType.roles, Action.edit, props.roleName);
+            window.location.assign(buildHashUrl(ResourceType.roles, Action.edit, props.roleName));
           }}
         >
           Add index permission

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -217,11 +217,8 @@ export function RoleView(props: RoleViewProps) {
               data-test-subj="map-users"
               fill
               onClick={() => {
-                window.location.href = buildHashUrl(
-                  ResourceType.roles,
-                  Action.edit,
-                  props.roleName,
-                  SubAction.mapuser
+                window.location.assign(
+                  buildHashUrl(ResourceType.roles, Action.edit, props.roleName, SubAction.mapuser)
                 );
               }}
             >
@@ -244,6 +241,7 @@ export function RoleView(props: RoleViewProps) {
 
           {isReserved && (
             <EuiCallOut
+              announceOnMount
               title="This role is reserved for the Security plugin environment. Reserved roles are restricted for any permission customizations."
               iconType="lock"
               size="s"
@@ -333,11 +331,13 @@ export function RoleView(props: RoleViewProps) {
                     <EuiSmallButton
                       data-test-subj="manage-mapping"
                       onClick={() => {
-                        window.location.href = buildHashUrl(
-                          ResourceType.roles,
-                          Action.edit,
-                          props.roleName,
-                          SubAction.mapuser
+                        window.location.assign(
+                          buildHashUrl(
+                            ResourceType.roles,
+                            Action.edit,
+                            props.roleName,
+                            SubAction.mapuser
+                          )
                         );
                       }}
                     >
@@ -388,7 +388,7 @@ export function RoleView(props: RoleViewProps) {
             color: 'success',
             title: `${props.roleName} deleted ${getClusterInfo(dataSourceEnabled, dataSource)}`,
           });
-          window.location.href = buildHashUrl(ResourceType.roles);
+          window.location.assign(buildHashUrl(ResourceType.roles));
         } catch (e) {
           addToast(createUnknownErrorToast('deleteRole', 'delete role'));
         }
@@ -435,7 +435,7 @@ export function RoleView(props: RoleViewProps) {
             color: 'success',
             title: `${props.roleName} deleted ${getClusterInfo(dataSourceEnabled, dataSource)}`,
           });
-          window.location.href = buildHashUrl(ResourceType.roles);
+          window.location.assign(buildHashUrl(ResourceType.roles));
         } catch (e) {
           addToast(createUnknownErrorToast('deleteRole', 'delete role'));
         }

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -85,7 +85,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
         tenant: tenantName,
         username: currentUsername,
       });
-      window.location.href = getNavLinkById(props.coreStart, PageId.dashboardId);
+      window.location.assign(getNavLinkById(props.coreStart, PageId.dashboardId));
     } catch (e) {
       console.log(e);
       addToast(createUnknownErrorToast('viewDashboard', `view dashboard for ${tenantName} tenant`));
@@ -98,7 +98,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
         tenant: tenantName,
         username: currentUsername,
       });
-      window.location.href = getNavLinkById(props.coreStart, PageId.visualizationId);
+      window.location.assign(getNavLinkById(props.coreStart, PageId.visualizationId));
     } catch (e) {
       console.log(e);
       addToast(
@@ -175,7 +175,7 @@ export function TenantsPanel(props: RoleViewTenantsPanelProps) {
           data-test-subj="addTenantPermission"
           disabled={props.isReserved}
           onClick={() => {
-            window.location.href = buildHashUrl(ResourceType.roles, Action.edit, props.roleName);
+            window.location.assign(buildHashUrl(ResourceType.roles, Action.edit, props.roleName));
           }}
         >
           Add tenant permission

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/index-permission-panel.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/index-permission-panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Role view - index permission panel Render document level security renders document level security when dls is invalid json 1`] = `
 <Fragment>

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/role-view.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Role view basic rendering when permission tab is selected 1`] = `
 <Fragment>

--- a/public/apps/configuration/panels/role-view/test/__snapshots__/tenants-panel.test.tsx.snap
+++ b/public/apps/configuration/panels/role-view/test/__snapshots__/tenants-panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Role view - tenant panel Tenant permission list render view dashboard column when tenant permissions contains multiple tenants or tenant pattern 1`] = `
 <Fragment>

--- a/public/apps/configuration/panels/role-view/test/index-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/index-permission-panel.test.tsx
@@ -78,7 +78,7 @@ describe('Role view - index permission panel', () => {
       const Wrapper = () => <>{renderFunc('{"key": "value"%%%}')}</>;
       const spy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
       const component = shallow(<Wrapper />);
-      expect(spy).toBeCalled();
+      expect(spy).toHaveBeenCalled();
       expect(component).toMatchSnapshot();
     });
   });

--- a/public/apps/configuration/panels/role-view/test/role-view.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/role-view.test.tsx
@@ -244,7 +244,7 @@ describe('Role view', () => {
     deleteFunc();
 
     process.nextTick(() => {
-      expect(updateRoleMapping).toBeCalled();
+      expect(updateRoleMapping).toHaveBeenCalled();
       done();
     });
   });
@@ -270,7 +270,7 @@ describe('Role view', () => {
     deleteFunc();
 
     process.nextTick(() => {
-      expect(spy).toBeCalled();
+      expect(spy).toHaveBeenCalled();
       done();
     });
   });
@@ -290,7 +290,7 @@ describe('Role view', () => {
     );
     component.find('[data-test-subj="delete"]').first().simulate('click');
 
-    expect(requestDeleteRoles).toBeCalled();
+    expect(requestDeleteRoles).toHaveBeenCalled();
   });
 
   it('error occurred while deleting the role', () => {
@@ -310,6 +310,6 @@ describe('Role view', () => {
       />
     );
     component.find('[data-test-subj="delete"]').first().simulate('click');
-    expect(createUnknownErrorToast).toBeCalled();
+    expect(createUnknownErrorToast).toHaveBeenCalled();
   });
 });

--- a/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
+++ b/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
@@ -311,8 +311,8 @@ export function ConfigureTab1(props: AppDependencies) {
   const errorCallOut = (
     <EuiCallOut title="Address the highlighted areas" color="danger" iconType="iInCircle">
       <p>
-        <EuiIcon type="dot" size={'s'} /> The private tenant is disabled. Select another default
-        tenant.
+        <EuiIcon type="dot" size={'s'} aria-hidden={true} /> The private tenant is disabled. Select
+        another default tenant.
       </p>
     </EuiCallOut>
   );

--- a/public/apps/configuration/panels/tenant-list/manage_tab.tsx
+++ b/public/apps/configuration/panels/tenant-list/manage_tab.tsx
@@ -232,7 +232,7 @@ export function ManageTab(props: AppDependencies) {
   let tenancyDisabledWarning;
   if (!true) {
     tenancyDisabledWarning = (
-      <EuiCallOut title="Tenancy is disabled" color="warning" iconType="iInCircle">
+      <EuiCallOut announceOnMount title="Tenancy is disabled" color="warning" iconType="iInCircle">
         <p>
           Tenancy is currently disabled and users don&apos;t have access to this feature. To create,
           edit tenants you must enabled tenanc throught he configure tenancy page.
@@ -251,7 +251,7 @@ export function ManageTab(props: AppDependencies) {
   const viewOrCreateDashboard = async (tenantValue: string, action: string) => {
     try {
       await changeTenant(tenantValue);
-      window.location.href = getNavLinkById(props.coreStart, PageId.dashboardId);
+      window.location.assign(getNavLinkById(props.coreStart, PageId.dashboardId));
     } catch (e) {
       console.log(e);
       addToast(
@@ -266,7 +266,7 @@ export function ManageTab(props: AppDependencies) {
   const viewOrCreateVisualization = async (tenantValue: string, action: string) => {
     try {
       await changeTenant(tenantValue);
-      window.location.href = getNavLinkById(props.coreStart, PageId.visualizationId);
+      window.location.assign(getNavLinkById(props.coreStart, PageId.visualizationId));
     } catch (e) {
       console.log(e);
       addToast(
@@ -287,45 +287,61 @@ export function ManageTab(props: AppDependencies) {
         dashboardsDefaultTenant === ''
       ) {
         return (
-          <EuiFacetButton icon={<EuiIcon type="dot" color="primary" />}>
+          <EuiFacetButton icon={<EuiIcon type="dot" color="primary" aria-hidden={true} />}>
             Default Tenant
           </EuiFacetButton>
         );
       }
-      return <EuiFacetButton icon={<EuiIcon type="dot" color="success" />}>Enabled</EuiFacetButton>;
+      return (
+        <EuiFacetButton icon={<EuiIcon type="dot" color="success" aria-hidden={true} />}>
+          Enabled
+        </EuiFacetButton>
+      );
     }
 
     if (tenantName === 'Private') {
       if (isPrivateTenantEnabled && isMultiTenancyEnabled) {
         if (tenantName === dashboardsDefaultTenant) {
           return (
-            <EuiFacetButton icon={<EuiIcon type="dot" color="primary" />}>
+            <EuiFacetButton icon={<EuiIcon type="dot" color="primary" aria-hidden={true} />}>
               Default Tenant
             </EuiFacetButton>
           );
         }
 
         return (
-          <EuiFacetButton icon={<EuiIcon type="dot" color="success" />}>Enabled</EuiFacetButton>
+          <EuiFacetButton icon={<EuiIcon type="dot" color="success" aria-hidden={true} />}>
+            Enabled
+          </EuiFacetButton>
         );
       }
       return (
-        <EuiFacetButton icon={<EuiIcon type="dot" color="#DDDDDD" />}>Disabled</EuiFacetButton>
+        <EuiFacetButton icon={<EuiIcon type="dot" color="#DDDDDD" aria-hidden={true} />}>
+          Disabled
+        </EuiFacetButton>
       );
     }
 
     if (isMultiTenancyEnabled) {
       if (tenantName === dashboardsDefaultTenant) {
         return (
-          <EuiFacetButton icon={<EuiIcon type="dot" color="primary" />}>
+          <EuiFacetButton icon={<EuiIcon type="dot" color="primary" aria-hidden={true} />}>
             Default Tenant
           </EuiFacetButton>
         );
       }
-      return <EuiFacetButton icon={<EuiIcon type="dot" color="success" />}>Enabled</EuiFacetButton>;
+      return (
+        <EuiFacetButton icon={<EuiIcon type="dot" color="success" aria-hidden={true} />}>
+          Enabled
+        </EuiFacetButton>
+      );
     }
 
-    return <EuiFacetButton icon={<EuiIcon type="dot" color="#DDDDDD" />}>Disabled</EuiFacetButton>;
+    return (
+      <EuiFacetButton icon={<EuiIcon type="dot" color="#DDDDDD" aria-hidden={true} />}>
+        Disabled
+      </EuiFacetButton>
+    );
   }
 
   const columns = [

--- a/public/apps/configuration/panels/tenant-list/test/__snapshots__/edit-modal.test.tsx.snap
+++ b/public/apps/configuration/panels/tenant-list/test/__snapshots__/edit-modal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Permission edit modal Submit button text should be Create when user is creating tenant 1`] = `
 <EuiButton

--- a/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
+++ b/public/apps/configuration/panels/tenant-list/test/__snapshots__/tenant-list.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Tenant list AccessError component should load access error component: configure tab 1`] = `
 <AccessErrorComponent

--- a/public/apps/configuration/panels/tenant-list/test/edit-modal.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/test/edit-modal.test.tsx
@@ -38,7 +38,7 @@ describe('Permission edit modal', () => {
   it('Submit change', () => {
     component.find('#submit').simulate('click');
 
-    expect(handleSave).toBeCalled();
+    expect(handleSave).toHaveBeenCalled();
   });
 
   it('handle tenant description change', () => {
@@ -46,7 +46,7 @@ describe('Permission edit modal', () => {
       target: { value: 'dummy' },
     } as React.ChangeEvent<HTMLTextAreaElement>;
     component.find('[data-test-subj="tenant-description"]').simulate('change', event);
-    expect(setState).toBeCalledWith('dummy');
+    expect(setState).toHaveBeenCalledWith('dummy');
   });
 
   it('Submit button text should be Create when user is creating tenant', () => {

--- a/public/apps/configuration/panels/tenant-list/test/tenant-list.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/test/tenant-list.test.tsx
@@ -181,7 +181,7 @@ describe('Tenant list', () => {
     deleteFunc();
 
     process.nextTick(() => {
-      expect(mockTenantUtils.requestDeleteTenant).toBeCalled();
+      expect(mockTenantUtils.requestDeleteTenant).toHaveBeenCalled();
       done();
     });
   });
@@ -206,7 +206,7 @@ describe('Tenant list', () => {
     deleteFunc();
 
     process.nextTick(() => {
-      expect(loggingFunc).toBeCalled();
+      expect(loggingFunc).toHaveBeenCalled();
       done();
     });
   });
@@ -224,7 +224,7 @@ describe('Tenant list', () => {
     const submitFunc = component.find(TenantEditModal).prop('handleSave');
     submitFunc('tenant_1', '');
 
-    expect(mockTenantUtils.updateTenant).toBeCalled();
+    expect(mockTenantUtils.updateTenant).toHaveBeenCalled();
   });
 
   it('submit tenant error', () => {
@@ -247,7 +247,7 @@ describe('Tenant list', () => {
     submitFunc('tenant_1', '');
 
     // Expect error log
-    expect(consoleLog).toBeCalledWith(error);
+    expect(consoleLog).toHaveBeenCalledWith(error);
   });
 
   describe('Action menu enable-disable check', () => {
@@ -406,7 +406,7 @@ describe('Tenant list', () => {
 
     it('switchTenant click', () => {
       component.find('#switchTenant').simulate('click');
-      expect(mockTenantUtils.selectTenant).toBeCalled();
+      expect(mockTenantUtils.selectTenant).toHaveBeenCalled();
     });
 
     it('Edit click', () => {

--- a/public/apps/configuration/panels/test/__snapshots__/expression-modal.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/expression-modal.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Expression modal renders when isModalVisible = True 1`] = `
 <div>

--- a/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/get-started.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Get started (landing page) renders when backend configuration is disabled 1`] = `
 <Fragment>

--- a/public/apps/configuration/panels/test/__snapshots__/nav-panel.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/nav-panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Navigation panel renders 1`] = `
 <EuiSideNav

--- a/public/apps/configuration/panels/test/__snapshots__/role-list.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/role-list.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Role list AccessError component should load access error component 1`] = `
 <Fragment>
@@ -256,6 +256,7 @@ exports[`Role list Render columns render Customization column 1`] = `
     grow={false}
   >
     <EuiIcon
+      aria-hidden={true}
       type="lock"
     />
   </EuiFlexItem>

--- a/public/apps/configuration/panels/test/__snapshots__/user-list.test.tsx.snap
+++ b/public/apps/configuration/panels/test/__snapshots__/user-list.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`User list AccessError component should load access error component 1`] = `
 <Fragment>

--- a/public/apps/configuration/panels/test/role-list.test.tsx
+++ b/public/apps/configuration/panels/test/role-list.test.tsx
@@ -269,7 +269,7 @@ describe('Role list', () => {
     deleteFunc();
 
     process.nextTick(() => {
-      expect(mockRoleListUtils.requestDeleteRoles).toBeCalled();
+      expect(mockRoleListUtils.requestDeleteRoles).toHaveBeenCalled();
       done();
     });
   });
@@ -290,7 +290,7 @@ describe('Role list', () => {
     const deleteFunc = useDeleteConfirmState.mock.calls[0][0];
 
     deleteFunc();
-    expect(spy).toBeCalled();
+    expect(spy).toHaveBeenCalled();
   });
 
   describe('Action menu click', () => {

--- a/public/apps/configuration/panels/test/user-list.test.tsx
+++ b/public/apps/configuration/panels/test/user-list.test.tsx
@@ -121,8 +121,8 @@ describe('User list', () => {
         />
       );
 
-      expect(getUserList).toBeCalled();
-      expect(getAuthInfo).toBeCalled();
+      expect(getUserList).toHaveBeenCalled();
+      expect(getAuthInfo).toHaveBeenCalled();
     });
 
     it('fetch data error', () => {
@@ -142,7 +142,7 @@ describe('User list', () => {
       );
 
       // Expect error flag set to true
-      expect(setState).toBeCalledWith(true);
+      expect(setState).toHaveBeenCalledWith(true);
     });
 
     it('delete user', (done) => {
@@ -159,7 +159,7 @@ describe('User list', () => {
       deleteFunc();
 
       process.nextTick(() => {
-        expect(requestDeleteUsers).toBeCalled();
+        expect(requestDeleteUsers).toHaveBeenCalled();
         done();
       });
     });
@@ -184,7 +184,7 @@ describe('User list', () => {
       deleteFunc();
 
       process.nextTick(() => {
-        expect(loggingFunc).toBeCalled();
+        expect(loggingFunc).toHaveBeenCalled();
         done();
       });
     });

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -161,7 +161,9 @@ export function UserList(props: AppDependencies) {
       data-test-subj="edit"
       key="edit"
       onClick={() => {
-        window.location.href = buildHashUrl(ResourceType.users, Action.edit, selection[0].username);
+        window.location.assign(
+          buildHashUrl(ResourceType.users, Action.edit, selection[0].username)
+        );
       }}
       disabled={selection.length !== 1}
     >
@@ -171,10 +173,8 @@ export function UserList(props: AppDependencies) {
       data-test-subj="duplicate"
       key="duplicate"
       onClick={() => {
-        window.location.href = buildHashUrl(
-          ResourceType.users,
-          Action.duplicate,
-          selection[0].username
+        window.location.assign(
+          buildHashUrl(ResourceType.users, Action.duplicate, selection[0].username)
         );
       }}
       disabled={selection.length !== 1}

--- a/public/apps/configuration/test/__snapshots__/access-error-component.test.tsx.snap
+++ b/public/apps/configuration/test/__snapshots__/access-error-component.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`AccessErrorComponent should display custom message prefix once loading is complete 1`] = `
 <EuiPageContent>

--- a/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
+++ b/public/apps/configuration/test/__snapshots__/app-router.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SecurityPluginTopNavMenu does not include API Keys routes when api_keys is disabled 1`] = `
 <ContextProvider

--- a/public/apps/configuration/test/top-nav-menu.test.tsx
+++ b/public/apps/configuration/test/top-nav-menu.test.tsx
@@ -57,7 +57,7 @@ describe('SecurityPluginTopNavMenu', () => {
       />
     );
 
-    expect(dataSourceMenuMock).toBeCalled();
+    expect(dataSourceMenuMock).toHaveBeenCalled();
     expect(wrapper.html()).not.toBe('');
   });
 
@@ -79,7 +79,7 @@ describe('SecurityPluginTopNavMenu', () => {
       />
     );
 
-    expect(dataSourceMenuMock).not.toBeCalled();
+    expect(dataSourceMenuMock).not.toHaveBeenCalled();
     expect(wrapper.html()).toBe('');
   });
 });

--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -67,7 +67,7 @@ export function renderCustomization(reserved: boolean, props: UIProps) {
   return (
     <EuiFlexGroup alignItems="center" gutterSize="xs">
       <EuiFlexItem grow={false}>
-        <EuiIcon type={reserved ? 'lock' : 'pencil'} />
+        <EuiIcon type={reserved ? 'lock' : 'pencil'} aria-hidden={true} />
       </EuiFlexItem>
       <EuiFlexItem grow={false}>
         <EuiText
@@ -125,7 +125,13 @@ export const displayHeaderWithTooltip = (columnHeader: string, tooltipText: stri
     <EuiToolTip content={tooltipText}>
       <span>
         {columnHeader}{' '}
-        <EuiIcon size="s" color="subdued" type="questionInCircle" className="eui-alignTop" />
+        <EuiIcon
+          size="s"
+          color="subdued"
+          type="questionInCircle"
+          className="eui-alignTop"
+          aria-hidden={true}
+        />
       </span>
     </EuiToolTip>
   );

--- a/public/apps/configuration/utils/test/__snapshots__/display-utils.test.tsx.snap
+++ b/public/apps/configuration/utils/test/__snapshots__/display-utils.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Display utils Render Customization column when reserved = False 1`] = `
 <div
@@ -8,6 +8,7 @@ exports[`Display utils Render Customization column when reserved = False 1`] = `
     grow={false}
   >
     <EuiIcon
+      aria-hidden={true}
       type="pencil"
     />
   </EuiFlexItem>
@@ -32,6 +33,7 @@ exports[`Display utils Render Customization column when reserved = True 1`] = `
     grow={false}
   >
     <EuiIcon
+      aria-hidden={true}
       type="lock"
     />
   </EuiFlexItem>
@@ -98,6 +100,7 @@ exports[`Display utils Render header with tooltip 1`] = `
       Header
        
       <EuiIcon
+        aria-hidden={true}
         className="eui-alignTop"
         color="subdued"
         size="s"

--- a/public/apps/configuration/utils/test/__snapshots__/form-row.test.tsx.snap
+++ b/public/apps/configuration/utils/test/__snapshots__/form-row.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Form row renders 1`] = `
 <EuiCompressedFormRow

--- a/public/apps/configuration/utils/test/__snapshots__/panel-with-header.test.tsx.snap
+++ b/public/apps/configuration/utils/test/__snapshots__/panel-with-header.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Panel with header renders 1`] = `
 <EuiPanel>

--- a/public/apps/configuration/utils/test/__snapshots__/password-edit-panel.test.tsx.snap
+++ b/public/apps/configuration/utils/test/__snapshots__/password-edit-panel.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Password edit panel repeat password field update 1`] = `
 <Fragment>

--- a/public/apps/configuration/utils/test/__snapshots__/password-strength-bar.test.tsx.snap
+++ b/public/apps/configuration/utils/test/__snapshots__/password-strength-bar.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Password strength bar tests renders 1`] = `
 <EuiFlexGroup

--- a/public/apps/configuration/utils/test/password-edit-panel.test.tsx
+++ b/public/apps/configuration/utils/test/password-edit-panel.test.tsx
@@ -62,7 +62,7 @@ describe('Password edit panel', () => {
     process.nextTick(() => {
       expect(updatePassword).toHaveBeenCalledTimes(1);
       expect(updateIsInvalid).toHaveBeenCalledTimes(1);
-      expect(setState).toBeCalledWith(mockDashboardsInfo.password_validation_error_message);
+      expect(setState).toHaveBeenCalledWith(mockDashboardsInfo.password_validation_error_message);
       done();
     });
   });
@@ -79,7 +79,7 @@ describe('Password edit panel', () => {
       target: { value: 'dummy' },
     } as React.ChangeEvent<HTMLInputElement>;
     component.find('[data-test-subj="password"]').simulate('change', event);
-    expect(setState).toBeCalledWith('dummy');
+    expect(setState).toHaveBeenCalledWith('dummy');
   });
 
   it('repeat password field update', () => {
@@ -95,6 +95,6 @@ describe('Password edit panel', () => {
       target: { value: 'dummy' },
     } as React.ChangeEvent<HTMLInputElement>;
     component.find('[data-test-subj="re-enter-password"]').simulate('change', event);
-    expect(setState).toBeCalledWith('dummy');
+    expect(setState).toHaveBeenCalledWith('dummy');
   });
 });

--- a/public/apps/configuration/utils/test/request-utils.test.ts
+++ b/public/apps/configuration/utils/test/request-utils.test.ts
@@ -33,7 +33,7 @@ describe('RequestContext', () => {
   });
 
   it('should error if no dataSourceId is passed', () => {
-    expect(() => createRequestContextWithDataSourceId()).toThrowError();
+    expect(() => createRequestContextWithDataSourceId()).toThrow();
   });
 
   it('should have the correct query based on the passed dataSourceId', () => {

--- a/public/apps/customerror/test/__snapshots__/custom-error.test.tsx.snap
+++ b/public/apps/customerror/test/__snapshots__/custom-error.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Custom error page test renders and clicks the button on the error page 1`] = `
 <EuiListGroup

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -78,7 +78,7 @@ export function getNextPath(serverBasePath: string) {
 
 function redirect(serverBasePath: string) {
   // navigate to nextUrl
-  window.location.href = getNextPath(serverBasePath);
+  window.location.assign(getNextPath(serverBasePath));
 }
 
 export function extractNextUrlFromWindowLocation(): string {

--- a/public/apps/login/test/__snapshots__/login-page.test.tsx.snap
+++ b/public/apps/login/test/__snapshots__/login-page.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Login page renders renders with config value for multiauth 1`] = `
 <EuiListGroup

--- a/public/apps/login/test/login-page.test.tsx
+++ b/public/apps/login/test/login-page.test.tsx
@@ -76,52 +76,39 @@ const configUiDefault = {
 
 describe('test extractNextUrlFromWindowLocation', () => {
   test('extract next url from window with nextUrl', () => {
-    // Trick to mock window.location
-    const originalLocation = window.location;
-    delete window.location;
-    window.location = new URL(
+    // jest-location-mock: assign the full URL instead of replacing window.location.
+    window.location.assign(
       "http://localhost:5601/app/login?nextUrl=%2Fapp%2Fdashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(filters:!(),refreshInterval:(pause:!f,value:900000),time:(from:now-24h,to:now))&_a=(description:'Analyze%20mock%20flight%20data%20for%20OpenSearch-Air,%20Logstash%20Airways,%20OpenSearch%20Dashboards%20Airlines%20and%20BeatsWest',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'%5BFlights%5D%20Global%20Flight%20Dashboard',viewMode:view)"
-    ) as any;
+    );
     expect(extractNextUrlFromWindowLocation()).toEqual(
       "?nextUrl=%2Fapp%2Fdashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(filters:!(),refreshInterval:(pause:!f,value:900000),time:(from:now-24h,to:now))&_a=(description:'Analyze%20mock%20flight%20data%20for%20OpenSearch-Air,%20Logstash%20Airways,%20OpenSearch%20Dashboards%20Airlines%20and%20BeatsWest',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'%5BFlights%5D%20Global%20Flight%20Dashboard',viewMode:view)"
     );
   });
 
   test('extract next url from window without nextUrl', () => {
-    const originalLocation = window.location;
-    delete window.location;
-    window.location = new URL('http://localhost:5601/app/home');
+    window.location.assign('http://localhost:5601/app/home');
     expect(extractNextUrlFromWindowLocation()).toEqual('');
   });
 });
 
 describe('test redirect', () => {
   test('extract redirect excludes security_tenant when no tenant in local storage', () => {
-    // Trick to mock window.location
-    const originalLocation = window.location;
-    delete window.location;
-    window.location = new URL('http://localhost:5601/app/login?nextUrl=%2Fapp%2Fdashboards') as any;
+    window.location.assign('http://localhost:5601/app/login?nextUrl=%2Fapp%2Fdashboards');
     setSavedTenant(null);
     const nextPath = getNextPath('');
     expect(nextPath).toEqual('/app/dashboards');
-    window.location = originalLocation;
   });
 
   test('extract redirect includes security_tenant when tenant in local storage', () => {
-    const originalLocation = window.location;
-    delete window.location;
-    window.location = new URL('http://localhost:5601/app/login?nextUrl=%2Fapp%2Fdashboards');
+    window.location.assign('http://localhost:5601/app/login?nextUrl=%2Fapp%2Fdashboards');
     setSavedTenant('custom');
     const nextPath = getNextPath('');
     expect(nextPath).toEqual('/app/dashboards?security_tenant=custom');
     setSavedTenant(null);
-    window.location = originalLocation;
   });
 
   test('extract redirect includes security_tenant when tenant in local storage, existing url params and hash', () => {
-    const originalLocation = window.location;
-    delete window.location;
-    window.location = new URL(
+    window.location.assign(
       "http://localhost:5601/app/login?nextUrl=%2Fapp%2Fdashboards?param1=value1#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(filters:!(),refreshInterval:(pause:!f,value:900000),time:(from:now-24h,to:now))&_a=(description:'Analyze%20mock%20flight%20data%20for%20OpenSearch-Air,%20Logstash%20Airways,%20OpenSearch%20Dashboards%20Airlines%20and%20BeatsWest',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'%5BFlights%5D%20Global%20Flight%20Dashboard',viewMode:view)"
     );
     setSavedTenant('custom');
@@ -130,7 +117,6 @@ describe('test redirect', () => {
       "/app/dashboards?param1=value1&security_tenant=custom#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g=(filters:!(),refreshInterval:(pause:!f,value:900000),time:(from:now-24h,to:now))&_a=(description:'Analyze%20mock%20flight%20data%20for%20OpenSearch-Air,%20Logstash%20Airways,%20OpenSearch%20Dashboards%20Airlines%20and%20BeatsWest',filters:!(),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:''),timeRestore:!t,title:'%5BFlights%5D%20Global%20Flight%20Dashboard',viewMode:view)"
     );
     setSavedTenant(null);
-    window.location = originalLocation;
   });
 });
 
@@ -283,7 +269,7 @@ describe('Login page', () => {
         target: { value: 'dummy' },
       } as React.ChangeEvent<HTMLInputElement>;
       component.find('[data-test-subj="user-name"]').simulate('change', event);
-      expect(setState).toBeCalledWith('dummy');
+      expect(setState).toHaveBeenCalledWith('dummy');
     });
 
     it('should update password field on change event', () => {
@@ -291,7 +277,7 @@ describe('Login page', () => {
         target: { value: 'dummy' },
       } as React.ChangeEvent<HTMLInputElement>;
       component.find('[data-test-subj="password"]').simulate('change', event);
-      expect(setState).toBeCalledWith('dummy');
+      expect(setState).toHaveBeenCalledWith('dummy');
     });
   });
 
@@ -314,13 +300,7 @@ describe('Login page', () => {
     });
 
     it('submit click event', () => {
-      window = Object.create(window);
-      const url = 'http://dummy.com';
-      Object.defineProperty(window, 'location', {
-        value: {
-          href: url,
-        },
-      });
+      // jest-location-mock handles navigation; no need to stub window.location.
       component.find('[data-test-subj="submit"]').simulate('click', {
         preventDefault: () => {},
       });

--- a/public/apps/resource-sharing/resource-sharing-panel.tsx
+++ b/public/apps/resource-sharing/resource-sharing-panel.tsx
@@ -360,7 +360,7 @@ const ShareAccessModal: React.FC<ModalProps> = ({
         <EuiSpacer size="m" />
         {!isSubmitting && errorLines.length > 0 && (
           <>
-            <EuiCallOut title="Request failed" color="danger" iconType="alert">
+            <EuiCallOut announceOnMount title="Request failed" color="danger" iconType="alert">
               <ul style={{ margin: 0, paddingLeft: 18 }}>
                 {errorLines.map((l, i) => (
                   <li key={i}>{l}</li>
@@ -372,7 +372,7 @@ const ShareAccessModal: React.FC<ModalProps> = ({
         )}
         {isInvalid && (
           <>
-            <EuiCallOut title="Add recipients" color="warning" iconType="alert">
+            <EuiCallOut announceOnMount title="Add recipients" color="warning" iconType="alert">
               The following access-levels have no recipients: {levelsWithNoRecipients.join(', ')}
             </EuiCallOut>
             <EuiSpacer size="s" />

--- a/public/utils/logout-utils.tsx
+++ b/public/utils/logout-utils.tsx
@@ -33,7 +33,7 @@ export function interceptError(logoutUrl: string, thisWindow: Window): any {
         thisWindow.location.pathname.toLowerCase().includes(CUSTOM_ERROR_PAGE_URI)
       )) {
         if (logoutUrl) {
-          thisWindow.location.href = logoutUrl;
+          thisWindow.location.assign(logoutUrl);
         } else {
           // when session timed out, user credentials in cookie are wiped out
           // refres the page will direct the user to go through login process

--- a/public/utils/test/datasource-utils.test.ts
+++ b/public/utils/test/datasource-utils.test.ts
@@ -28,28 +28,19 @@ describe('Tests datasource utils', () => {
   });
 
   it('Tests getting the datasource from the url', () => {
-    const mockSearchNoDataSourceId = '?foo=bar&baz=qux';
-    Object.defineProperty(window, 'location', {
-      value: { search: mockSearchNoDataSourceId },
-      writable: true,
-    });
+    // jest-location-mock: drive window.location.search via assign() with full URLs.
+    window.location.assign('http://localhost:5601/?foo=bar&baz=qux');
     expect(getDataSourceFromUrl()).toEqual({});
-    const mockSearchDataSourceIdNotfirst =
-      '?foo=bar&baz=qux&dataSource=%7B"id"%3A"94ffa650-f11a-11ee-a585-793f7b098e1a"%2C"label"%3A"9202"%7D';
-    Object.defineProperty(window, 'location', {
-      value: { search: mockSearchDataSourceIdNotfirst },
-      writable: true,
-    });
+    window.location.assign(
+      'http://localhost:5601/?foo=bar&baz=qux&dataSource=%7B"id"%3A"94ffa650-f11a-11ee-a585-793f7b098e1a"%2C"label"%3A"9202"%7D'
+    );
     expect(getDataSourceFromUrl()).toEqual({
       id: '94ffa650-f11a-11ee-a585-793f7b098e1a',
       label: '9202',
     });
-    const mockSearchDataSourceIdFirst =
-      '?dataSource=%7B"id"%3A"94ffa650-f11a-11ee-a585-793f7b098e1a"%2C"label"%3A"9202"%7D';
-    Object.defineProperty(window, 'location', {
-      value: { search: mockSearchDataSourceIdFirst },
-      writable: true,
-    });
+    window.location.assign(
+      'http://localhost:5601/?dataSource=%7B"id"%3A"94ffa650-f11a-11ee-a585-793f7b098e1a"%2C"label"%3A"9202"%7D'
+    );
     expect(getDataSourceFromUrl()).toEqual({
       id: '94ffa650-f11a-11ee-a585-793f7b098e1a',
       label: '9202',
@@ -57,18 +48,13 @@ describe('Tests datasource utils', () => {
   });
 
   it('Tests setting the datasource in the url', () => {
-    const replaceState = jest.fn();
     const mockUrl = 'http://localhost:5601/app/security-dashboards-plugin#/auth';
-    Object.defineProperty(window, 'location', {
-      value: { href: mockUrl },
-      writable: true,
-    });
-    Object.defineProperty(window, 'history', {
-      value: { replaceState },
-      writable: true,
-    });
+    window.location.assign(mockUrl);
+    // Spy on the real history.replaceState rather than replacing window.history,
+    // which jest-location-mock's afterEach reset hook relies on (needs pushState).
+    const replaceState = jest.spyOn(window.history, 'replaceState').mockImplementation();
     setDataSourceInUrl({ id: '', label: 'Local cluster' });
-    expect(replaceState).toBeCalledWith(
+    expect(replaceState).toHaveBeenCalledWith(
       {},
       '',
       'http://localhost:5601/app/security-dashboards-plugin?dataSource=%7B%22id%22%3A%22%22%2C%22label%22%3A%22Local+cluster%22%7D#/auth'
@@ -76,11 +62,7 @@ describe('Tests datasource utils', () => {
   });
 
   it('Tests getting the datasource from the url with undefined dataSource', () => {
-    const mockSearchUndefinedDataSource = '?dataSource=undefined';
-    Object.defineProperty(window, 'location', {
-      value: { search: mockSearchUndefinedDataSource },
-      writable: true,
-    });
+    window.location.assign('http://localhost:5601/?dataSource=undefined');
     expect(getDataSourceFromUrl()).toEqual({});
   });
 

--- a/server/auth/types/openid/openid_auth.test.ts
+++ b/server/auth/types/openid/openid_auth.test.ts
@@ -310,7 +310,7 @@ describe('test OpenId authHeaderValue', () => {
     });
 
     expect(await openIdAuthentication.isValidCookie(testCookie, {})).toBe(true);
-    expect(mockClient.post).toBeCalledTimes(1);
+    expect(mockClient.post).toHaveBeenCalledTimes(1);
     global.Date.now = realDateNow;
   });
 
@@ -421,7 +421,7 @@ describe('Test OpenID Unauthorized Flows', () => {
 
     openIdAuthentication.handleUnauthedRequest(osRequest, mockLifecycleFactory, authToolkit);
 
-    expect(mockLifecycleFactory.unauthorized).toBeCalledTimes(1);
+    expect(mockLifecycleFactory.unauthorized).toHaveBeenCalledTimes(1);
   });
 
   test('Ensure request without path redirects to default route', () => {

--- a/server/readonly/readonly_service.test.ts
+++ b/server/readonly/readonly_service.test.ts
@@ -184,7 +184,7 @@ describe('checks isReadonly', () => {
     const service = getService();
     service.isAnonymousPage = jest.fn(() => true);
     await service.isReadonly(httpServerMock.createOpenSearchDashboardsRequest());
-    expect(service.isAnonymousPage).toBeCalled();
+    expect(service.isAnonymousPage).toHaveBeenCalled();
   });
   it('calls isReadOnlyTenant with correct authinfo', async () => {
     const cookie = mockCookie({ tenant: 'readonly_tenant' });

--- a/test/jest.config.server.js
+++ b/test/jest.config.server.js
@@ -24,6 +24,10 @@ export default {
     // Use a plugin-local shim that resolves relative to its own file location instead.
     '^query-string$':
       '<rootDir>/plugins/security-dashboards-plugin/test/mocks/query_string_mock.js',
+    // Under Jest 30's stricter package "exports" resolution, `import ... from 'jose'` resolves
+    // to jose's pure-ESM `browser` build (dist/browser/index.js), which Jest can't parse
+    // ("Unexpected token 'export'"). Pin it to the CommonJS build the `require` condition uses.
+    '^jose$': '<rootDir>/plugins/security-dashboards-plugin/node_modules/jose/dist/node/cjs/index.js',
   },
   roots: ['<rootDir>/plugins/security-dashboards-plugin'],
   testMatch: ['**/test/jest_integration/**/*.test.ts', '**/server/**/*.test.ts'],

--- a/test/jest.config.server.js
+++ b/test/jest.config.server.js
@@ -17,12 +17,24 @@ import config from '../../../src/dev/jest/config';
 
 export default {
   ...config,
+  moduleNameMapper: {
+    ...config.moduleNameMapper,
+    // The shared query-string shim resolves the package via process.cwd(), which the
+    // plugin's custom test runner leaves pointing at the plugin dir (no node_modules there).
+    // Use a plugin-local shim that resolves relative to its own file location instead.
+    '^query-string$':
+      '<rootDir>/plugins/security-dashboards-plugin/test/mocks/query_string_mock.js',
+  },
   roots: ['<rootDir>/plugins/security-dashboards-plugin'],
   testMatch: ['**/test/jest_integration/**/*.test.ts', '**/server/**/*.test.ts'],
   testPathIgnorePatterns: config.testPathIgnorePatterns.filter(
     (pattern) => !pattern.includes('integration_tests')
   ),
+  // Preserve the base setupFilesAfterEnv chain (jest-location-mock is a harmless
+  // no-op in node env; mocks.js guards its window-dependent mocks), then keep the
+  // plugin-specific integration timeout and TextEncoder/TextDecoder polyfill.
   setupFilesAfterEnv: [
+    ...config.setupFilesAfterEnv,
     '<rootDir>/src/dev/jest/setup/after_env.integration.js',
     '<rootDir>/plugins/security-dashboards-plugin/test/setup/after_env.js',
   ],

--- a/test/jest.config.server.js
+++ b/test/jest.config.server.js
@@ -27,7 +27,8 @@ export default {
     // Under Jest 30's stricter package "exports" resolution, `import ... from 'jose'` resolves
     // to jose's pure-ESM `browser` build (dist/browser/index.js), which Jest can't parse
     // ("Unexpected token 'export'"). Pin it to the CommonJS build the `require` condition uses.
-    '^jose$': '<rootDir>/plugins/security-dashboards-plugin/node_modules/jose/dist/node/cjs/index.js',
+    '^jose$':
+      '<rootDir>/plugins/security-dashboards-plugin/node_modules/jose/dist/node/cjs/index.js',
   },
   roots: ['<rootDir>/plugins/security-dashboards-plugin'],
   testMatch: ['**/test/jest_integration/**/*.test.ts', '**/server/**/*.test.ts'],

--- a/test/jest.config.ui.js
+++ b/test/jest.config.ui.js
@@ -17,13 +17,27 @@ import config from '../../../src/dev/jest/config';
 
 export default {
   ...config,
+  moduleNameMapper: {
+    ...config.moduleNameMapper,
+    // The shared query-string shim resolves the package via process.cwd(), which the
+    // plugin's custom test runner leaves pointing at the plugin dir (no node_modules there).
+    // Use a plugin-local shim that resolves relative to its own file location instead.
+    '^query-string$':
+      '<rootDir>/plugins/security-dashboards-plugin/test/mocks/query_string_mock.js',
+  },
   roots: ['<rootDir>/plugins/security-dashboards-plugin'],
   testMatch: ['**/public/**/*.test.{ts,tsx,js,jsx}', '**/common/*.test.{ts, tsx}'],
   testPathIgnorePatterns: [
     '<rootDir>/plugins/security-dashboards-plugin/build/',
     '<rootDir>/plugins/security-dashboards-plugin/node_modules/',
   ],
-  setupFilesAfterEnv: ['<rootDir>/src/dev/jest/setup/after_env.integration.js'],
+  // Preserve the base setupFilesAfterEnv chain (jest-location-mock, mocks.js which
+  // provides matchMedia/localStorage/HOST for jsdom 26, react_testing_library, monaco_mock)
+  // which the previous override dropped, then keep the plugin-specific integration timeout.
+  setupFilesAfterEnv: [
+    ...config.setupFilesAfterEnv,
+    '<rootDir>/src/dev/jest/setup/after_env.integration.js',
+  ],
   collectCoverageFrom: [
     '<rootDir>/plugins/security-dashboards-plugin/public/**/*.{ts,tsx}',
     '!<rootDir>/plugins/security-dashboards-plugin/public/**/*.test.{ts,tsx}',

--- a/test/mocks/query_string_mock.js
+++ b/test/mocks/query_string_mock.js
@@ -1,0 +1,40 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+/**
+ * Plugin-local variant of src/dev/jest/mocks/query_string_mock.js.
+ *
+ * The shared base mock resolves query-string via `process.cwd()`, assuming cwd is
+ * the OpenSearch Dashboards repo root. This plugin runs Jest through its own runner
+ * (test/run_jest_tests.js), which leaves process.cwd() pointing at the plugin
+ * directory (which has no node_modules/query-string). Resolve the package relative
+ * to this file instead so it works regardless of cwd.
+ */
+
+const path = require('path');
+
+// This file lives at <repoRoot>/plugins/security-dashboards-plugin/test/mocks/.
+// Walk back up to the repo root to reach the hoisted node_modules/query-string.
+const repoRoot = path.resolve(__dirname, '../../../..');
+
+// eslint-disable-next-line import/no-dynamic-require
+const mod = require(path.resolve(repoRoot, 'node_modules/query-string/index.js'));
+
+const api = mod && mod.__esModule && typeof mod.stringify !== 'function' ? mod.default : mod;
+
+module.exports = {
+  __esModule: true,
+  default: api,
+};


### PR DESCRIPTION
Closes #2474

### Description

Migrate this plugin's Jest test suites to run under **Jest 30.4.2 + jsdom 26.1.0**, following the
core OpenSearch-Dashboards upgrade in opensearch-project/OpenSearch-Dashboards#12381. The plugin
runs its tests against the parent repo's jest binary (via `test/run_jest_tests.js`), so it breaks
once the core upgrade lands.

This plugin ships **two** Jest suites, driven by separate configs and npm scripts:

- **`yarn test:jest_ui`** (`test/jest.config.ui.js`) — browser/jsdom tests under `public/`.
  **Result:** `76 suites / 475 tests / 70 snapshots passed`, exit 0.
- **`yarn test:jest_server`** (`test/jest.config.server.js`) — server-side tests under `server/`
  **plus** the `test/jest_integration/**` suites. The 16 pure unit suites are green:
  `16 suites / 107 tests / 0 snapshots passed`, exit 0 (run with
  `--testPathIgnorePatterns jest_integration`).

> **Note on `jest_integration`:** the server config also globs in the 6 `test/jest_integration/*.test.ts`
> suites (`basic_auth`, `security_entity_api`, `proxy_multiauth`, `multi_tenancy`, `jwt_multiauth`,
> `jwt_auth`). These spin up a real OpenSearch Dashboards server and require a **live OpenSearch
> cluster on `localhost:9200`** (plus `ADMIN_PASSWORD`); without one they fail with
> `ECONNREFUSED 127.0.0.1:9200`. They are environment-dependent and out of scope for the Jest 30
> migration's green-suite verification.

#### Common changes (shared across the plugin-migration campaign)
- **Configs (`test/jest.config.ui.js`, `test/jest.config.server.js`):** both previously spread the
  shared base `config` but then **overwrote** `setupFilesAfterEnv` with only their own entries,
  dropping the base chain. Restored the base chain by spreading `...config.setupFilesAfterEnv`
  first, then re-appending the plugin's own setup files. This brings back `jest-location-mock`,
  `mocks.js` (which supplies `matchMedia` / `localStorage` / `HOST` for jsdom 26),
  `react_testing_library`, and `monaco_mock` — all required under Jest 30 / jsdom 26.
- **Matcher codemod:** `toThrowError` → `toThrow` and `toBeCalled*` → `toHaveBeenCalled*` across the
  test files (Jest 30 removed the aliases). Applied in both UI and server test files (e.g.
  `request-utils.test.ts`, `openid_auth.test.ts`, `readonly_service.test.ts`, and the account /
  configuration UI tests).
- **Snapshots:** bumped the snapshot header URL (`goo.gl/fbAQLP` → `jestjs.io/docs/snapshot-testing`)
  across 28 `.snap` files — Jest 30 refuses to load the old header. Only 2 files had non-header
  content changes, and both are driven by the `aria-hidden` source edits below
  (`display-utils.test.tsx.snap`, `role-list.test.tsx.snap`); no serialization-only or content
  regressions elsewhere.

#### Plugin-specific changes
- **query-string ESM resolution (`test/mocks/query_string_mock.js`, new file):** the shared core
  shim (`src/dev/jest/mocks/query_string_mock.js`) resolves `query-string` via `process.cwd()`,
  assuming cwd is the repo root. This plugin runs Jest through its own runner
  (`test/run_jest_tests.js`), which leaves `process.cwd()` pointing at the plugin directory (no
  `node_modules/query-string` there), so the shim throws. Added a plugin-local shim that resolves
  the package relative to its own file location (walking up to the hoisted repo-root
  `node_modules/query-string`), and wired it via `moduleNameMapper` `'^query-string$'` in **both**
  jest configs.
- **`window.location` (jsdom 26 makes it non-configurable):** the old tests used the
  `delete window.location; window.location = new URL(...)` trick and
  `Object.defineProperty(window, 'location', ...)`, which no longer work under jsdom 26. Migrated
  to `jest-location-mock`:
  - Source: changed 17 `public/` source files from `window.location.href = X` to
    `window.location.assign(X)` (e.g. `account/utils.tsx`, `account/account-nav-button.tsx`,
    `configuration/panels/tenant-list/manage_tab.tsx`, `configuration/panels/role-view/role-view.tsx`,
    `login/login-page.tsx`, `utils/logout-utils.tsx`, and the other role/user/audit-logging panels).
  - Tests: rewrote the location-mocking in `account-app.test.tsx`, `account-nav-button.test.tsx`,
    `switch-tenants.test.tsx`, `login-page.test.tsx`, and `datasource-utils.test.ts` to drive
    `window.location.assign(fullUrl)` and assert on the `jest-location-mock` `assign` spy, removing
    the `delete window.location` / `defineProperty` scaffolding.
- **`window.history` in `datasource-utils.test.ts`:** replaced `Object.defineProperty(window,
  'history', ...)` with `jest.spyOn(window.history, 'replaceState')` so `jest-location-mock`'s
  `afterEach` reset hook (which relies on the real `history.pushState`) keeps working.
- **`react-dom/server` / `TextEncoder` on the server suite:** the server config's
  `test/setup/after_env.js` (already present) polyfills `TextEncoder`/`TextDecoder` from `util`,
  needed under jsdom 26 for server-side tests. This is preserved by the `setupFilesAfterEnv` fix
  above (the previous override would have dropped ordering relative to the base chain).
- **`aria-hidden` on decorative `EuiIcon`s:** the newer EUI shipped with the Jest 30 stack renders
  differently; added `aria-hidden={true}` to decorative icons in `display-utils.tsx`,
  `manage_tab.tsx` (plus an `announceOnMount` on an `EuiCallOut`), and other configuration panels,
  and regenerated the 2 affected snapshots to match.

No `package.json` change was needed — the plugin inherits the parent repo's Jest 30 stack.

### Issues Resolved

Part of the Jest 30 + jsdom 26 migration campaign (core: opensearch-project/OpenSearch-Dashboards#12381).
<!-- Closes #<this-plugin-issue> -->

### Testing

- `yarn test:jest_ui --ci` → `76 suites / 475 tests / 70 snapshots passed`, exit 0.
- `yarn test:jest_server --ci --testPathIgnorePatterns jest_integration` →
  `16 suites / 107 tests passed`, exit 0.
- The 6 `test/jest_integration/**` suites require a live OpenSearch cluster on `localhost:9200`
  (with `ADMIN_PASSWORD`) and were not run in this environment.

### Check List
- [x] New functionality includes testing
  - [x] All tests pass (both `test:jest_ui` and `test:jest_server` unit suites; `jest_integration`
    requires a live `:9200` cluster)
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
