### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add License Header
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,35 @@
+{
+  "**/*.*": [
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".html",
+    ".config",
+    ".png",
+    ".svg",
+    ".ico",
+    ".pem",
+    ".p12",
+    ".lock",
+    ".snap",
+    ".git",
+    ".gitignore",
+    ".prettierrc",
+    ".prettierignore",
+    ".whitesource",
+    ".lycheeignore",
+    "node_modules/",
+    "build/",
+    "dist/",
+    "target/",
+    "**/__snapshots__/",
+    "*.d.ts",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/build_tools/rename_zip.js
+++ b/build_tools/rename_zip.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/common/index.test.ts
+++ b/common/index.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/common/index.ts
+++ b/common/index.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/account-app.tsx
+++ b/public/apps/account/account-app.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/account-nav-button.tsx
+++ b/public/apps/account/account-nav-button.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/constants.tsx
+++ b/public/apps/account/constants.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/log-out-button.tsx
+++ b/public/apps/account/log-out-button.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/password-reset-panel.tsx
+++ b/public/apps/account/password-reset-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/role-info-panel.tsx
+++ b/public/apps/account/role-info-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/tenant-switch-panel.tsx
+++ b/public/apps/account/tenant-switch-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/test/account-app.test.tsx
+++ b/public/apps/account/test/account-app.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/test/account-nav-button.test.tsx
+++ b/public/apps/account/test/account-nav-button.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/test/log-out-button.test.tsx
+++ b/public/apps/account/test/log-out-button.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/test/password-reset-panel.test.tsx
+++ b/public/apps/account/test/password-reset-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/test/plugin.test.tsx
+++ b/public/apps/account/test/plugin.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/test/role-info-panel.test.tsx
+++ b/public/apps/account/test/role-info-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/test/switch-tenants.test.tsx
+++ b/public/apps/account/test/switch-tenants.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/test/tenant-switch-panel.test.tsx
+++ b/public/apps/account/test/tenant-switch-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/types.ts
+++ b/public/apps/account/types.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/account/utils.tsx
+++ b/public/apps/account/utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/apps-constants.tsx
+++ b/public/apps/apps-constants.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/_index.scss
+++ b/public/apps/configuration/_index.scss
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/access-error-component.tsx
+++ b/public/apps/configuration/access-error-component.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/app-router.tsx
+++ b/public/apps/configuration/app-router.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/configuration-app.tsx
+++ b/public/apps/configuration/configuration-app.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/constants.tsx
+++ b/public/apps/configuration/constants.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/cross-page-toast.tsx
+++ b/public/apps/configuration/cross-page-toast.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/header/header-components.tsx
+++ b/public/apps/configuration/header/header-components.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/header/header-props.tsx
+++ b/public/apps/configuration/header/header-props.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/header/test/header-components.test.tsx
+++ b/public/apps/configuration/header/test/header-components.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/api-token-create.tsx
+++ b/public/apps/configuration/panels/api-token-create.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/api-token-list.tsx
+++ b/public/apps/configuration/panels/api-token-list.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/_index.scss
+++ b/public/apps/configuration/panels/audit-logging/_index.scss
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .described-form-group {
   max-width: 1500px;
 }

--- a/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging-edit-settings.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/audit-logging.tsx
+++ b/public/apps/configuration/panels/audit-logging/audit-logging.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/code-editor.tsx
+++ b/public/apps/configuration/panels/audit-logging/code-editor.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/constants.tsx
+++ b/public/apps/configuration/panels/audit-logging/constants.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
+++ b/public/apps/configuration/panels/audit-logging/edit-setting-group.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging-edit-settings.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/audit-logging.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/test/code-editor.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/code-editor.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/test/edit-setting-group.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/edit-setting-group.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/test/view-setting-group.test.tsx
+++ b/public/apps/configuration/panels/audit-logging/test/view-setting-group.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/types.tsx
+++ b/public/apps/configuration/panels/audit-logging/types.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/audit-logging/view-setting-group.tsx
+++ b/public/apps/configuration/panels/audit-logging/view-setting-group.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/auth-view/_index.scss
+++ b/public/apps/configuration/panels/auth-view/_index.scss
@@ -1,3 +1,7 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 .instruction-text {
   max-width: 800px;
   margin: auto;

--- a/public/apps/configuration/panels/auth-view/auth-view.tsx
+++ b/public/apps/configuration/panels/auth-view/auth-view.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authentication-sequence-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/auth-view/authorization-panel.tsx
+++ b/public/apps/configuration/panels/auth-view/authorization-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/auth-view/instruction-view.tsx
+++ b/public/apps/configuration/panels/auth-view/instruction-view.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/auth-view/test/auth-view.test.tsx
+++ b/public/apps/configuration/panels/auth-view/test/auth-view.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/auth-view/test/authentication-sequence-panel.test.tsx
+++ b/public/apps/configuration/panels/auth-view/test/authentication-sequence-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/auth-view/test/authorization-panel.test.tsx
+++ b/public/apps/configuration/panels/auth-view/test/authorization-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/auth-view/test/instruction-view.test.tsx
+++ b/public/apps/configuration/panels/auth-view/test/instruction-view.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/expression-modal.tsx
+++ b/public/apps/configuration/panels/expression-modal.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/get-started.tsx
+++ b/public/apps/configuration/panels/get-started.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/attribute-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/backend-role-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/internal-user-edit/test/attribute-panel.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/attribute-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/backend-role-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/internal-user-edit/test/internal-user-edit.test.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/test/internal-user-edit.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/internal-user-edit/types.tsx
+++ b/public/apps/configuration/panels/internal-user-edit/types.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/nav-panel.tsx
+++ b/public/apps/configuration/panels/nav-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/permission-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/permission-list/edit-modal.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/permission-list/permission-list.tsx
+++ b/public/apps/configuration/panels/permission-list/permission-list.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/permission-list/test/edit-modal.test.tsx
+++ b/public/apps/configuration/panels/permission-list/test/edit-modal.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/permission-list/test/permission-list.test.tsx
+++ b/public/apps/configuration/panels/permission-list/test/permission-list.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/permission-tree/_index.scss
+++ b/public/apps/configuration/panels/permission-tree/_index.scss
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/permission-tree/index.ts
+++ b/public/apps/configuration/panels/permission-tree/index.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/permission-tree/permission-tree.tsx
+++ b/public/apps/configuration/panels/permission-tree/permission-tree.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/permission-tree/test/permission-tree.test.tsx
+++ b/public/apps/configuration/panels/permission-tree/test/permission-tree.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/cluster-permission-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/index-permission-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-edit/role-edit.tsx
+++ b/public/apps/configuration/panels/role-edit/role-edit.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-edit/tenant-panel.tsx
+++ b/public/apps/configuration/panels/role-edit/tenant-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-edit/test/cluster-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/cluster-permission-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-edit/test/index-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/index-permission-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-edit/test/role-edit-filtering.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/role-edit-filtering.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/role-edit.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-edit/test/tenant-panel.test.tsx
+++ b/public/apps/configuration/panels/role-edit/test/tenant-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-edit/types.tsx
+++ b/public/apps/configuration/panels/role-edit/types.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-list.tsx
+++ b/public/apps/configuration/panels/role-list.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
+++ b/public/apps/configuration/panels/role-mapping/external-identities-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
+++ b/public/apps/configuration/panels/role-mapping/role-edit-mapped-user.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-mapping/test/external-identities-panel.test.tsx
+++ b/public/apps/configuration/panels/role-mapping/test/external-identities-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-mapping/test/role-edit-mapped-user.test.tsx
+++ b/public/apps/configuration/panels/role-mapping/test/role-edit-mapped-user.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-mapping/test/users-panel.test.tsx
+++ b/public/apps/configuration/panels/role-mapping/test/users-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-mapping/types.tsx
+++ b/public/apps/configuration/panels/role-mapping/types.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-mapping/users-panel.tsx
+++ b/public/apps/configuration/panels/role-mapping/users-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-view/cluster-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/cluster-permission-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-view/index-permission-panel.tsx
+++ b/public/apps/configuration/panels/role-view/index-permission-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-view/role-view.tsx
+++ b/public/apps/configuration/panels/role-view/role-view.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-view/tenants-panel.tsx
+++ b/public/apps/configuration/panels/role-view/tenants-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-view/test/cluster-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/cluster-permission-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-view/test/index-permission-panel.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/index-permission-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-view/test/role-view-multitenancy.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/role-view-multitenancy.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-view/test/role-view.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/role-view.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/role-view/test/tenants-panel.test.tsx
+++ b/public/apps/configuration/panels/role-view/test/tenants-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/tenancy-config/types.tsx
+++ b/public/apps/configuration/panels/tenancy-config/types.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
+++ b/public/apps/configuration/panels/tenant-list/configure_tab1.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/tenant-list/edit-modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/edit-modal.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/tenant-list/manage_tab.tsx
+++ b/public/apps/configuration/panels/tenant-list/manage_tab.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/tenant-list/save_changes_modal.tsx
+++ b/public/apps/configuration/panels/tenant-list/save_changes_modal.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/tenant-list/tenant-list.tsx
+++ b/public/apps/configuration/panels/tenant-list/tenant-list.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/tenant-list/test/edit-modal.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/test/edit-modal.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/tenant-list/test/tenant-list.test.tsx
+++ b/public/apps/configuration/panels/tenant-list/test/tenant-list.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/test/api-token-create.test.tsx
+++ b/public/apps/configuration/panels/test/api-token-create.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/test/api-token-list.test.tsx
+++ b/public/apps/configuration/panels/test/api-token-list.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/test/expression-modal.test.tsx
+++ b/public/apps/configuration/panels/test/expression-modal.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/test/get-started.test.tsx
+++ b/public/apps/configuration/panels/test/get-started.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/test/nav-panel.test.tsx
+++ b/public/apps/configuration/panels/test/nav-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/test/role-list.test.tsx
+++ b/public/apps/configuration/panels/test/role-list.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/test/user-list.test.tsx
+++ b/public/apps/configuration/panels/test/user-list.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/panels/user-list.tsx
+++ b/public/apps/configuration/panels/user-list.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/test/access-error-component.test.tsx
+++ b/public/apps/configuration/test/access-error-component.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/test/app-router.test.tsx
+++ b/public/apps/configuration/test/app-router.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/test/top-nav-menu.test.tsx
+++ b/public/apps/configuration/test/top-nav-menu.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/top-nav-menu.tsx
+++ b/public/apps/configuration/top-nav-menu.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/types.ts
+++ b/public/apps/configuration/types.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/ui-constants.tsx
+++ b/public/apps/configuration/ui-constants.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/action-groups-utils.tsx
+++ b/public/apps/configuration/utils/action-groups-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/api-token-utils.tsx
+++ b/public/apps/configuration/utils/api-token-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/array-state-utils.tsx
+++ b/public/apps/configuration/utils/array-state-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/audit-logging-utils.tsx
+++ b/public/apps/configuration/utils/audit-logging-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/auth-view-utils.tsx
+++ b/public/apps/configuration/utils/auth-view-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/combo-box-utils.tsx
+++ b/public/apps/configuration/utils/combo-box-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/context-menu.tsx
+++ b/public/apps/configuration/utils/context-menu.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/delete-confirm-modal-utils.tsx
+++ b/public/apps/configuration/utils/delete-confirm-modal-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/display-utils.tsx
+++ b/public/apps/configuration/utils/display-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/form-row.tsx
+++ b/public/apps/configuration/utils/form-row.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/index-permission-utils.tsx
+++ b/public/apps/configuration/utils/index-permission-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/internal-user-detail-utils.tsx
+++ b/public/apps/configuration/utils/internal-user-detail-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/internal-user-list-utils.tsx
+++ b/public/apps/configuration/utils/internal-user-list-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/loading-spinner-utils.tsx
+++ b/public/apps/configuration/utils/loading-spinner-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/name-row.tsx
+++ b/public/apps/configuration/utils/name-row.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/panel-with-header.tsx
+++ b/public/apps/configuration/utils/panel-with-header.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/password-edit-panel.tsx
+++ b/public/apps/configuration/utils/password-edit-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/password-strength-bar.tsx
+++ b/public/apps/configuration/utils/password-strength-bar.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/request-utils.ts
+++ b/public/apps/configuration/utils/request-utils.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/resource-utils.tsx
+++ b/public/apps/configuration/utils/resource-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/resource-validation-util.tsx
+++ b/public/apps/configuration/utils/resource-validation-util.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/role-detail-utils.tsx
+++ b/public/apps/configuration/utils/role-detail-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/role-list-utils.tsx
+++ b/public/apps/configuration/utils/role-list-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/role-mapping-utils.tsx
+++ b/public/apps/configuration/utils/role-mapping-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/storage-utils.tsx
+++ b/public/apps/configuration/utils/storage-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/tenancy-config_util.tsx
+++ b/public/apps/configuration/utils/tenancy-config_util.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/tenant-utils.tsx
+++ b/public/apps/configuration/utils/tenant-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/action-groups-utils.test.tsx
+++ b/public/apps/configuration/utils/test/action-groups-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/api-token-utils.test.tsx
+++ b/public/apps/configuration/utils/test/api-token-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/delete-confirm-modal-utils.test.tsx
+++ b/public/apps/configuration/utils/test/delete-confirm-modal-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/display-utils.test.tsx
+++ b/public/apps/configuration/utils/test/display-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/form-row.test.tsx
+++ b/public/apps/configuration/utils/test/form-row.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/index-permission-utils.test.tsx
+++ b/public/apps/configuration/utils/test/index-permission-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/internal-user-list-utils.test.tsx
+++ b/public/apps/configuration/utils/test/internal-user-list-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/name-row.test.tsx
+++ b/public/apps/configuration/utils/test/name-row.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/panel-with-header.test.tsx
+++ b/public/apps/configuration/utils/test/panel-with-header.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/password-edit-panel.test.tsx
+++ b/public/apps/configuration/utils/test/password-edit-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/password-strength-bar.test.tsx
+++ b/public/apps/configuration/utils/test/password-strength-bar.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/request-utils.test.ts
+++ b/public/apps/configuration/utils/test/request-utils.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/resource-utils.test.tsx
+++ b/public/apps/configuration/utils/test/resource-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/resource-validation-util.test.tsx
+++ b/public/apps/configuration/utils/test/resource-validation-util.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/role-list-utils.test.tsx
+++ b/public/apps/configuration/utils/test/role-list-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/role-mapping-utils.test.tsx
+++ b/public/apps/configuration/utils/test/role-mapping-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/tenant-utils.test.tsx
+++ b/public/apps/configuration/utils/test/tenant-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/test/toast-utils.test.tsx
+++ b/public/apps/configuration/utils/test/toast-utils.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/toast-utils.tsx
+++ b/public/apps/configuration/utils/toast-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/configuration/utils/url-builder.tsx
+++ b/public/apps/configuration/utils/url-builder.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/customerror/_index.scss
+++ b/public/apps/customerror/_index.scss
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/customerror/custom-error.tsx
+++ b/public/apps/customerror/custom-error.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/customerror/test/custom-error.test.tsx
+++ b/public/apps/customerror/test/custom-error.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/error-utils.ts
+++ b/public/apps/error-utils.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/login/_index.scss
+++ b/public/apps/login/_index.scss
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/login/login-app.tsx
+++ b/public/apps/login/login-app.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/login/test/login-page.test.tsx
+++ b/public/apps/login/test/login-page.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/resource-access-management-app.tsx
+++ b/public/apps/resource-sharing/resource-access-management-app.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/resource-share-button.tsx
+++ b/public/apps/resource-sharing/resource-share-button.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/resource-sharing-panel.tsx
+++ b/public/apps/resource-sharing/resource-sharing-panel.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/share-access-modal.tsx
+++ b/public/apps/resource-sharing/share-access-modal.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/share-button-dom-spi.tsx
+++ b/public/apps/resource-sharing/share-button-dom-spi.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/share-button-embeddable.tsx
+++ b/public/apps/resource-sharing/share-button-embeddable.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/share-icons.tsx
+++ b/public/apps/resource-sharing/share-icons.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/share-utils.ts
+++ b/public/apps/resource-sharing/share-utils.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/test/resource-access-management-app.test.tsx
+++ b/public/apps/resource-sharing/test/resource-access-management-app.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright OpenSearch Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/test/resource-share-button.test.tsx
+++ b/public/apps/resource-sharing/test/resource-share-button.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright OpenSearch Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/test/resource-sharing-panel.test.tsx
+++ b/public/apps/resource-sharing/test/resource-sharing-panel.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright OpenSearch Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/test/share-button-dom-spi.test.tsx
+++ b/public/apps/resource-sharing/test/share-button-dom-spi.test.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright OpenSearch Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/resource-sharing/types.ts
+++ b/public/apps/resource-sharing/types.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/translation-utils.ts
+++ b/public/apps/translation-utils.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/apps/types.ts
+++ b/public/apps/types.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/index.ts
+++ b/public/index.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/services/chrome_wrapper.ts
+++ b/public/services/chrome_wrapper.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/services/shared-link.ts
+++ b/public/services/shared-link.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/services/test/shared-link.test.ts
+++ b/public/services/test/shared-link.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/test/plugin.test.ts
+++ b/public/test/plugin.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/types.ts
+++ b/public/types.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/utils/auth-info-utils.tsx
+++ b/public/utils/auth-info-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/utils/dashboards-info-utils.tsx
+++ b/public/utils/dashboards-info-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/utils/datasource-utils.ts
+++ b/public/utils/datasource-utils.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/utils/login-utils.tsx
+++ b/public/utils/login-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/utils/logout-utils.tsx
+++ b/public/utils/logout-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/utils/password-reset-panel-utils.tsx
+++ b/public/utils/password-reset-panel-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/utils/resource-sharing-utils.tsx
+++ b/public/utils/resource-sharing-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/utils/storage-utils.tsx
+++ b/public/utils/storage-utils.tsx
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/utils/test/datasource-utils.test.ts
+++ b/public/utils/test/datasource-utils.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/public/utils/test/password-reset-panel-utils.test.ts
+++ b/public/utils/test/password-reset-panel-utils.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/auth_handler_factory.test.ts
+++ b/server/auth/auth_handler_factory.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/auth_handler_factory.ts
+++ b/server/auth/auth_handler_factory.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/login/login_page.ts
+++ b/server/auth/login/login_page.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/authentication_type.test.ts
+++ b/server/auth/types/authentication_type.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/authentication_type.ts
+++ b/server/auth/types/authentication_type.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/basic/basic_auth.test.ts
+++ b/server/auth/types/basic/basic_auth.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/basic/basic_auth.ts
+++ b/server/auth/types/basic/basic_auth.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/basic/routes.ts
+++ b/server/auth/types/basic/routes.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/index.ts
+++ b/server/auth/types/index.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/jwt/jwt_auth.ts
+++ b/server/auth/types/jwt/jwt_auth.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/jwt/jwt_helper.test.ts
+++ b/server/auth/types/jwt/jwt_helper.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/jwt/jwt_helper.ts
+++ b/server/auth/types/jwt/jwt_helper.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/jwt/routes.ts
+++ b/server/auth/types/jwt/routes.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/multiple/multi_auth.test.ts
+++ b/server/auth/types/multiple/multi_auth.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/multiple/multi_auth.ts
+++ b/server/auth/types/multiple/multi_auth.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/multiple/routes.ts
+++ b/server/auth/types/multiple/routes.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/openid/helper.test.ts
+++ b/server/auth/types/openid/helper.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/openid/helper.ts
+++ b/server/auth/types/openid/helper.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/openid/openid_auth.test.ts
+++ b/server/auth/types/openid/openid_auth.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/openid/openid_auth.ts
+++ b/server/auth/types/openid/openid_auth.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/openid/routes.ts
+++ b/server/auth/types/openid/routes.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/proxy/proxy_auth.test.ts
+++ b/server/auth/types/proxy/proxy_auth.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/proxy/proxy_auth.ts
+++ b/server/auth/types/proxy/proxy_auth.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/proxy/routes.ts
+++ b/server/auth/types/proxy/routes.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/saml/saml_auth.test.ts
+++ b/server/auth/types/saml/saml_auth.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/types/saml/saml_auth.ts
+++ b/server/auth/types/saml/saml_auth.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/auth/user.ts
+++ b/server/auth/user.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/backend/opensearch_security_client.ts
+++ b/server/backend/opensearch_security_client.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/backend/opensearch_security_configuration_plugin.ts
+++ b/server/backend/opensearch_security_configuration_plugin.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/backend/opensearch_security_plugin.ts
+++ b/server/backend/opensearch_security_plugin.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/errors/index.ts
+++ b/server/errors/index.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/errors/no_available_tenant_error.ts
+++ b/server/errors/no_available_tenant_error.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/errors/unauthenticated_error.ts
+++ b/server/errors/unauthenticated_error.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/multitenancy/routes.ts
+++ b/server/multitenancy/routes.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/multitenancy/tenant_index.ts
+++ b/server/multitenancy/tenant_index.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/multitenancy/tenant_resolver.test.ts
+++ b/server/multitenancy/tenant_resolver.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/multitenancy/tenant_resolver.ts
+++ b/server/multitenancy/tenant_resolver.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/multitenancy/test/tenant_index.test.ts
+++ b/server/multitenancy/test/tenant_index.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/multitenancy/test/tenant_resolver.test.ts
+++ b/server/multitenancy/test/tenant_resolver.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/readonly/readonly_service.test.ts
+++ b/server/readonly/readonly_service.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/readonly/readonly_service.ts
+++ b/server/readonly/readonly_service.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/routes/api-token-routes.ts
+++ b/server/routes/api-token-routes.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/routes/auth_type_routes.ts
+++ b/server/routes/auth_type_routes.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/routes/resource_access_management_routes.ts
+++ b/server/routes/resource_access_management_routes.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/saved_objects/saved_objects_wrapper.ts
+++ b/server/saved_objects/saved_objects_wrapper.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/session/cookie_splitter.test.ts
+++ b/server/session/cookie_splitter.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/session/cookie_splitter.ts
+++ b/server/session/cookie_splitter.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/session/security_cookie.ts
+++ b/server/session/security_cookie.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/types.ts
+++ b/server/types.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/utils/compression.test.ts
+++ b/server/utils/compression.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/utils/compression.ts
+++ b/server/utils/compression.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/utils/import_proxy_agent.js
+++ b/server/utils/import_proxy_agent.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/utils/next_url.test.ts
+++ b/server/utils/next_url.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/utils/next_url.ts
+++ b/server/utils/next_url.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/server/utils/object_properties_defined.ts
+++ b/server/utils/object_properties_defined.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/constant.ts
+++ b/test/constant.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_disabled.spec.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
+++ b/test/cypress/e2e/multi-datasources/multi_datasources_enabled.spec.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/cypress/e2e/resource-sharing/resource_access_management.spec.js
+++ b/test/cypress/e2e/resource-sharing/resource_access_management.spec.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/cypress/support/index.d.ts
+++ b/test/cypress/support/index.d.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/helper/cookie.ts
+++ b/test/helper/cookie.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/helper/entity_operation.ts
+++ b/test/helper/entity_operation.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/helper/sleep.ts
+++ b/test/helper/sleep.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/jest.config.server.js
+++ b/test/jest.config.server.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright OpenSearch Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/jest.config.ui.js
+++ b/test/jest.config.ui.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  * Copyright OpenSearch Contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/jest_integration/basic_auth.test.ts
+++ b/test/jest_integration/basic_auth.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/jest_integration/constants.ts
+++ b/test/jest_integration/constants.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/jest_integration/jwt_auth.test.ts
+++ b/test/jest_integration/jwt_auth.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/jest_integration/jwt_multiauth.test.ts
+++ b/test/jest_integration/jwt_multiauth.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/jest_integration/multi_tenancy.test.ts
+++ b/test/jest_integration/multi_tenancy.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/jest_integration/proxy_multiauth.test.ts
+++ b/test/jest_integration/proxy_multiauth.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/jest_integration/runIdpServer.js
+++ b/test/jest_integration/runIdpServer.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/jest_integration/security_entity_api.test.ts
+++ b/test/jest_integration/security_entity_api.test.ts
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/mocks/query_string_mock.js
+++ b/test/mocks/query_string_mock.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/run_jest_tests.js
+++ b/test/run_jest_tests.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").

--- a/test/setup/after_env.js
+++ b/test/setup/after_env.js
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: Apache-2.0
  *   Copyright OpenSearch Contributors
  *
  *   Licensed under the Apache License, Version 2.0 (the "License").


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files
  
### Related Issues
[#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)


### Why these changes are required?


### What is the old behavior before changes and new behavior after changes?


### Issues Resolved
[List any issues this PR will resolve (Is this a backport? If so, please add backport PR # and/or commits #)]

### Testing
[Please provide details of testing done: unit testing, integration testing and manual testing]

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).