### PR TITLE
Derive login page title from branding applicationTitle

### DIFF
--- a/public/apps/login/login-app.tsx
+++ b/public/apps/login/login-app.tsx
@@ -26,8 +26,14 @@ export function renderApp(
   params: AppMountParameters,
   config: ClientConfigType
 ) {
+  const applicationTitle = coreStart.injectedMetadata?.getBranding()?.applicationTitle;
   ReactDOM.render(
-    <LoginPage http={coreStart.http} chrome={coreStart.chrome} config={config} />,
+    <LoginPage
+      http={coreStart.http}
+      chrome={coreStart.chrome}
+      config={config}
+      applicationTitle={applicationTitle}
+    />,
     params.element
   );
   return () => ReactDOM.unmountComponentAtNode(params.element);

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -42,6 +42,8 @@ interface LoginPageDeps {
   http: CoreStart['http'];
   chrome: CoreStart['chrome'];
   config: ClientConfigType;
+  // `opensearchDashboards.branding.applicationTitle`, if customized
+  applicationTitle?: string;
 }
 
 interface LoginButtonConfig {
@@ -290,7 +292,8 @@ export function LoginPage(props: LoginPageDeps) {
       )}
       <EuiSpacer size="s" />
       <EuiText size="m" textAlign="center">
-        {props.config.ui.basicauth.login.title || 'Log in to OpenSearch Dashboards'}
+        {props.config.ui.basicauth.login.title ||
+          `Log in to ${props.applicationTitle || 'OpenSearch Dashboards'}`}
       </EuiText>
       <EuiSpacer size="s" />
       <EuiText size="s" textAlign="center">

--- a/public/apps/login/test/login-app.test.tsx
+++ b/public/apps/login/test/login-app.test.tsx
@@ -1,0 +1,75 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+/**
+ * @jest-environment jsdom
+ */
+import { renderApp } from '../login-app';
+import { AuthType } from '../../../../common';
+
+function mockCoreStart(applicationTitle?: string) {
+  return {
+    http: {
+      basePath: {
+        serverBasePath: '',
+      },
+    },
+    chrome: {
+      logos: { OpenSearch: { url: '' } },
+    },
+    injectedMetadata: {
+      getBranding: jest.fn(() => ({ applicationTitle })),
+    },
+  } as any;
+}
+
+const config = {
+  ui: {
+    basicauth: {
+      login: {
+        title: '',
+        subtitle: '',
+        showbrandimage: false,
+        brandimage: '',
+        buttonstyle: '',
+      },
+    },
+  },
+  auth: {
+    type: AuthType.BASIC,
+  },
+} as any;
+
+describe('Login app', () => {
+  it('renders login title derived from branding applicationTitle', () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+
+    const unmount = renderApp(mockCoreStart('My Custom Analytics'), { element } as any, config);
+
+    expect(element.textContent).toContain('Log in to My Custom Analytics');
+    unmount();
+  });
+
+  it('renders default login title when branding applicationTitle is not set', () => {
+    const element = document.createElement('div');
+    document.body.appendChild(element);
+
+    const unmount = renderApp(mockCoreStart(), { element } as any, config);
+
+    expect(element.textContent).toContain('Log in to OpenSearch Dashboards');
+    unmount();
+  });
+});

--- a/public/apps/login/test/login-page.test.tsx
+++ b/public/apps/login/test/login-page.test.tsx
@@ -247,6 +247,53 @@ describe('Login page', () => {
     });
   });
 
+  describe('renders login title', () => {
+    const config: ClientConfigType = {
+      ui: configUiDefault,
+      auth: {
+        type: AuthType.BASIC,
+      },
+    } as any;
+
+    it('renders default title when login title and branding applicationTitle are not configured', () => {
+      const component = shallow(
+        <LoginPage http={mockHttpStart as any} chrome={chrome} config={config as any} />
+      );
+      expect(component.contains('Log in to OpenSearch Dashboards')).toBe(true);
+    });
+
+    it('renders title derived from branding applicationTitle when login title is not configured', () => {
+      const component = shallow(
+        <LoginPage
+          http={mockHttpStart as any}
+          chrome={chrome}
+          config={config as any}
+          applicationTitle="My Custom Analytics"
+        />
+      );
+      expect(component.contains('Log in to My Custom Analytics')).toBe(true);
+    });
+
+    it('renders configured login title over branding applicationTitle', () => {
+      const configWithTitle: ClientConfigType = {
+        ui: configUI,
+        auth: {
+          type: AuthType.BASIC,
+        },
+      } as any;
+      const component = shallow(
+        <LoginPage
+          http={mockHttpStart as any}
+          chrome={chrome}
+          config={configWithTitle as any}
+          applicationTitle="My Custom Analytics"
+        />
+      );
+      expect(component.contains('Title1')).toBe(true);
+      expect(component.contains('Log in to My Custom Analytics')).toBe(false);
+    });
+  });
+
   describe('event trigger testing', () => {
     let component;
     const setState = jest.fn();

--- a/server/index.ts
+++ b/server/index.ts
@@ -135,7 +135,9 @@ export const configSchema = schema.object({
     }),
     loadbalancer_url: schema.maybe(schema.string()),
     login: schema.object({
-      title: schema.string({ defaultValue: 'Log in to OpenSearch Dashboards' }),
+      // An empty title means the login page falls back to a title derived from
+      // `opensearchDashboards.branding.applicationTitle` on the browser side.
+      title: schema.string({ defaultValue: '' }),
       subtitle: schema.string({
         defaultValue:
           'If you have forgotten your username or password, contact your system administrator.',
@@ -252,7 +254,9 @@ export const configSchema = schema.object({
       // the login config here is the same as old config `_security.basicauth.login`
       // Since we are now rendering login page to browser app, so move these config to browser side.
       login: schema.object({
-        title: schema.string({ defaultValue: 'Log in to OpenSearch Dashboards' }),
+        // An empty title means the login page falls back to a title derived from
+        // `opensearchDashboards.branding.applicationTitle` on the browser side.
+        title: schema.string({ defaultValue: '' }),
         subtitle: schema.string({
           defaultValue:
             'If you have forgotten your username or password, contact your system administrator.',


### PR DESCRIPTION
### Description

The login page always shows "Log in to OpenSearch Dashboards" even when a custom `opensearchDashboards.branding.applicationTitle` is configured. There were two parts to this:

1. `public/apps/login/login-page.tsx` hardcoded `'Log in to OpenSearch Dashboards'` as the JSX fallback.
2. The config schema in `server/index.ts` defaulted `ui.basicauth.login.title` (and the legacy `basicauth.login.title`) to that same string, so the config value exposed to the browser was never empty and the JSX fallback was dead code anyway.

This PR:

- Changes the schema defaults for `basicauth.login.title` and `ui.basicauth.login.title` from `'Log in to OpenSearch Dashboards'` to `''`, so the browser can tell "not configured" apart from an explicit title.
- Reads `branding.applicationTitle` via `coreStart.injectedMetadata.getBranding()` in `renderApp` (the same pattern used by the overview-page fix in opensearch-project/OpenSearch-Dashboards#11555) and passes it to `LoginPage` as a new optional `applicationTitle` prop. `ChromeStart` only exposes `logos`, not the branding title, so the branding cannot be read from the existing `chrome` prop.
- Uses `Log in to ${applicationTitle}` as the title fallback, with `'OpenSearch Dashboards'` as the final fallback when no branding title is set.

An explicitly configured `opensearch_security.ui.basicauth.login.title` still takes precedence over the branding-derived title, and installs without custom branding render exactly the same text as before.

### Category

Bug fix

### Why these changes are required?

Admins who rebrand OpenSearch Dashboards via `opensearchDashboards.branding.applicationTitle` expect the login page to follow the rebrand without having to separately configure `opensearch_security.ui.basicauth.login.title`.

### What is the old behavior before changes and new behavior after changes?

**Old:** With `opensearchDashboards.branding.applicationTitle: "My Custom Analytics"` and no explicit security login title, the login page shows "Log in to OpenSearch Dashboards".

**New:** The same configuration shows "Log in to My Custom Analytics". With no branding configured, the title is unchanged ("Log in to OpenSearch Dashboards"). An explicit `opensearch_security.ui.basicauth.login.title` wins in both cases.

### Issues Resolved

Resolves #2406
Related: #915, opensearch-project/OpenSearch-Dashboards#3049, and [this comment](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11555#issuecomment-4188392196) on opensearch-project/OpenSearch-Dashboards#11555

### Testing

- Added unit tests covering: default title with no branding, branding-derived title, and explicit config title taking precedence over branding.
- Full UI jest suite passes inside an OpenSearch-Dashboards checkout: 76 suites, 478 tests, 70 snapshots (all existing login-page snapshots unchanged, confirming no render change for unbranded installs).
- `eslint` clean on all changed files.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
