### PR TITLE
Support both SAML ACS route prefixes

### DIFF
--- a/server/auth/types/saml/routes.test.ts
+++ b/server/auth/types/saml/routes.test.ts
@@ -1,0 +1,64 @@
+/*
+ *   Copyright OpenSearch Contributors
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License").
+ *   You may not use this file except in compliance with the License.
+ *   A copy of the License is located at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   or in the "license" file accompanying this file. This file is distributed
+ *   on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *   express or implied. See the License for the specific language governing
+ *   permissions and limitations under the License.
+ */
+
+import { CoreSetup, IRouter, SessionStorageFactory } from '../../../../../../src/core/server';
+import { SecurityPluginConfigType } from '../../..';
+import { SecurityClient } from '../../../backend/opensearch_security_client';
+import { SecuritySessionCookie } from '../../../session/security_cookie';
+import { SamlAuthRoutes } from './routes';
+
+const SAML_ACS_PATHS = {
+  '/_plugins/_security/saml/acs': false,
+  '/_opendistro/_security/saml/acs': true,
+  '/_plugins/_security/saml/acs/idpinitiated': false,
+  '/_opendistro/_security/saml/acs/idpinitiated': true,
+};
+
+describe('SAML ACS routes', () => {
+  test('registers canonical and legacy routes with compatible XSRF behavior', () => {
+    const router = ({
+      get: jest.fn(),
+      post: jest.fn(),
+    } as unknown) as IRouter;
+    const coreSetup = ({
+      http: {
+        basePath: { serverBasePath: '' },
+        resources: { register: jest.fn() },
+      },
+    } as unknown) as CoreSetup;
+    const routes = new SamlAuthRoutes(
+      router,
+      {} as SecurityPluginConfigType,
+      {} as SessionStorageFactory<SecuritySessionCookie>,
+      {} as SecurityClient,
+      coreSetup
+    );
+
+    routes.setupRoutes();
+
+    const routeConfigs = (router.post as jest.Mock).mock.calls.map(([config]) => config);
+    for (const [path, xsrfRequired] of Object.entries(SAML_ACS_PATHS)) {
+      expect(routeConfigs).toContainEqual(
+        expect.objectContaining({
+          path,
+          options: {
+            authRequired: false,
+            xsrfRequired,
+          },
+        })
+      );
+    }
+  });
+});

--- a/server/auth/types/saml/routes.ts
+++ b/server/auth/types/saml/routes.ts
@@ -28,6 +28,9 @@ import {
   setExtraAuthStorage,
 } from '../../../session/cookie_splitter';
 
+const SAML_ACS_PATHS = ['/_plugins/_security/saml/acs', '/_opendistro/_security/saml/acs'] as const;
+const SAML_IDP_INITIATED_ACS_PATHS = SAML_ACS_PATHS.map((path) => `${path}/idpinitiated`);
+
 export class SamlAuthRoutes {
   constructor(
     private readonly router: IRouter,
@@ -99,169 +102,178 @@ export class SamlAuthRoutes {
       }
     );
 
-    this.router.post(
-      {
-        path: `/_opendistro/_security/saml/acs`,
-        validate: {
-          body: schema.any(),
+    for (const path of SAML_ACS_PATHS) {
+      this.router.post(
+        {
+          path,
+          validate: {
+            body: schema.any(),
+          },
+          options: {
+            authRequired: false,
+            // SAML HTTP-POST binding cannot supply an OSD XSRF header. Legacy routes retain their
+            // existing server.xsrf.allowlist behavior, while the new route works with existing configuration.
+            xsrfRequired: path.startsWith('/_opendistro/'),
+          },
         },
-        options: {
-          authRequired: false,
-        },
-      },
-      async (context, request, response) => {
-        let requestId: string = '';
-        let nextUrl: string = '/';
-        let redirectHash: boolean = false;
-        try {
-          const cookie = await this.sessionStorageFactory.asScoped(request).get();
-          if (cookie) {
-            requestId = cookie.saml?.requestId || '';
-            nextUrl =
-              cookie.saml?.nextUrl ||
-              `${this.coreSetup.http.basePath.serverBasePath}/app/opensearch-dashboards`;
-            redirectHash = cookie.saml?.redirectHash || false;
+        async (context, request, response) => {
+          let requestId: string = '';
+          let nextUrl: string = '/';
+          let redirectHash: boolean = false;
+          try {
+            const cookie = await this.sessionStorageFactory.asScoped(request).get();
+            if (cookie) {
+              requestId = cookie.saml?.requestId || '';
+              nextUrl =
+                cookie.saml?.nextUrl ||
+                `${this.coreSetup.http.basePath.serverBasePath}/app/opensearch-dashboards`;
+              redirectHash = cookie.saml?.redirectHash || false;
+            }
+            if (!requestId) {
+              return response.badRequest({
+                body: 'Invalid requestId',
+              });
+            }
+          } catch (error) {
+            context.security_plugin.logger.error(`Failed to parse cookie: ${error}`);
+            return response.badRequest();
           }
-          if (!requestId) {
-            return response.badRequest({
-              body: 'Invalid requestId',
+
+          try {
+            const credentials = await this.securityClient.authToken({
+              requestId,
+              samlResponse: request.body.SAMLResponse,
+              acsEndpoint: undefined,
+              authRequestType: AuthType.SAML,
             });
+            const user = await this.securityClient.authenticateWithHeader(
+              request,
+              'authorization',
+              credentials.authorization
+            );
+
+            let expiryTime = Date.now() + this.config.session.ttl;
+            const [headerEncoded, payloadEncoded, signature] = credentials.authorization.split('.');
+            if (!payloadEncoded) {
+              context.security_plugin.logger.error('JWT token payload not found');
+            }
+            const tokenPayload = JSON.parse(Buffer.from(payloadEncoded, 'base64').toString());
+
+            if (tokenPayload.exp) {
+              expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
+            }
+
+            const cookie: SecuritySessionCookie = {
+              username: user.username,
+              credentials: {
+                authHeaderValueExtra: true,
+              },
+              authType: AuthType.SAML, // TODO: create constant
+              expiryTime,
+            };
+
+            setExtraAuthStorage(
+              request,
+              credentials.authorization,
+              this.getExtraAuthStorageOptions(context.security_plugin.logger)
+            );
+
+            this.sessionStorageFactory.asScoped(request).set(cookie);
+
+            if (redirectHash) {
+              return response.redirected({
+                headers: {
+                  location: `${
+                    this.coreSetup.http.basePath.serverBasePath
+                  }/auth/saml/redirectUrlFragment?nextUrl=${escape(nextUrl)}`,
+                },
+              });
+            } else {
+              return response.redirected({
+                headers: {
+                  location: nextUrl,
+                },
+              });
+            }
+          } catch (error) {
+            context.security_plugin.logger.error(
+              `SAML SP initiated authentication workflow failed: ${error}`
+            );
           }
-        } catch (error) {
-          context.security_plugin.logger.error(`Failed to parse cookie: ${error}`);
-          return response.badRequest();
+
+          return response.internalError();
         }
+      );
+    }
 
-        try {
-          const credentials = await this.securityClient.authToken({
-            requestId,
-            samlResponse: request.body.SAMLResponse,
-            acsEndpoint: undefined,
-            authRequestType: AuthType.SAML,
-          });
-          const user = await this.securityClient.authenticateWithHeader(
-            request,
-            'authorization',
-            credentials.authorization
-          );
+    for (const path of SAML_IDP_INITIATED_ACS_PATHS) {
+      this.router.post(
+        {
+          path,
+          validate: {
+            body: schema.any(),
+          },
+          options: {
+            authRequired: false,
+            // IdP-initiated responses are authenticated by their signed SAML assertion.
+            xsrfRequired: path.startsWith('/_opendistro/'),
+          },
+        },
+        async (context, request, response) => {
+          const acsEndpoint = `${this.coreSetup.http.basePath.serverBasePath}${path}`;
+          try {
+            const credentials = await this.securityClient.authToken({
+              requestId: undefined,
+              samlResponse: request.body.SAMLResponse,
+              acsEndpoint,
+              authRequestType: AuthType.SAML,
+            });
+            const user = await this.securityClient.authenticateWithHeader(
+              request,
+              'authorization',
+              credentials.authorization
+            );
 
-          let expiryTime = Date.now() + this.config.session.ttl;
-          const [headerEncoded, payloadEncoded, signature] = credentials.authorization.split('.');
-          if (!payloadEncoded) {
-            context.security_plugin.logger.error('JWT token payload not found');
-          }
-          const tokenPayload = JSON.parse(Buffer.from(payloadEncoded, 'base64').toString());
+            let expiryTime = Date.now() + this.config.session.ttl;
+            const [headerEncoded, payloadEncoded, signature] = credentials.authorization.split('.');
+            if (!payloadEncoded) {
+              context.security_plugin.logger.error('JWT token payload not found');
+            }
+            const tokenPayload = JSON.parse(Buffer.from(payloadEncoded, 'base64').toString());
+            if (tokenPayload.exp) {
+              expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
+            }
 
-          if (tokenPayload.exp) {
-            expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
-          }
+            const cookie: SecuritySessionCookie = {
+              username: user.username,
+              credentials: {
+                authHeaderValueExtra: true,
+              },
+              authType: AuthType.SAML, // TODO: create constant
+              expiryTime,
+            };
 
-          const cookie: SecuritySessionCookie = {
-            username: user.username,
-            credentials: {
-              authHeaderValueExtra: true,
-            },
-            authType: AuthType.SAML, // TODO: create constant
-            expiryTime,
-          };
+            setExtraAuthStorage(
+              request,
+              credentials.authorization,
+              this.getExtraAuthStorageOptions(context.security_plugin.logger)
+            );
 
-          setExtraAuthStorage(
-            request,
-            credentials.authorization,
-            this.getExtraAuthStorageOptions(context.security_plugin.logger)
-          );
-
-          this.sessionStorageFactory.asScoped(request).set(cookie);
-
-          if (redirectHash) {
+            this.sessionStorageFactory.asScoped(request).set(cookie);
             return response.redirected({
               headers: {
-                location: `${
-                  this.coreSetup.http.basePath.serverBasePath
-                }/auth/saml/redirectUrlFragment?nextUrl=${escape(nextUrl)}`,
+                location: `${this.coreSetup.http.basePath.serverBasePath}/app/opensearch-dashboards`,
               },
             });
-          } else {
-            return response.redirected({
-              headers: {
-                location: nextUrl,
-              },
-            });
+          } catch (error) {
+            context.security_plugin.logger.error(
+              `SAML IDP initiated authentication workflow failed: ${error}`
+            );
           }
-        } catch (error) {
-          context.security_plugin.logger.error(
-            `SAML SP initiated authentication workflow failed: ${error}`
-          );
+          return response.internalError();
         }
-
-        return response.internalError();
-      }
-    );
-
-    this.router.post(
-      {
-        path: `/_opendistro/_security/saml/acs/idpinitiated`,
-        validate: {
-          body: schema.any(),
-        },
-        options: {
-          authRequired: false,
-        },
-      },
-      async (context, request, response) => {
-        const acsEndpoint = `${this.coreSetup.http.basePath.serverBasePath}/_opendistro/_security/saml/acs/idpinitiated`;
-        try {
-          const credentials = await this.securityClient.authToken({
-            requestId: undefined,
-            samlResponse: request.body.SAMLResponse,
-            acsEndpoint,
-            authRequestType: AuthType.SAML,
-          });
-          const user = await this.securityClient.authenticateWithHeader(
-            request,
-            'authorization',
-            credentials.authorization
-          );
-
-          let expiryTime = Date.now() + this.config.session.ttl;
-          const [headerEncoded, payloadEncoded, signature] = credentials.authorization.split('.');
-          if (!payloadEncoded) {
-            context.security_plugin.logger.error('JWT token payload not found');
-          }
-          const tokenPayload = JSON.parse(Buffer.from(payloadEncoded, 'base64').toString());
-          if (tokenPayload.exp) {
-            expiryTime = parseInt(tokenPayload.exp, 10) * 1000;
-          }
-
-          const cookie: SecuritySessionCookie = {
-            username: user.username,
-            credentials: {
-              authHeaderValueExtra: true,
-            },
-            authType: AuthType.SAML, // TODO: create constant
-            expiryTime,
-          };
-
-          setExtraAuthStorage(
-            request,
-            credentials.authorization,
-            this.getExtraAuthStorageOptions(context.security_plugin.logger)
-          );
-
-          this.sessionStorageFactory.asScoped(request).set(cookie);
-          return response.redirected({
-            headers: {
-              location: `${this.coreSetup.http.basePath.serverBasePath}/app/opensearch-dashboards`,
-            },
-          });
-        } catch (error) {
-          context.security_plugin.logger.error(
-            `SAML IDP initiated authentication workflow failed: ${error}`
-          );
-        }
-        return response.internalError();
-      }
-    );
+      );
+    }
 
     // captureUrlFragment is the first route that will be invoked in the SP initiated login.
     // This route will execute the captureUrlFragment.js script.
@@ -328,7 +340,7 @@ export class SamlAuthRoutes {
       }
     );
 
-    //  Once the User is authenticated via the '_opendistro/_security/saml/acs' route,
+    // Once the user is authenticated through a SAML ACS route,
     //  the browser will be redirected to '/auth/saml/redirectUrlFragment' route,
     //  which will execute the redirectUrlFragment.js.
     this.coreSetup.http.resources.register(

--- a/test/jest_integration/runIdpServer.js
+++ b/test/jest_integration/runIdpServer.js
@@ -37,7 +37,7 @@ const argv = minimist(process.argv.slice(2), {
 });
 
 const IDP_PORT = Number(argv.port);
-const ACS_URL = `http://localhost:5601${argv.basePath}/_opendistro/_security/saml/acs`;
+const ACS_URL = `http://localhost:5601${argv.basePath}/_plugins/_security/saml/acs`;
 const AUDIENCE = 'https://localhost:9200';
 const ISSUER = 'urn:example:idp';
 


### PR DESCRIPTION
## Summary

- Register `/_plugins/_security/saml/acs` as the canonical SAML ACS route.
- Keep the legacy `/_opendistro/_security/saml/acs` route working as an alias.
- Apply the same compatibility behavior to IdP-initiated SAML.
- Make the new `/_plugins` ACS routes explicitly XSRF-exempt while retaining the existing allowlist-controlled behavior for legacy routes.
- Exercise the canonical route in the integration-test IdP.

## Compatibility

SAML ACS endpoints must accept cross-origin form posts from the identity provider. The new canonical routes therefore disable route-level XSRF enforcement. SP-initiated responses remain tied to the request ID stored in the user's session, and IdP-initiated responses are authenticated by their signed SAML assertion.

The legacy routes continue using their existing `server.xsrf.allowlist` behavior. Existing installations can therefore leave entries such as `/_opendistro/_security/saml/acs` unchanged in `opensearch_dashboards.yml` when the backend begins advertising `/_plugins/_security/saml/acs`.

The legacy routes remain registered for identity providers that are still configured to post directly to `/_opendistro` URLs.

Companion Security PR: https://github.com/opensearch-project/security/pull/6487

## History

This revisits #895 and #1565 while avoiding the incompatibility that required #1035 and #1036. It addresses #1031.

## Testing

- `mise exec node@22.22.3 -- yarn test:jest_server --runInBand server/auth/types/saml/routes.test.ts`
