### PR TITLE
Isolate co-located CI test clusters to prevent accidental cluster merge

### DIFF
--- a/.github/actions/isolate-remote-cluster/action.yml
+++ b/.github/actions/isolate-remote-cluster/action.yml
@@ -31,6 +31,9 @@ runs:
         # rejects in combination with single-node discovery.
         sed -i -e '/^[[:space:]]*cluster\.initial_cluster_manager_nodes/d' \
                -e '/^[[:space:]]*cluster\.initial_master_nodes/d' "$CONFIG"
+        # Derived from the HTTP port so different callers cannot collide;
+        # 9202 -> 9402, outside the default discovery probe range (9300-9305).
+        TRANSPORT_PORT=$((OS_PORT + 200))
         {
           echo ''
           echo '# Keep this node isolated from the default cluster on the same host.'
@@ -38,7 +41,7 @@ runs:
           echo 'cluster.name: opensearch-remote-cluster'
           echo '# Outside the default discovery probe range (9300-9305), so the other'
           echo '# node cannot find this one via loopback seed scanning either.'
-          echo 'transport.port: 9402'
+          echo "transport.port: ${TRANSPORT_PORT}"
         } >> "$CONFIG"
 
     - name: Stop node (Linux)
@@ -53,8 +56,12 @@ runs:
     - name: Stop node (Windows)
       if: ${{ runner.os == 'Windows' }}
       shell: pwsh
+      env:
+        OS_PORT: ${{ inputs.port }}
       run: |
-        Get-Process -Name java -ErrorAction SilentlyContinue | Stop-Process -Force
+        Get-CimInstance Win32_Process -Filter "Name='java.exe'" |
+          Where-Object { $_.CommandLine -match "SNAPSHOT$env:OS_PORT" } |
+          ForEach-Object { Stop-Process -Id $_.ProcessId -Force }
         Start-Sleep -Seconds 10
 
     - name: Restart node (Linux)

--- a/.github/actions/isolate-remote-cluster/action.yml
+++ b/.github/actions/isolate-remote-cluster/action.yml
@@ -1,0 +1,80 @@
+---
+name: 'Isolate remote OpenSearch cluster'
+description: 'Reconfigures an already-started secondary OpenSearch node with single-node discovery, a distinct cluster name, and an out-of-range transport port, then restarts it. Without this, the node shares the default cluster name and loopback seed hosts (127.0.0.1:9300-9305) with the node later started on 9200, and the two can merge into one cluster. See issue #2506. Must run before the default-port node is started, while this node is the only one running.'
+
+inputs:
+  opensearch-version:
+    description: 'The version of OpenSearch used to start the node (determines the install directory name)'
+    required: true
+  admin-password:
+    description: 'Admin password for the readiness check'
+    required: true
+  port:
+    description: 'HTTP port of the remote node'
+    required: false
+    default: '9202'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Apply isolated discovery settings
+      shell: bash
+      run: |
+        set -euo pipefail
+        CONFIG="./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT${{ inputs.port }}/config/opensearch.yml"
+        {
+          echo ''
+          echo '# Keep this node isolated from the default cluster on the same host.'
+          echo 'discovery.type: single-node'
+          echo 'cluster.name: opensearch-remote-cluster'
+          echo '# Outside the default discovery probe range (9300-9305), so the other'
+          echo '# node cannot find this one via loopback seed scanning either.'
+          echo 'transport.port: 9402'
+        } >> "$CONFIG"
+
+    - name: Stop node (Linux)
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      run: |
+        pkill -f "SNAPSHOT${{ inputs.port }}" || true
+        sleep 5
+
+    - name: Stop node (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      shell: pwsh
+      run: |
+        Get-Process -Name java -ErrorAction SilentlyContinue | Stop-Process -Force
+        Start-Sleep -Seconds 10
+
+    - name: Restart node (Linux)
+      if: ${{ runner.os == 'Linux' }}
+      shell: bash
+      run: /bin/bash -c "./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT${{ inputs.port }}/bin/opensearch &"
+
+    - name: Restart node (Windows)
+      if: ${{ runner.os == 'Windows' }}
+      shell: pwsh
+      run: start .\opensearch-${{ inputs.opensearch-version }}-SNAPSHOT${{ inputs.port }}\bin\opensearch.bat
+
+    - name: Wait for node and verify it is a single-node cluster
+      shell: bash
+      run: |
+        set -euo pipefail
+        for i in $(seq 1 36); do
+          if nodes=$(curl -s -k --fail -u 'admin:${{ inputs.admin-password }}' "https://localhost:${{ inputs.port }}/_cat/nodes"); then
+            count=$(printf '%s\n' "$nodes" | sed '/^$/d' | wc -l)
+            if [ "$count" -eq 1 ]; then
+              echo "Remote node restarted as an isolated single-node cluster."
+              exit 0
+            fi
+            echo "Unexpected node count on restarted remote: $count"
+            printf '%s\n' "$nodes"
+            exit 1
+          fi
+          sleep 5
+        done
+        echo "Remote node did not come back up in time; last log lines:"
+        tail -n 100 ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT${{ inputs.port }}/logs/opensearch-remote-cluster.log \
+          || tail -n 100 ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT${{ inputs.port }}/logs/opensearch.log \
+          || true
+        exit 1

--- a/.github/actions/isolate-remote-cluster/action.yml
+++ b/.github/actions/isolate-remote-cluster/action.yml
@@ -19,9 +19,18 @@ runs:
   steps:
     - name: Apply isolated discovery settings
       shell: bash
+      env:
+        OS_VERSION: ${{ inputs.opensearch-version }}
+        OS_PORT: ${{ inputs.port }}
       run: |
         set -euo pipefail
-        CONFIG="./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT${{ inputs.port }}/config/opensearch.yml"
+        case "$OS_PORT" in ''|*[!0-9]*) echo "Invalid port: $OS_PORT"; exit 1;; esac
+        case "$OS_VERSION" in ''|*[!0-9A-Za-z.-]*) echo "Invalid version: $OS_VERSION"; exit 1;; esac
+        CONFIG="./opensearch-${OS_VERSION}-SNAPSHOT${OS_PORT}/config/opensearch.yml"
+        # The demo setup writes a cluster bootstrap node list, which OpenSearch
+        # rejects in combination with single-node discovery.
+        sed -i -e '/^[[:space:]]*cluster\.initial_cluster_manager_nodes/d' \
+               -e '/^[[:space:]]*cluster\.initial_master_nodes/d' "$CONFIG"
         {
           echo ''
           echo '# Keep this node isolated from the default cluster on the same host.'
@@ -35,8 +44,10 @@ runs:
     - name: Stop node (Linux)
       if: ${{ runner.os == 'Linux' }}
       shell: bash
+      env:
+        OS_PORT: ${{ inputs.port }}
       run: |
-        pkill -f "SNAPSHOT${{ inputs.port }}" || true
+        pkill -f "SNAPSHOT${OS_PORT}" || true
         sleep 5
 
     - name: Stop node (Windows)
@@ -49,19 +60,29 @@ runs:
     - name: Restart node (Linux)
       if: ${{ runner.os == 'Linux' }}
       shell: bash
-      run: /bin/bash -c "./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT${{ inputs.port }}/bin/opensearch &"
+      env:
+        OS_VERSION: ${{ inputs.opensearch-version }}
+        OS_PORT: ${{ inputs.port }}
+      run: /bin/bash -c "./opensearch-${OS_VERSION}-SNAPSHOT${OS_PORT}/bin/opensearch &"
 
     - name: Restart node (Windows)
       if: ${{ runner.os == 'Windows' }}
       shell: pwsh
-      run: start .\opensearch-${{ inputs.opensearch-version }}-SNAPSHOT${{ inputs.port }}\bin\opensearch.bat
+      env:
+        OS_VERSION: ${{ inputs.opensearch-version }}
+        OS_PORT: ${{ inputs.port }}
+      run: Start-Process -FilePath ".\opensearch-$($env:OS_VERSION)-SNAPSHOT$($env:OS_PORT)\bin\opensearch.bat"
 
     - name: Wait for node and verify it is a single-node cluster
       shell: bash
+      env:
+        OS_VERSION: ${{ inputs.opensearch-version }}
+        OS_PORT: ${{ inputs.port }}
+        ADMIN_PASSWORD: ${{ inputs.admin-password }}
       run: |
         set -euo pipefail
         for i in $(seq 1 36); do
-          if nodes=$(curl -s -k --fail -u 'admin:${{ inputs.admin-password }}' "https://localhost:${{ inputs.port }}/_cat/nodes"); then
+          if nodes=$(curl -s -k --fail -u "admin:${ADMIN_PASSWORD}" "https://localhost:${OS_PORT}/_cat/nodes"); then
             count=$(printf '%s\n' "$nodes" | sed '/^$/d' | wc -l)
             if [ "$count" -eq 1 ]; then
               echo "Remote node restarted as an isolated single-node cluster."
@@ -74,7 +95,7 @@ runs:
           sleep 5
         done
         echo "Remote node did not come back up in time; last log lines:"
-        tail -n 100 ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT${{ inputs.port }}/logs/opensearch-remote-cluster.log \
-          || tail -n 100 ./opensearch-${{ inputs.opensearch-version }}-SNAPSHOT${{ inputs.port }}/logs/opensearch.log \
+        tail -n 100 "./opensearch-${OS_VERSION}-SNAPSHOT${OS_PORT}/logs/opensearch-remote-cluster.log" \
+          || tail -n 100 "./opensearch-${OS_VERSION}-SNAPSHOT${OS_PORT}/logs/opensearch.log" \
           || true
         exit 1

--- a/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
+++ b/.github/workflows/cypress-test-multidatasources-enabled-e2e.yml
@@ -86,6 +86,15 @@ jobs:
           curl https://localhost:9202/_cat/plugins -v -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} -k
         shell: bash
 
+      # Prevent the local node (started later with default discovery settings) from
+      # joining the remote node's cluster via loopback seed scanning. See #2506.
+      - name: Isolate remote cluster
+        uses: ./.github/actions/isolate-remote-cluster
+        with:
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
+          port: '9202'
+
       # Configure the Dashboard for multi datasources
       - name: Create OpenSearch Dashboards Config
         if: ${{ runner.os == 'Linux' }}

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -111,11 +111,29 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          local_uuid=$(curl -s -k -u 'admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}' https://localhost:9200/ | grep '"cluster_uuid"')
-          remote_uuid=$(curl -s -k -u 'admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}' https://localhost:9202/ | grep '"cluster_uuid"')
+          extract_uuid() {
+            curl -s -k -u 'admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}' "$1" \
+              | sed -n 's/.*"cluster_uuid"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+          }
+          # A freshly started node briefly reports "_na_" until its cluster
+          # state is recovered; retry rather than compare transient values.
+          for i in $(seq 1 12); do
+            local_uuid=$(extract_uuid https://localhost:9200/)
+            remote_uuid=$(extract_uuid https://localhost:9202/)
+            if [ -n "$local_uuid" ] && [ -n "$remote_uuid" ] \
+              && [ "$local_uuid" != "_na_" ] && [ "$remote_uuid" != "_na_" ]; then
+              break
+            fi
+            sleep 5
+          done
           echo "local:  $local_uuid"
           echo "remote: $remote_uuid"
-          if [ -z "$local_uuid" ] || [ "$local_uuid" = "$remote_uuid" ]; then
+          if [ -z "$local_uuid" ] || [ -z "$remote_uuid" ] \
+            || [ "$local_uuid" = "_na_" ] || [ "$remote_uuid" = "_na_" ]; then
+            echo "ERROR: could not obtain a settled cluster_uuid from both nodes."
+            exit 1
+          fi
+          if [ "$local_uuid" = "$remote_uuid" ]; then
             echo "ERROR: the local (9200) and remote (9202) nodes report the same cluster_uuid - they merged into one cluster."
             exit 1
           fi

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -86,7 +86,16 @@ jobs:
         run: |
           curl https://localhost:9202/_cat/plugins -v -u admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }} -k
         shell: bash
-  
+
+      # Prevent the local node (started next with default discovery settings) from
+      # joining the remote node's cluster via loopback seed scanning. See #2506.
+      - name: Isolate remote cluster
+        uses: ./.github/actions/isolate-remote-cluster
+        with:
+          opensearch-version: ${{ env.OPENSEARCH_VERSION }}
+          admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
+          port: '9202'
+
       - name: Run OpenSearch with security
         uses: opensearch-project/opensearch-build/.github/actions/start-opensearch@3d9a524bbfc8128d96113cc578b462153f2ea8d4
         with:
@@ -95,6 +104,21 @@ jobs:
           security-enabled: 'true'
           admin-password: ${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}
           jdk-version: '21'
+
+      # Fail fast (with a clear message) if the nodes merged anyway, instead of
+      # failing the datasource isolation tests half an hour later. See #2506.
+      - name: Verify local and remote clusters are separate
+        shell: bash
+        run: |
+          set -euo pipefail
+          local_uuid=$(curl -s -k -u 'admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}' https://localhost:9200/ | grep '"cluster_uuid"')
+          remote_uuid=$(curl -s -k -u 'admin:${{ env.OPENSEARCH_INITIAL_ADMIN_PASSWORD }}' https://localhost:9202/ | grep '"cluster_uuid"')
+          echo "local:  $local_uuid"
+          echo "remote: $remote_uuid"
+          if [ -z "$local_uuid" ] || [ "$local_uuid" = "$remote_uuid" ]; then
+            echo "ERROR: the local (9200) and remote (9202) nodes report the same cluster_uuid - they merged into one cluster."
+            exit 1
+          fi
 
 
       # https://github.com/actions/runner-images/issues/2840#issuecomment-790492173


### PR DESCRIPTION
### Description

Prevents the two co-located CI test clusters from accidentally merging into one cluster.

The "remote" node (`:9202`) and local node (`:9200`) are both started by `opensearch-build`'s `start-opensearch` action, which only appends `http.port` for the non-default node. Neither it nor the security demo installer sets `discovery.type: single-node`, a distinct `cluster.name`, or a `transport.port` — so both nodes run with the default cluster name (`opensearch`), default node name (`smoketestnode`), transport ports 9300/9301, and default loopback seed scanning (`127.0.0.1:9300–9305`). Depending on startup timing, the local node can discover the remote node's transport port and **join its cluster instead of bootstrapping its own**, making both endpoints serve one shared security index.

When that happens, exactly the remote/local isolation tests in `test/jest_integration/security_entity_api.test.ts` fail (CRUD Permissions / CRUD Roles / Audit logging for external datasource) while everything else passes — the intermittent, mostly-Windows failure documented in #2506, with the join visible in the failing run's cluster logs.

This PR adds:

- **`.github/actions/isolate-remote-cluster`** — a composite action that runs after the remote node is up but before the local node starts. It appends `discovery.type: single-node`, `cluster.name: opensearch-remote-cluster`, and `transport.port: 9402` (outside the default 9300–9305 discovery probe range) to the remote node's config, restarts it (per-OS stop/start mirroring the upstream action's start commands), and waits until it reports exactly one node.
- Wiring in **`integration-test.yml`** and **`cypress-test-multidatasources-enabled-e2e.yml`** (the two workflows that run a second cluster on 9202).
- A **fail-fast guard** in `integration-test.yml` after local startup: if both endpoints report the same `cluster_uuid`, the job fails immediately with a clear message instead of failing the datasource isolation tests half an hour later.

The distinct cluster name and single-node discovery each independently prevent the join (name mismatch → the local node refuses to join; single-node → the remote never joins anything); the out-of-range transport port additionally makes the remote undiscoverable. The restart happens while the remote is the only Java process running, so the per-OS stop steps cannot hit the wrong process.

### Category

Maintenance

### Why these changes are required?

See #2506: the same commit tree passed the integration workflow at 23:12 and failed it at 23:19 on 2026-08-21 (PR #2503), with the failing run's local-node log showing it applying cluster state from the remote node instead of electing itself. Timing-dependent cluster merges will keep intermittently failing unrelated PRs until the nodes are isolated.

### What is the old behavior before changes and new behavior after changes?

**Old:** Both test nodes start with default discovery settings; whether they form separate clusters depends on startup timing. When they merge, datasource isolation tests fail with confusing assertion errors ~30 minutes into the job.

**New:** The remote node is restarted as an explicitly isolated single-node cluster before the local node ever starts. If the nodes somehow still merged, the integration workflow fails within seconds of local startup with an explicit cluster_uuid mismatch error.

### Issues Resolved

Resolves #2506

### Testing

- YAML of all three files validated; the composite action's bash steps syntax-checked with `bash -n` (with inputs substituted).
- The CI runs on this PR exercise the changed workflows directly on both Linux and Windows, including the new restart path and the cluster_uuid guard.

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

🤖 This PR was written by [Claude Code](https://claude.com/claude-code) on behalf of @seanthegeek.
