### PR TITLE
Retry sample-resource-plugin gradle build to absorb Eclipse formatter download timeouts

### DIFF
--- a/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-resource-sharing-enabled-e2e.yml
@@ -67,8 +67,21 @@ jobs:
 
           pushd security-src
             chmod +x ./gradlew
-            # Build the sample resource plugin
-            ./gradlew :opensearch-sample-resource-plugin:assemble
+            # Build the sample resource plugin. Retried because the Spotless
+            # Eclipse JDT formatter is resolved at Gradle configuration time and
+            # its download intermittently times out (SocketTimeoutException),
+            # failing the build before any task runs. See issue #2504.
+            for attempt in 1 2 3; do
+              if ./gradlew :opensearch-sample-resource-plugin:assemble; then
+                break
+              elif [ "$attempt" -eq 3 ]; then
+                echo "Build failed after $attempt attempts"
+                exit 1
+              else
+                echo "Build attempt $attempt failed; retrying in $((attempt * 30))s..."
+                sleep $((attempt * 30))
+              fi
+            done
             ZIP_PATH=$(ls -t sample-resource-plugin/build/distributions/*.zip | head -n1)
             echo "Built sample plugin: $ZIP_PATH"
             cp "$ZIP_PATH" "$GITHUB_WORKSPACE/sample-resource-plugin.zip"


### PR DESCRIPTION
### Description

Wraps the `./gradlew :opensearch-sample-resource-plugin:assemble` invocation in the `cypress-test-resource-sharing-enabled-e2e.yml` workflow in a retry loop (up to 3 attempts, 30s/60s backoff).

The security repo's Spotless configuration resolves the Eclipse JDT formatter at **Gradle configuration time** ([gradle/formatting.gradle](https://github.com/opensearch-project/security/blob/main/gradle/formatting.gradle)), so any task invocation — including plain `assemble` — downloads it before running anything. When that download times out, the build fails with:

```
A problem occurred configuring root project 'opensearch-security'.
> java.io.IOException: Failed to load eclipse jdt formatter: java.lang.RuntimeException: java.net.SocketTimeoutException: timeout
```

Because the failure is at configuration time, no `-x spotless*` task exclusion can avoid it — a retry is the smallest reliable mitigation from this repo's side. The failing attempt costs ~45s, so worst case adds about 3 minutes before failing for real reasons.

### Category

Maintenance

### Why these changes are required?

See #2504: on 2026-08-21 this transient timeout failed the job twice on #2503 and six consecutive times on another PR, each time before any test ran. Contributors without write access cannot rerun a single job, so each flake costs a full CI retrigger.

### What is the old behavior before changes and new behavior after changes?

**Old:** A single transient formatter-download timeout fails the whole Cypress resource-access-management job.

**New:** The build is retried up to 3 times with backoff; only a persistent failure fails the job. Genuine build errors still fail (after retries) with the same logs.

### Issues Resolved

Resolves #2504

### Testing

- YAML validated; the embedded bash block syntax-checked with `bash -n`.
- The retry loop preserves `set -euo pipefail` semantics: the gradle call is inside an `if` condition, and a final failed attempt exits 1 explicitly.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

🤖 This PR was written by [Claude Code](https://claude.com/claude-code) on behalf of @seanthegeek.
