### PR TITLE
Fix/anonymous auth next url

### DIFF
--- a/public/apps/login/login-page.tsx
+++ b/public/apps/login/login-page.tsx
@@ -237,8 +237,9 @@ export function LoginPage(props: LoginPageDeps) {
 
           if (props.config.auth.anonymous_auth_enabled) {
             const anonymousConfig = props.config.ui[AuthType.ANONYMOUS].login;
+            const anonymousAuthLoginUrl = ANONYMOUS_AUTH_LOGIN + extractNextUrlFromWindowLocation();
             formBody.push(
-              renderLoginButton(AuthType.ANONYMOUS, ANONYMOUS_AUTH_LOGIN, anonymousConfig)
+              renderLoginButton(AuthType.ANONYMOUS, anonymousAuthLoginUrl, anonymousConfig)
             );
           }
 

--- a/public/apps/login/test/login-page.test.tsx
+++ b/public/apps/login/test/login-page.test.tsx
@@ -308,3 +308,39 @@ describe('Login page', () => {
     });
   });
 });
+
+describe('Anonymous auth login button', () => {
+  const mockHttpStart = {
+    basePath: {
+      serverBasePath: '/app/opensearch-dashboards',
+    },
+  };
+  const config = {
+    ui: configUI,
+    auth: {
+      type: [AuthType.BASIC],
+      logout_url: API_AUTH_LOGOUT,
+      anonymous_auth_enabled: true,
+    },
+  };
+
+  const anonymousLoginHref = () => {
+    const chrome = chromeServiceMock.createStartContract();
+    const component = shallow(
+      <LoginPage http={mockHttpStart as any} chrome={chrome} config={config as any} />
+    );
+    return component.find('[aria-label="anonymous_login_button"]').prop('href');
+  };
+
+  it('keeps the nextUrl query parameter', () => {
+    window.location.assign('http://localhost:5601/app/login?nextUrl=%2Fapp%2Fdashboards');
+    expect(anonymousLoginHref()).toEqual(
+      '/app/opensearch-dashboards/auth/anonymous?nextUrl=%2Fapp%2Fdashboards'
+    );
+  });
+
+  it('does not add a query parameter when nextUrl is absent', () => {
+    window.location.assign('http://localhost:5601/app/login');
+    expect(anonymousLoginHref()).toEqual('/app/opensearch-dashboards/auth/anonymous');
+  });
+});


### PR DESCRIPTION
### Description
The anonymous auth login button on the login page always pointed to `/auth/anonymous` without forwarding the `nextUrl` query parameter. The button href is now built with the `nextUrl` extracted from the current window location, so the originally requested page is preserved through the anonymous login flow.

### Category
Bug fix

### Why these changes are required?
When an unauthenticated user opens a deep link (for example a specific dashboard), OpenSearch Dashboards redirects to the login page with a `nextUrl` query parameter. The other login options forward that parameter, but the anonymous auth button dropped it, so the deep link was lost and the user had to navigate to the target page manually after logging in.

### What is the old behavior before changes and new behavior after changes?
Old behavior: the anonymous login button linked to `<serverBasePath>/auth/anonymous`, so after authenticating the user landed on the default page regardless of where the login was triggered from.
New behavior: the button links to `<serverBasePath>/auth/anonymous?nextUrl=<encoded original path>` when a `nextUrl` is present on the login page URL, and remains unchanged (no query string) when it is absent.

### Issues Resolved
N/A

### Testing
Unit tests were added in `public/apps/login/test/login-page.test.tsx` covering the anonymous login button href in both cases: `nextUrl` present (the parameter is preserved) and `nextUrl` absent (no query parameter is added). The existing login page unit tests continue to pass.

### Check List
- [x] New functionality includes testing
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).