### PR TITLE
Disable multi-tenancy in multi-data-source tests

### DIFF
--- a/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
@@ -42,6 +42,8 @@ jobs:
             config_version: 2
           config:
             dynamic:
+              kibana:
+                multitenancy_enabled: false
               http:
                 anonymous_auth_enabled: false
               authc:
@@ -56,6 +58,7 @@ jobs:
                   authentication_backend:
                     type: intern
           EOT
+          cp config_custom.yml config_custom_remote.yml
 
       - name: Download security plugin and create setup scripts
         uses: ./.github/actions/download-plugin
@@ -72,7 +75,7 @@ jobs:
           plugins: "file:$(pwd)/opensearch-security.zip"
           security-enabled: true
           admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
-          security_config_file: config_custom.yml
+          security_config_file: config_custom_remote.yml
           port: 9202
           jdk-version: 21
           resource-sharing-enabled: true
@@ -94,8 +97,7 @@ jobs:
           opensearch.username: "kibanaserver"
           opensearch.password: "kibanaserver"
           opensearch.requestHeadersWhitelist: [ authorization,securitytenant ]
-          opensearch_security.multitenancy.enabled: true
-          opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
+          opensearch_security.multitenancy.enabled: false
           opensearch_security.readonly_mode.roles: ["kibana_read_only"]
           opensearch_security.cookie.secure: false
           data_source.enabled: true
@@ -106,6 +108,7 @@ jobs:
       - name: Run Cypress Tests
         uses: ./.github/actions/run-cypress-tests
         with:
+          security_config_file: config_custom.yml
           dashboards_config_file: opensearch_dashboards_multidatasources.yml
           yarn_command: 'CYPRESS_VERIFY_TIMEOUT=60000 yarn cypress:run --browser chrome --headless --env LOGIN_AS_ADMIN=true --spec "test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js"'
           resource_sharing_enabled: "true"

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -71,7 +71,6 @@ let localDataSourceUrl;
 
 describe('Multi-datasources enabled', () => {
   beforeEach(() => {
-    localStorage.setItem('opendistro::security::tenant::saved', '""');
     localStorage.setItem('home:newThemeModal:show', 'false');
     createDataSource().then((resp) => {
       if (resp && resp.body) {
@@ -154,14 +153,6 @@ describe('Multi-datasources enabled', () => {
       cy.get('[data-test-subj="tableHeaderCell_name_0"]').click();
       cy.get('[data-test-subj="checkboxSelectRow-9202-permission"]').should('exist');
     });
-  });
-
-  it('Checks Tenancy Tab', () => {
-    // Datasource is locked to local cluster for tenancy tab
-    cy.visit(`http://localhost:5601/app/security-dashboards-plugin${localDataSourceUrl}#/tenants`);
-
-    cy.contains('h1', 'Dashboards multi-tenancy');
-    cy.get('[data-test-subj="dataSourceViewButton"]').should('contain', 'Local cluster');
   });
 
   it('Checks Audit Logs Tab', () => {

--- a/test/jest_integration/security_entity_api.test.ts
+++ b/test/jest_integration/security_entity_api.test.ts
@@ -463,7 +463,7 @@ describe('start OpenSearch Dashboards server multi datasources enabled', () => {
           password: OPENSEARCH_DASHBOARDS_SERVER_PASSWORD,
         },
         opensearch_security: {
-          multitenancy: { enabled: true, tenants: { preferred: ['Private', 'Global'] } },
+          multitenancy: { enabled: false },
         },
       },
       {


### PR DESCRIPTION
## Summary

- disable Security multi-tenancy in the multi-data-source Cypress workflow
- apply the same backend Security configuration to both local and remote OpenSearch fixtures
- remove the tenancy-only assertion from the MDS Cypress specification
- align the multi-data-source server integration suite with the non-multitenant configuration

## Root cause

The multi-data-source workflow enabled both MDS and Security multi-tenancy. Data source saved objects were therefore created in the caller's tenant, while the credential lookup used the internal Dashboards user and could not find the tenant-specific object. The resulting `Saved object [data-source/<id>] not found` errors caused the Security MDS tests to fail consistently.

MDS and Security multi-tenancy are intended to be mutually exclusive. This change runs the MDS coverage in the supported non-multitenant configuration instead of changing Dashboards credential lookup behavior to support the invalid combination.

## Validation

- multi-data-source server integration block: 6 tests passed against two local OpenSearch clusters with unmodified Dashboards core
- ESLint passed for the modified JavaScript and TypeScript tests
- Prettier passed for the modified JavaScript and TypeScript tests
- workflow YAML parsed successfully
- `git diff --check` passed
